### PR TITLE
Nav: non-sticky, left drawer (45%), translucent header; brand alignment; hide on Home.

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,6 +1,6 @@
 :root {
-  --ttg-nav-bg: rgba(8, 26, 45, 0.92);
-  --ttg-nav-border: rgba(255, 255, 255, 0.08);
+  --ttg-nav-bg: rgba(8, 26, 45, 0.38);
+  --ttg-nav-border: rgba(255, 255, 255, 0.18);
   --ttg-nav-text: #f2f6ff;
 }
 
@@ -9,9 +9,9 @@
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
   color: var(--ttg-nav-text);
   background: var(--ttg-nav-bg);
-  backdrop-filter: blur(18px);
-  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.35);
+  backdrop-filter: blur(18px) saturate(135%);
   border-bottom: 1px solid var(--ttg-nav-border);
+  box-shadow: 0 24px 54px rgba(0, 0, 0, 0.22);
 }
 
 #global-nav a {
@@ -21,25 +21,28 @@
 
 #global-nav .nav-inner {
   display: flex;
-  align-items: center;
-  gap: 16px;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
   margin: 0 auto;
   max-width: 1100px;
-  padding: 14px 20px;
+  padding: 18px 20px;
 }
 
 #ttg-nav-open {
-  display: none;
+  display: flex;
   align-items: center;
   justify-content: center;
-  width: 42px;
-  height: 42px;
+  width: 44px;
+  height: 44px;
   border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.22);
-  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.24);
+  background: rgba(255, 255, 255, 0.12);
   color: inherit;
   cursor: pointer;
   padding: 0;
+  box-shadow: 0 8px 26px rgba(0, 0, 0, 0.24);
+  backdrop-filter: blur(12px);
 }
 
 #ttg-nav-open .hamburger-bars {
@@ -74,39 +77,19 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 2px;
-  line-height: 1.1;
+  gap: 4px;
+  line-height: 1.08;
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.35);
 }
 
 #global-nav .brand-title {
   font-weight: 800;
-  font-size: 1.08rem;
+  font-size: 1.15rem;
 }
 
 #global-nav .brand-sub {
-  opacity: 0.85;
-  font-size: 0.9rem;
-}
-
-#global-nav .links {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 18px;
-}
-
-#global-nav .links a {
-  padding: 8px 0;
-  border-bottom: 2px solid transparent;
-  transition: border-color 0.2s ease;
-}
-
-#global-nav .links a:hover {
-  border-bottom-color: rgba(255, 255, 255, 0.55);
-}
-
-#global-nav .links a[aria-current="page"] {
-  border-bottom-color: rgba(255, 255, 255, 0.92);
+  opacity: 0.9;
+  font-size: 0.94rem;
 }
 
 #ttg-overlay {
@@ -123,7 +106,8 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: min(86vw, 340px);
+  width: min(45vw, 420px);
+  max-width: 420px;
   height: 100dvh;
   transform: translateX(-100%);
   transition: transform 0.25s ease;
@@ -219,16 +203,6 @@ body.ttg-nav-locked {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
-}
-
-@media (max-width: 920px) {
-  #global-nav .links {
-    display: none;
-  }
-
-  #ttg-nav-open {
-    display: flex;
-  }
 }
 
 /* Footer social strip (consistent across pages) */

--- a/gear.html
+++ b/gear.html
@@ -5,7 +5,7 @@
   <title>The Tank Guide — Gear (Guided)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Build your aquarium setup step by step — tanks, filtration, lighting, and more." />
-  <link rel="stylesheet" href="css/style.css?v=1.0.5" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.6" />
   <link rel="icon" href="/favicon.ico" />
 
   <style>
@@ -129,7 +129,7 @@
         });
       }
 
