### PR TITLE
Align global navigation drawer across pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -167,8 +167,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: min(45vw, 360px);
-  max-width: 360px;
+  width: clamp(280px, 45vw, 360px);
   height: 100dvh;
   transform: translateX(-100%);
   transition: transform 0.25s ease;
@@ -184,6 +183,18 @@
   padding-right: calc(24px + env(safe-area-inset-right));
   z-index: 5100;
   overflow-y: auto;
+}
+
+@media (min-width: 768px) {
+  #ttg-drawer {
+    width: clamp(320px, 32vw, 400px);
+  }
+}
+
+@media (min-width: 1100px) {
+  #ttg-drawer {
+    width: clamp(360px, 28vw, 420px);
+  }
 }
 
 #ttg-drawer header {

--- a/gear.html
+++ b/gear.html
@@ -5,7 +5,7 @@
   <title>The Tank Guide — Gear (Guided)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Build your aquarium setup step by step — tanks, filtration, lighting, and more." />
-  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <link rel="icon" href="/favicon.ico" />
 
   <style>
@@ -64,81 +64,94 @@
   <!-- Global nav include (shared across pages) -->
   <div id="site-nav"></div>
   <script>
-    (function(){
-      function initNav(){
-        const root = document.getElementById('global-nav');
-        if (!root) return;
+    (function () {
+      const NAV_VERSION = '1.0.8';
+      const placeholder = document.getElementById('site-nav');
+      if (!placeholder) return;
 
-        const here = window.location.pathname.replace(/\/+$/,'') || '/';
-        const current = here === '/' ? '/index.html' : here;
-        const mark = (selector) => {
-          root.querySelectorAll(selector).forEach((link) => {
-            const hrefAttr = link.getAttribute('href');
-            if (!hrefAttr) return;
-            const target = new URL(hrefAttr, window.location.origin).pathname.replace(/\/+$/,'') || '/';
-            const normalized = target === '/' ? '/index.html' : target;
-            if (normalized === current) {
-              link.setAttribute('aria-current', 'page');
-            }
-          });
-        };
-        mark('.links a');
-        mark('#ttg-drawer a');
+      const normalizePath = (value) => {
+        try {
+          const url = new URL(value, window.location.origin);
+          const path = url.pathname.replace(/\/+$/, '') || '/';
+          return path === '/' ? '/index.html' : path;
+        } catch (error) {
+          return value;
+        }
+      };
 
+      const markCurrentLinks = (root) => {
+        const current = normalizePath(window.location.pathname || '/');
+        root.querySelectorAll('.links a, #ttg-drawer a').forEach((link) => {
+          const hrefAttr = link.getAttribute('href');
+          if (!hrefAttr) return;
+          if (normalizePath(hrefAttr) === current) {
+            link.setAttribute('aria-current', 'page');
+          }
+        });
+      };
+
+      const attachInteractions = (root) => {
         const openBtn = root.querySelector('#ttg-nav-open');
         const closeBtn = root.querySelector('#ttg-nav-close');
         const overlay = root.querySelector('#ttg-overlay');
         const drawer = root.querySelector('#ttg-drawer');
 
+        if (!drawer) return;
+
         const lockBody = () => {
           document.documentElement.classList.add('ttg-nav-locked');
           document.body.classList.add('ttg-nav-locked');
         };
+
         const unlockBody = () => {
           document.documentElement.classList.remove('ttg-nav-locked');
           document.body.classList.remove('ttg-nav-locked');
         };
 
-        const open = () => {
-          if (!root || root.getAttribute('data-open') === 'true') return;
-          root.setAttribute('data-open', 'true');
-          overlay?.removeAttribute('hidden');
-          drawer?.setAttribute('aria-hidden', 'false');
-          openBtn?.setAttribute('aria-expanded', 'true');
-          lockBody();
-          const firstLink = drawer?.querySelector('a');
-          (firstLink || closeBtn || drawer)?.focus({ preventScroll: true });
-        };
-
         const close = () => {
-          if (!root || root.getAttribute('data-open') !== 'true') return;
+          if (root.getAttribute('data-open') !== 'true') return;
           root.setAttribute('data-open', 'false');
           overlay?.setAttribute('hidden', '');
-          drawer?.setAttribute('aria-hidden', 'true');
+          drawer.setAttribute('aria-hidden', 'true');
           openBtn?.setAttribute('aria-expanded', 'false');
           unlockBody();
           openBtn?.focus({ preventScroll: true });
         };
 
-        openBtn?.addEventListener('click', open);
-        closeBtn?.addEventListener('click', close);
-        overlay?.addEventListener('click', close);
-        drawer?.querySelectorAll('a').forEach((link) => link.addEventListener('click', close));
-        document.addEventListener('keydown', (event) => {
+        const open = () => {
+          if (root.getAttribute('data-open') === 'true') return;
+          root.setAttribute('data-open', 'true');
+          overlay?.removeAttribute('hidden');
+          drawer.setAttribute('aria-hidden', 'false');
+          openBtn?.setAttribute('aria-expanded', 'true');
+          lockBody();
+          const focusTarget = drawer.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
+          (focusTarget || closeBtn || drawer).focus?.({ preventScroll: true });
+        };
+
+        const handleKeydown = (event) => {
           if (event.key === 'Escape') {
             close();
           }
-        });
-      }
+        };
 
-      fetch('/nav.html?v=1.0.7')
+        openBtn?.addEventListener('click', open);
+        closeBtn?.addEventListener('click', close);
+        overlay?.addEventListener('click', close);
+        drawer.querySelectorAll('a').forEach((link) => link.addEventListener('click', close));
+        document.addEventListener('keydown', handleKeydown);
+      };
+
+      fetch(`/nav.html?v=${NAV_VERSION}`)
         .then((response) => response.text())
         .then((html) => {
-          const placeholder = document.getElementById('site-nav');
-          if (!placeholder) return;
           placeholder.outerHTML = html;
-          initNav();
-        });
+          const root = document.getElementById('global-nav');
+          if (!root) return;
+          markCurrentLinks(root);
+          attachInteractions(root);
+        })
+        .catch(() => {});
     })();
   </script>
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — A product of FishKeepingLifeCo</title>
   <meta name="description" content="Smart tools and guides to plan, stock, and set up your aquarium — all in one place." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.0.6" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
 
   <style>
     :root{

--- a/media.html
+++ b/media.html
@@ -5,7 +5,7 @@
   <title>The Tank Guide — Media Hub</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Media Hub — Watch • Read • Explore. Aquarium videos and blogs for every aquarist." />
-  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <link rel="icon" href="/favicon.ico" />
   <meta property="og:title" content="The Tank Guide — Media Hub" />
   <meta property="og:description" content="Watch • Read • Explore — videos and blogs for every aquarist." />
@@ -95,81 +95,94 @@
   <!-- Global nav include -->
   <div id="site-nav"></div>
   <script>
-    (function(){
-      function initNav(){
-        const root = document.getElementById('global-nav');
-        if (!root) return;
+    (function () {
+      const NAV_VERSION = '1.0.8';
+      const placeholder = document.getElementById('site-nav');
+      if (!placeholder) return;
 
-        const here = window.location.pathname.replace(/\/+$/,'') || '/';
-        const current = here === '/' ? '/index.html' : here;
-        const mark = (selector) => {
-          root.querySelectorAll(selector).forEach((link) => {
-            const hrefAttr = link.getAttribute('href');
-            if (!hrefAttr) return;
-            const target = new URL(hrefAttr, window.location.origin).pathname.replace(/\/+$/,'') || '/';
-            const normalized = target === '/' ? '/index.html' : target;
-            if (normalized === current) {
-              link.setAttribute('aria-current', 'page');
-            }
-          });
-        };
-        mark('.links a');
-        mark('#ttg-drawer a');
+      const normalizePath = (value) => {
+        try {
+          const url = new URL(value, window.location.origin);
+          const path = url.pathname.replace(/\/+$/, '') || '/';
+          return path === '/' ? '/index.html' : path;
+        } catch (error) {
+          return value;
+        }
+      };
 
+      const markCurrentLinks = (root) => {
+        const current = normalizePath(window.location.pathname || '/');
+        root.querySelectorAll('.links a, #ttg-drawer a').forEach((link) => {
+          const hrefAttr = link.getAttribute('href');
+          if (!hrefAttr) return;
+          if (normalizePath(hrefAttr) === current) {
+            link.setAttribute('aria-current', 'page');
+          }
+        });
+      };
+
+      const attachInteractions = (root) => {
         const openBtn = root.querySelector('#ttg-nav-open');
         const closeBtn = root.querySelector('#ttg-nav-close');
         const overlay = root.querySelector('#ttg-overlay');
         const drawer = root.querySelector('#ttg-drawer');
 
+        if (!drawer) return;
+
         const lockBody = () => {
           document.documentElement.classList.add('ttg-nav-locked');
           document.body.classList.add('ttg-nav-locked');
         };
+
         const unlockBody = () => {
           document.documentElement.classList.remove('ttg-nav-locked');
           document.body.classList.remove('ttg-nav-locked');
         };
 
-        const open = () => {
-          if (!root || root.getAttribute('data-open') === 'true') return;
-          root.setAttribute('data-open', 'true');
-          overlay?.removeAttribute('hidden');
-          drawer?.setAttribute('aria-hidden', 'false');
-          openBtn?.setAttribute('aria-expanded', 'true');
-          lockBody();
-          const firstLink = drawer?.querySelector('a');
-          (firstLink || closeBtn || drawer)?.focus({ preventScroll: true });
-        };
-
         const close = () => {
-          if (!root || root.getAttribute('data-open') !== 'true') return;
+          if (root.getAttribute('data-open') !== 'true') return;
           root.setAttribute('data-open', 'false');
           overlay?.setAttribute('hidden', '');
-          drawer?.setAttribute('aria-hidden', 'true');
+          drawer.setAttribute('aria-hidden', 'true');
           openBtn?.setAttribute('aria-expanded', 'false');
           unlockBody();
           openBtn?.focus({ preventScroll: true });
         };
 
-        openBtn?.addEventListener('click', open);
-        closeBtn?.addEventListener('click', close);
-        overlay?.addEventListener('click', close);
-        drawer?.querySelectorAll('a').forEach((link) => link.addEventListener('click', close));
-        document.addEventListener('keydown', (event) => {
+        const open = () => {
+          if (root.getAttribute('data-open') === 'true') return;
+          root.setAttribute('data-open', 'true');
+          overlay?.removeAttribute('hidden');
+          drawer.setAttribute('aria-hidden', 'false');
+          openBtn?.setAttribute('aria-expanded', 'true');
+          lockBody();
+          const focusTarget = drawer.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
+          (focusTarget || closeBtn || drawer).focus?.({ preventScroll: true });
+        };
+
+        const handleKeydown = (event) => {
           if (event.key === 'Escape') {
             close();
           }
-        });
-      }
+        };
 
-      fetch('/nav.html?v=1.0.7')
+        openBtn?.addEventListener('click', open);
+        closeBtn?.addEventListener('click', close);
+        overlay?.addEventListener('click', close);
+        drawer.querySelectorAll('a').forEach((link) => link.addEventListener('click', close));
+        document.addEventListener('keydown', handleKeydown);
+      };
+
+      fetch(`/nav.html?v=${NAV_VERSION}`)
         .then((response) => response.text())
         .then((html) => {
-          const placeholder = document.getElementById('site-nav');
-          if (!placeholder) return;
           placeholder.outerHTML = html;
-          initNav();
-        });
+          const root = document.getElementById('global-nav');
+          if (!root) return;
+          markCurrentLinks(root);
+          attachInteractions(root);
+        })
+        .catch(() => {});
     })();
   </script>
 

--- a/nav.html
+++ b/nav.html
@@ -1,7 +1,7 @@
 <header id="global-nav" data-open="false">
   <div class="nav-inner">
     <div class="nav-primary">
-      <button id="ttg-nav-open" aria-label="Open menu" aria-controls="ttg-drawer" aria-expanded="false">
+      <button id="ttg-nav-open" type="button" aria-label="Open menu" aria-controls="ttg-drawer" aria-expanded="false">
         <span class="hamburger-bars" aria-hidden="true"></span>
         <span class="visually-hidden">Menu</span>
       </button>
@@ -27,7 +27,7 @@
   <aside id="ttg-drawer" role="dialog" aria-modal="true" aria-label="Navigation" aria-hidden="true" tabindex="-1">
     <header>
       <strong>Menu</strong>
-      <button id="ttg-nav-close" aria-label="Close menu">×</button>
+      <button id="ttg-nav-close" type="button" aria-label="Close menu">×</button>
     </header>
     <nav aria-label="Mobile">
       <a href="/index.html">Home</a>

--- a/params.html
+++ b/params.html
@@ -6,7 +6,7 @@
   <title>Cycling Coach — The Tank Guide</title>
   <meta name="description" content="Cycling Coach is under construction — coming soon to help you master the nitrogen cycle." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
 
   <style>
     :root{
@@ -58,81 +58,94 @@
   <!-- Global nav include (shared across pages) -->
   <div id="site-nav"></div>
   <script>
-    (function(){
-      function initNav(){
-        const root = document.getElementById('global-nav');
-        if (!root) return;
+    (function () {
+      const NAV_VERSION = '1.0.8';
+      const placeholder = document.getElementById('site-nav');
+      if (!placeholder) return;
 
-        const here = window.location.pathname.replace(/\/+$/,'') || '/';
-        const current = here === '/' ? '/index.html' : here;
-        const mark = (selector) => {
-          root.querySelectorAll(selector).forEach((link) => {
-            const hrefAttr = link.getAttribute('href');
-            if (!hrefAttr) return;
-            const target = new URL(hrefAttr, window.location.origin).pathname.replace(/\/+$/,'') || '/';
-            const normalized = target === '/' ? '/index.html' : target;
-            if (normalized === current) {
-              link.setAttribute('aria-current', 'page');
-            }
-          });
-        };
-        mark('.links a');
-        mark('#ttg-drawer a');
+      const normalizePath = (value) => {
+        try {
+          const url = new URL(value, window.location.origin);
+          const path = url.pathname.replace(/\/+$/, '') || '/';
+          return path === '/' ? '/index.html' : path;
+        } catch (error) {
+          return value;
+        }
+      };
 
+      const markCurrentLinks = (root) => {
+        const current = normalizePath(window.location.pathname || '/');
+        root.querySelectorAll('.links a, #ttg-drawer a').forEach((link) => {
+          const hrefAttr = link.getAttribute('href');
+          if (!hrefAttr) return;
+          if (normalizePath(hrefAttr) === current) {
+            link.setAttribute('aria-current', 'page');
+          }
+        });
+      };
+
+      const attachInteractions = (root) => {
         const openBtn = root.querySelector('#ttg-nav-open');
         const closeBtn = root.querySelector('#ttg-nav-close');
         const overlay = root.querySelector('#ttg-overlay');
         const drawer = root.querySelector('#ttg-drawer');
 
+        if (!drawer) return;
+
         const lockBody = () => {
           document.documentElement.classList.add('ttg-nav-locked');
           document.body.classList.add('ttg-nav-locked');
         };
+
         const unlockBody = () => {
           document.documentElement.classList.remove('ttg-nav-locked');
           document.body.classList.remove('ttg-nav-locked');
         };
 
-        const open = () => {
-          if (!root || root.getAttribute('data-open') === 'true') return;
-          root.setAttribute('data-open', 'true');
-          overlay?.removeAttribute('hidden');
-          drawer?.setAttribute('aria-hidden', 'false');
-          openBtn?.setAttribute('aria-expanded', 'true');
-          lockBody();
-          const firstLink = drawer?.querySelector('a');
-          (firstLink || closeBtn || drawer)?.focus({ preventScroll: true });
-        };
-
         const close = () => {
-          if (!root || root.getAttribute('data-open') !== 'true') return;
+          if (root.getAttribute('data-open') !== 'true') return;
           root.setAttribute('data-open', 'false');
           overlay?.setAttribute('hidden', '');
-          drawer?.setAttribute('aria-hidden', 'true');
+          drawer.setAttribute('aria-hidden', 'true');
           openBtn?.setAttribute('aria-expanded', 'false');
           unlockBody();
           openBtn?.focus({ preventScroll: true });
         };
 
-        openBtn?.addEventListener('click', open);
-        closeBtn?.addEventListener('click', close);
-        overlay?.addEventListener('click', close);
-        drawer?.querySelectorAll('a').forEach((link) => link.addEventListener('click', close));
-        document.addEventListener('keydown', (event) => {
+        const open = () => {
+          if (root.getAttribute('data-open') === 'true') return;
+          root.setAttribute('data-open', 'true');
+          overlay?.removeAttribute('hidden');
+          drawer.setAttribute('aria-hidden', 'false');
+          openBtn?.setAttribute('aria-expanded', 'true');
+          lockBody();
+          const focusTarget = drawer.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
+          (focusTarget || closeBtn || drawer).focus?.({ preventScroll: true });
+        };
+
+        const handleKeydown = (event) => {
           if (event.key === 'Escape') {
             close();
           }
-        });
-      }
+        };
 
-      fetch('/nav.html?v=1.0.7')
+        openBtn?.addEventListener('click', open);
+        closeBtn?.addEventListener('click', close);
+        overlay?.addEventListener('click', close);
+        drawer.querySelectorAll('a').forEach((link) => link.addEventListener('click', close));
+        document.addEventListener('keydown', handleKeydown);
+      };
+
+      fetch(`/nav.html?v=${NAV_VERSION}`)
         .then((response) => response.text())
         .then((html) => {
-          const placeholder = document.getElementById('site-nav');
-          if (!placeholder) return;
           placeholder.outerHTML = html;
-          initNav();
-        });
+          const root = document.getElementById('global-nav');
+          if (!root) return;
+          markCurrentLinks(root);
+          attachInteractions(root);
+        })
+        .catch(() => {});
     })();
   </script>
 

--- a/stocking.html
+++ b/stocking.html
@@ -5,7 +5,7 @@
   <title>FishkeepingLifeCo — Stocking Calculator</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Global nav / shared styles (same versioning as Media) -->
-  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <!-- Page styles -->
   <link rel="stylesheet" href="css/Style.css?v=1.0.3" />
   <style>
@@ -20,86 +20,94 @@
   <!-- Global nav include (same pattern as Media) -->
   <div id="site-nav"></div>
   <script>
-    (function(){
-      function initNav(){
-        const root = document.getElementById('global-nav');
-        if (!root) return;
+    (function () {
+      const NAV_VERSION = '1.0.8';
+      const placeholder = document.getElementById('site-nav');
+      if (!placeholder) return;
 
-        const here = window.location.pathname.replace(/\/+$/,'') || '/';
-        const current = here === '/' ? '/index.html' : here;
-        const mark = (selector) => {
-          root.querySelectorAll(selector).forEach((link) => {
-            const hrefAttr = link.getAttribute('href');
-            if (!hrefAttr) return;
-            const target = new URL(hrefAttr, window.location.origin).pathname.replace(/\/+$/,'') || '/';
-            const normalized = target === '/' ? '/index.html' : target;
-            if (normalized === current) {
-              link.setAttribute('aria-current', 'page');
-            }
-          });
-        };
-        mark('.links a');
-        mark('#ttg-drawer a');
+      const normalizePath = (value) => {
+        try {
+          const url = new URL(value, window.location.origin);
+          const path = url.pathname.replace(/\/+$/, '') || '/';
+          return path === '/' ? '/index.html' : path;
+        } catch (error) {
+          return value;
+        }
+      };
 
+      const markCurrentLinks = (root) => {
+        const current = normalizePath(window.location.pathname || '/');
+        root.querySelectorAll('.links a, #ttg-drawer a').forEach((link) => {
+          const hrefAttr = link.getAttribute('href');
+          if (!hrefAttr) return;
+          if (normalizePath(hrefAttr) === current) {
+            link.setAttribute('aria-current', 'page');
+          }
+        });
+      };
+
+      const attachInteractions = (root) => {
         const openBtn = root.querySelector('#ttg-nav-open');
         const closeBtn = root.querySelector('#ttg-nav-close');
         const overlay = root.querySelector('#ttg-overlay');
         const drawer = root.querySelector('#ttg-drawer');
 
+        if (!drawer) return;
+
         const lockBody = () => {
           document.documentElement.classList.add('ttg-nav-locked');
           document.body.classList.add('ttg-nav-locked');
         };
+
         const unlockBody = () => {
           document.documentElement.classList.remove('ttg-nav-locked');
           document.body.classList.remove('ttg-nav-locked');
         };
 
-        const open = () => {
-          if (!root || root.getAttribute('data-open') === 'true') return;
-          root.setAttribute('data-open', 'true');
-          overlay?.removeAttribute('hidden');
-          drawer?.setAttribute('aria-hidden', 'false');
-          openBtn?.setAttribute('aria-expanded', 'true');
-          lockBody();
-          const firstLink = drawer?.querySelector('a');
-          (firstLink || closeBtn || drawer)?.focus({ preventScroll: true });
-        };
-
         const close = () => {
-          if (!root || root.getAttribute('data-open') !== 'true') return;
+          if (root.getAttribute('data-open') !== 'true') return;
           root.setAttribute('data-open', 'false');
           overlay?.setAttribute('hidden', '');
-          drawer?.setAttribute('aria-hidden', 'true');
+          drawer.setAttribute('aria-hidden', 'true');
           openBtn?.setAttribute('aria-expanded', 'false');
           unlockBody();
           openBtn?.focus({ preventScroll: true });
         };
 
-        openBtn?.addEventListener('click', open);
-        closeBtn?.addEventListener('click', close);
-        overlay?.addEventListener('click', close);
-        drawer?.querySelectorAll('a').forEach((link) => link.addEventListener('click', close));
-        document.addEventListener('keydown', (event) => {
+        const open = () => {
+          if (root.getAttribute('data-open') === 'true') return;
+          root.setAttribute('data-open', 'true');
+          overlay?.removeAttribute('hidden');
+          drawer.setAttribute('aria-hidden', 'false');
+          openBtn?.setAttribute('aria-expanded', 'true');
+          lockBody();
+          const focusTarget = drawer.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
+          (focusTarget || closeBtn || drawer).focus?.({ preventScroll: true });
+        };
+
+        const handleKeydown = (event) => {
           if (event.key === 'Escape') {
             close();
           }
-        });
-      }
+        };
 
-      fetch('/nav.html?v=1.0.7')
+        openBtn?.addEventListener('click', open);
+        closeBtn?.addEventListener('click', close);
+        overlay?.addEventListener('click', close);
+        drawer.querySelectorAll('a').forEach((link) => link.addEventListener('click', close));
+        document.addEventListener('keydown', handleKeydown);
+      };
+
+      fetch(`/nav.html?v=${NAV_VERSION}`)
         .then((response) => response.text())
         .then((html) => {
-          const placeholder = document.getElementById('site-nav');
-          if (!placeholder) return;
           placeholder.outerHTML = html;
-          initNav();
-          setTimeout(() => {
-            if (document.activeElement && document.activeElement.blur) {
-              document.activeElement.blur();
-            }
-          }, 0);
-        });
+          const root = document.getElementById('global-nav');
+          if (!root) return;
+          markCurrentLinks(root);
+          attachInteractions(root);
+        })
+        .catch(() => {});
     })();
   </script>
 


### PR DESCRIPTION
## Summary
- adjust the shared navigation drawer sizing to use clamp-based widths so it opens from the left at 45% on phones while capping at 360–420px on larger screens
- load the global navigation consistently across the Stocking, Gear, Params, and Media pages with shared logic to mark the active page and close the drawer via overlay, Esc, or drawer links
- add button types and bump cache-busting versions so updated nav markup and styles reach every page

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d385e12de083329325652951a06ca9