-      fetch('/nav.html?v=1.0.5')
+      fetch('/nav.html?v=1.0.6')
         .then((response) => response.text())
         .then((html) => {
           const placeholder = document.getElementById('site-nav');

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — A product of FishKeepingLifeCo</title>
   <meta name="description" content="Smart tools and guides to plan, stock, and set up your aquarium — all in one place." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.0.5" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.6" />
 
   <style>
     :root{

--- a/media.html
+++ b/media.html
@@ -5,7 +5,7 @@
   <title>The Tank Guide — Media Hub</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Media Hub — Watch • Read • Explore. Aquarium videos and blogs for every aquarist." />
-  <link rel="stylesheet" href="css/style.css?v=1.0.5" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.6" />
   <link rel="icon" href="/favicon.ico" />
   <meta property="og:title" content="The Tank Guide — Media Hub" />
   <meta property="og:description" content="Watch • Read • Explore — videos and blogs for every aquarist." />
@@ -18,8 +18,8 @@
       --card-bg: rgba(255,255,255,.6);
       --border: rgba(0,0,0,.08);
       --muted: rgba(0,0,0,.65);
-      --ttg-nav-bg: linear-gradient(135deg, rgba(0, 119, 199, 0.88) 0%, rgba(10, 77, 135, 0.88) 100%);
-      --ttg-nav-border: rgba(255, 255, 255, 0.3);
+      --ttg-nav-bg: linear-gradient(135deg, rgba(0, 119, 199, 0.42) 0%, rgba(10, 77, 135, 0.42) 100%);
+      --ttg-nav-border: rgba(255, 255, 255, 0.26);
       --ttg-nav-text: #f2f6ff;
     }
 
@@ -162,7 +162,7 @@
         });
       }
 
-      fetch('/nav.html?v=1.0.5')
+      fetch('/nav.html?v=1.0.6')
         .then((response) => response.text())
         .then((html) => {
           const placeholder = document.getElementById('site-nav');

--- a/nav.html
+++ b/nav.html
@@ -10,15 +10,6 @@
       <span class="brand-sub">a product of <strong>FishKeepingLifeCo</strong></span>
     </a>
 
-    <nav class="links" aria-label="Primary">
-      <a href="/index.html">Home</a>
-      <a href="/stocking.html">Stocking Advisor</a>
-      <a href="/gear.html">Gear</a>
-      <a href="/params.html">Cycling Coach</a>
-      <a href="/media.html">Media</a>
-      <a href="/about.html">About</a>
-      <a href="/feedback.html">Feedback</a>
-    </nav>
   </div>
 
   <div id="ttg-overlay" hidden></div>

--- a/params.html
+++ b/params.html
@@ -6,7 +6,7 @@
   <title>Cycling Coach — The Tank Guide</title>
   <meta name="description" content="Cycling Coach is under construction — coming soon to help you master the nitrogen cycle." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.0.5" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.6" />
 
   <style>
     :root{
@@ -123,7 +123,7 @@
         });
       }
 
-      fetch('/nav.html?v=1.0.5')
+      fetch('/nav.html?v=1.0.6')
         .then((response) => response.text())
         .then((html) => {
           const placeholder = document.getElementById('site-nav');

--- a/stocking.html
+++ b/stocking.html
@@ -5,7 +5,7 @@
   <title>FishkeepingLifeCo — Stocking Calculator</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Global nav / shared styles (same versioning as Media) -->
-  <link rel="stylesheet" href="css/style.css?v=1.0.5" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.6" />
   <!-- Page styles -->
   <link rel="stylesheet" href="css/Style.css?v=1.0.3" />
 </head>
@@ -81,7 +81,7 @@
         });
       }
 
-      fetch('/nav.html?v=1.0.5')
+      fetch('/nav.html?v=1.0.6')
         .then((response) => response.text())
         .then((html) => {
           const placeholder = document.getElementById('site-nav');


### PR DESCRIPTION
## Summary
- restyle the global header to be translucent, non-fixed, and align the brand stack with the hamburger trigger
- resize the mobile drawer to slide in from the left at 45vw (max 420px) and remove the desktop link row from the header
- bump interior pages to reference the updated nav/css bundle while keeping the homepage free of the shared nav include

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d37d256cb88332a04073b9482c7ff5