### PR TITLE
feat(nav): align navigation across product pages

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
 :root {
-  --ttg-nav-bg: rgba(8, 20, 36, 0.45);
+  --ttg-nav-bg: rgba(8, 22, 38, 0.32);
   --ttg-nav-text: #f3f6ff;
   --ttg-nav-link: rgba(243, 246, 255, 0.82);
   --ttg-nav-overlay: rgba(4, 15, 26, 0.58);
@@ -10,10 +10,10 @@
   z-index: 4000;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
   color: var(--ttg-nav-text, #f3f6ff);
-  background: var(--ttg-nav-bg, rgba(8, 20, 36, 0.45));
-  backdrop-filter: blur(18px) saturate(135%);
-  -webkit-backdrop-filter: blur(18px) saturate(135%);
-  box-shadow: 0 22px 50px rgba(0, 0, 0, 0.28);
+  background: var(--ttg-nav-bg, rgba(8, 22, 38, 0.32));
+  backdrop-filter: blur(20px) saturate(140%);
+  -webkit-backdrop-filter: blur(20px) saturate(140%);
+  box-shadow: 0 12px 36px rgba(6, 18, 36, 0.18);
 }
 
 #global-nav a {
@@ -25,7 +25,7 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 14px;
+  gap: 12px;
   margin: 0 auto;
   width: min(100%, 1100px);
   padding: 16px 20px 18px;
@@ -36,7 +36,7 @@
 
 #global-nav .nav-primary {
   display: grid;
-  grid-template-columns: auto 1fr;
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
   column-gap: 16px;
 }
@@ -93,19 +93,25 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 4px;
+  gap: 2px;
   line-height: 1.1;
   text-shadow: 0 1px 8px rgba(0, 0, 0, 0.38);
 }
 
 #global-nav .brand-title {
   font-weight: 800;
-  font-size: 1.15rem;
+  font-size: 1.12rem;
 }
 
 #global-nav .brand-sub {
   opacity: 0.9;
-  font-size: 0.94rem;
+  font-size: 0.92rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
+#global-nav .brand-sub-em {
+  font-weight: 600;
 }
 
 #global-nav .links {
@@ -138,6 +144,7 @@
   text-decoration: underline;
   text-underline-offset: 0.4em;
   text-decoration-thickness: 0.16em;
+  font-weight: 600;
 }
 
 @media (min-width: 900px) {
@@ -185,18 +192,6 @@
   overflow-y: auto;
 }
 
-@media (min-width: 768px) {
-  #ttg-drawer {
-    width: clamp(320px, 32vw, 400px);
-  }
-}
-
-@media (min-width: 1100px) {
-  #ttg-drawer {
-    width: clamp(360px, 28vw, 420px);
-  }
-}
-
 #ttg-drawer header {
   display: flex;
   align-items: center;
@@ -236,7 +231,7 @@
 
 #ttg-drawer a {
   display: block;
-  padding: 12px 0;
+  padding: 10px 0;
   border-radius: 10px;
   color: inherit;
   text-decoration: none;
@@ -250,6 +245,7 @@
 }
 
 #ttg-drawer a[aria-current="page"] {
+  font-weight: 600;
   text-decoration: underline;
   text-underline-offset: 0.4em;
   text-decoration-thickness: 0.16em;

--- a/gear.html
+++ b/gear.html
@@ -5,7 +5,7 @@
   <title>The Tank Guide — Gear (Guided)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Build your aquarium setup step by step — tanks, filtration, lighting, and more." />
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.1.0" />
   <link rel="icon" href="/favicon.ico" />
 
   <style>
@@ -63,97 +63,7 @@
 
   <!-- Global nav include (shared across pages) -->
   <div id="site-nav"></div>
-  <script>
-    (function () {
-      const NAV_VERSION = '1.0.8';
-      const placeholder = document.getElementById('site-nav');
-      if (!placeholder) return;
-
-      const normalizePath = (value) => {
-        try {
-          const url = new URL(value, window.location.origin);
-          const path = url.pathname.replace(/\/+$/, '') || '/';
-          return path === '/' ? '/index.html' : path;
-        } catch (error) {
-          return value;
-        }
-      };
-
-      const markCurrentLinks = (root) => {
-        const current = normalizePath(window.location.pathname || '/');
-        root.querySelectorAll('.links a, #ttg-drawer a').forEach((link) => {
-          const hrefAttr = link.getAttribute('href');
-          if (!hrefAttr) return;
-          if (normalizePath(hrefAttr) === current) {
-            link.setAttribute('aria-current', 'page');
-          }
-        });
-      };
-
-      const attachInteractions = (root) => {
-        const openBtn = root.querySelector('#ttg-nav-open');
-        const closeBtn = root.querySelector('#ttg-nav-close');
-        const overlay = root.querySelector('#ttg-overlay');
-        const drawer = root.querySelector('#ttg-drawer');
-
-        if (!drawer) return;
-
-        const lockBody = () => {
-          document.documentElement.classList.add('ttg-nav-locked');
-          document.body.classList.add('ttg-nav-locked');
-        };
-
-        const unlockBody = () => {
-          document.documentElement.classList.remove('ttg-nav-locked');
-          document.body.classList.remove('ttg-nav-locked');
-        };
-
-        const close = () => {
-          if (root.getAttribute('data-open') !== 'true') return;
-          root.setAttribute('data-open', 'false');
-          overlay?.setAttribute('hidden', '');
-          drawer.setAttribute('aria-hidden', 'true');
-          openBtn?.setAttribute('aria-expanded', 'false');
-          unlockBody();
-          openBtn?.focus({ preventScroll: true });
-        };
-
-        const open = () => {
-          if (root.getAttribute('data-open') === 'true') return;
-          root.setAttribute('data-open', 'true');
-          overlay?.removeAttribute('hidden');
-          drawer.setAttribute('aria-hidden', 'false');
-          openBtn?.setAttribute('aria-expanded', 'true');
-          lockBody();
-          const focusTarget = drawer.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
-          (focusTarget || closeBtn || drawer).focus?.({ preventScroll: true });
-        };
-
-        const handleKeydown = (event) => {
-          if (event.key === 'Escape') {
-            close();
-          }
-        };
-
-        openBtn?.addEventListener('click', open);
-        closeBtn?.addEventListener('click', close);
-        overlay?.addEventListener('click', close);
-        drawer.querySelectorAll('a').forEach((link) => link.addEventListener('click', close));
-        document.addEventListener('keydown', handleKeydown);
-      };
-
-      fetch(`/nav.html?v=${NAV_VERSION}`)
-        .then((response) => response.text())
-        .then((html) => {
-          placeholder.outerHTML = html;
-          const root = document.getElementById('global-nav');
-          if (!root) return;
-          markCurrentLinks(root);
-          attachInteractions(root);
-        })
-        .catch(() => {});
-    })();
-  </script>
+  <script type="module" src="/js/modules/nav.js?v=1.1.0"></script>
 
   <!-- Hero -->
   <section class="hero">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — A product of FishKeepingLifeCo</title>
   <meta name="description" content="Smart tools and guides to plan, stock, and set up your aquarium — all in one place." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.1.0" />
 
   <style>
     :root{

--- a/js/modules/nav.js
+++ b/js/modules/nav.js
@@ -1,0 +1,103 @@
+const NAV_VERSION = '1.1.0';
+const NAV_ENDPOINT = `/nav.html?v=${NAV_VERSION}`;
+const SKIP_PATHS = new Set(['/', '/index.html']);
+
+const normalizePath = (value) => {
+  try {
+    const url = new URL(value, window.location.origin);
+    const path = url.pathname.replace(/\/+$/, '') || '/';
+    return path === '/' ? '/index.html' : path;
+  } catch (error) {
+    return value;
+  }
+};
+
+const markCurrentLinks = (root, current) => {
+  root.querySelectorAll('.links a, #ttg-drawer a').forEach((link) => {
+    const hrefAttr = link.getAttribute('href');
+    if (!hrefAttr) return;
+    if (normalizePath(hrefAttr) === current) {
+      link.setAttribute('aria-current', 'page');
+    }
+  });
+};
+
+const attachInteractions = (root) => {
+  const openBtn = root.querySelector('#ttg-nav-open');
+  const closeBtn = root.querySelector('#ttg-nav-close');
+  const overlay = root.querySelector('#ttg-overlay');
+  const drawer = root.querySelector('#ttg-drawer');
+
+  if (!drawer) return;
+
+  const lockBody = () => {
+    document.documentElement.classList.add('ttg-nav-locked');
+    document.body.classList.add('ttg-nav-locked');
+  };
+
+  const unlockBody = () => {
+    document.documentElement.classList.remove('ttg-nav-locked');
+    document.body.classList.remove('ttg-nav-locked');
+  };
+
+  const close = () => {
+    if (root.getAttribute('data-open') !== 'true') return;
+    root.setAttribute('data-open', 'false');
+    overlay?.setAttribute('hidden', '');
+    drawer.setAttribute('aria-hidden', 'true');
+    openBtn?.setAttribute('aria-expanded', 'false');
+    unlockBody();
+    openBtn?.focus({ preventScroll: true });
+  };
+
+  const open = () => {
+    if (root.getAttribute('data-open') === 'true') return;
+    root.setAttribute('data-open', 'true');
+    overlay?.removeAttribute('hidden');
+    drawer.setAttribute('aria-hidden', 'false');
+    openBtn?.setAttribute('aria-expanded', 'true');
+    lockBody();
+    const focusTarget = drawer.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
+    (focusTarget || closeBtn || drawer).focus?.({ preventScroll: true });
+  };
+
+  const handleKeydown = (event) => {
+    if (event.key === 'Escape') {
+      close();
+    }
+  };
+
+  openBtn?.addEventListener('click', open);
+  closeBtn?.addEventListener('click', close);
+  overlay?.addEventListener('click', close);
+  drawer.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', close);
+  });
+  document.addEventListener('keydown', handleKeydown);
+};
+
+const placeholder = document.getElementById('site-nav');
+if (placeholder) {
+  const currentPath = normalizePath(window.location.pathname || '/');
+  if (SKIP_PATHS.has(currentPath)) {
+    placeholder.remove();
+  } else {
+    fetch(NAV_ENDPOINT)
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error('Failed to fetch nav');
+        }
+        return response.text();
+      })
+      .then((html) => {
+        placeholder.outerHTML = html;
+        const root = document.getElementById('global-nav');
+        if (!root) return;
+        markCurrentLinks(root, currentPath);
+        attachInteractions(root);
+      })
+      .catch(() => {
+        placeholder.remove();
+      });
+  }
+}

--- a/media.html
+++ b/media.html
@@ -5,7 +5,7 @@
   <title>The Tank Guide — Media Hub</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Media Hub — Watch • Read • Explore. Aquarium videos and blogs for every aquarist." />
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.1.0" />
   <link rel="icon" href="/favicon.ico" />
   <meta property="og:title" content="The Tank Guide — Media Hub" />
   <meta property="og:description" content="Watch • Read • Explore — videos and blogs for every aquarist." />
@@ -94,97 +94,7 @@
 
   <!-- Global nav include -->
   <div id="site-nav"></div>
-  <script>
-    (function () {
-      const NAV_VERSION = '1.0.8';
-      const placeholder = document.getElementById('site-nav');
-      if (!placeholder) return;
-
-      const normalizePath = (value) => {
-        try {
-          const url = new URL(value, window.location.origin);
-          const path = url.pathname.replace(/\/+$/, '') || '/';
-          return path === '/' ? '/index.html' : path;
-        } catch (error) {
-          return value;
-        }
-      };
-
-      const markCurrentLinks = (root) => {
-        const current = normalizePath(window.location.pathname || '/');
-        root.querySelectorAll('.links a, #ttg-drawer a').forEach((link) => {
-          const hrefAttr = link.getAttribute('href');
-          if (!hrefAttr) return;
-          if (normalizePath(hrefAttr) === current) {
-            link.setAttribute('aria-current', 'page');
-          }
-        });
-      };
-
-      const attachInteractions = (root) => {
-        const openBtn = root.querySelector('#ttg-nav-open');
-        const closeBtn = root.querySelector('#ttg-nav-close');
-        const overlay = root.querySelector('#ttg-overlay');
-        const drawer = root.querySelector('#ttg-drawer');
-
-        if (!drawer) return;
-
-        const lockBody = () => {
-          document.documentElement.classList.add('ttg-nav-locked');
-          document.body.classList.add('ttg-nav-locked');
-        };
-
-        const unlockBody = () => {
-          document.documentElement.classList.remove('ttg-nav-locked');
-          document.body.classList.remove('ttg-nav-locked');
-        };
-
-        const close = () => {
-          if (root.getAttribute('data-open') !== 'true') return;
-          root.setAttribute('data-open', 'false');
-          overlay?.setAttribute('hidden', '');
-          drawer.setAttribute('aria-hidden', 'true');
-          openBtn?.setAttribute('aria-expanded', 'false');
-          unlockBody();
-          openBtn?.focus({ preventScroll: true });
-        };
-
-        const open = () => {
-          if (root.getAttribute('data-open') === 'true') return;
-          root.setAttribute('data-open', 'true');
-          overlay?.removeAttribute('hidden');
-          drawer.setAttribute('aria-hidden', 'false');
-          openBtn?.setAttribute('aria-expanded', 'true');
-          lockBody();
-          const focusTarget = drawer.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
-          (focusTarget || closeBtn || drawer).focus?.({ preventScroll: true });
-        };
-
-        const handleKeydown = (event) => {
-          if (event.key === 'Escape') {
-            close();
-          }
-        };
-
-        openBtn?.addEventListener('click', open);
-        closeBtn?.addEventListener('click', close);
-        overlay?.addEventListener('click', close);
-        drawer.querySelectorAll('a').forEach((link) => link.addEventListener('click', close));
-        document.addEventListener('keydown', handleKeydown);
-      };
-
-      fetch(`/nav.html?v=${NAV_VERSION}`)
-        .then((response) => response.text())
-        .then((html) => {
-          placeholder.outerHTML = html;
-          const root = document.getElementById('global-nav');
-          if (!root) return;
-          markCurrentLinks(root);
-          attachInteractions(root);
-        })
-        .catch(() => {});
-    })();
-  </script>
+  <script type="module" src="/js/modules/nav.js?v=1.1.0"></script>
 
   <!-- Hero -->
   <section class="hero">

--- a/nav.html
+++ b/nav.html
@@ -1,14 +1,14 @@
 <header id="global-nav" data-open="false">
   <div class="nav-inner">
     <div class="nav-primary">
-      <button id="ttg-nav-open" type="button" aria-label="Open menu" aria-controls="ttg-drawer" aria-expanded="false">
+      <button id="ttg-nav-open" type="button" aria-label="Open menu" aria-haspopup="dialog" aria-controls="ttg-drawer" aria-expanded="false">
         <span class="hamburger-bars" aria-hidden="true"></span>
         <span class="visually-hidden">Menu</span>
       </button>
 
       <a class="brand" href="/index.html" aria-label="The Tank Guide — Home">
         <span class="brand-title">The Tank Guide</span>
-        <span class="brand-sub">a product of <strong>FishKeepingLifeCo</strong></span>
+        <span class="brand-sub">a product of <span class="brand-sub-em">FishKeepingLifeCo</span></span>
       </a>
     </div>
 

--- a/params.html
+++ b/params.html
@@ -6,7 +6,7 @@
   <title>Cycling Coach — The Tank Guide</title>
   <meta name="description" content="Cycling Coach is under construction — coming soon to help you master the nitrogen cycle." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.1.0" />
 
   <style>
     :root{
@@ -57,97 +57,7 @@
 
   <!-- Global nav include (shared across pages) -->
   <div id="site-nav"></div>
-  <script>
-    (function () {
-      const NAV_VERSION = '1.0.8';
-      const placeholder = document.getElementById('site-nav');
-      if (!placeholder) return;
-
-      const normalizePath = (value) => {
-        try {
-          const url = new URL(value, window.location.origin);
-          const path = url.pathname.replace(/\/+$/, '') || '/';
-          return path === '/' ? '/index.html' : path;
-        } catch (error) {
-          return value;
-        }
-      };
-
-      const markCurrentLinks = (root) => {
-        const current = normalizePath(window.location.pathname || '/');
-        root.querySelectorAll('.links a, #ttg-drawer a').forEach((link) => {
-          const hrefAttr = link.getAttribute('href');
-          if (!hrefAttr) return;
-          if (normalizePath(hrefAttr) === current) {
-            link.setAttribute('aria-current', 'page');
-          }
-        });
-      };
-
-      const attachInteractions = (root) => {
-        const openBtn = root.querySelector('#ttg-nav-open');
-        const closeBtn = root.querySelector('#ttg-nav-close');
-        const overlay = root.querySelector('#ttg-overlay');
-        const drawer = root.querySelector('#ttg-drawer');
-
-        if (!drawer) return;
-
-        const lockBody = () => {
-          document.documentElement.classList.add('ttg-nav-locked');
-          document.body.classList.add('ttg-nav-locked');
-        };
-
-        const unlockBody = () => {
-          document.documentElement.classList.remove('ttg-nav-locked');
-          document.body.classList.remove('ttg-nav-locked');
-        };
-
-        const close = () => {
-          if (root.getAttribute('data-open') !== 'true') return;
-          root.setAttribute('data-open', 'false');
-          overlay?.setAttribute('hidden', '');
-          drawer.setAttribute('aria-hidden', 'true');
-          openBtn?.setAttribute('aria-expanded', 'false');
-          unlockBody();
-          openBtn?.focus({ preventScroll: true });
-        };
-
-        const open = () => {
-          if (root.getAttribute('data-open') === 'true') return;
-          root.setAttribute('data-open', 'true');
-          overlay?.removeAttribute('hidden');
-          drawer.setAttribute('aria-hidden', 'false');
-          openBtn?.setAttribute('aria-expanded', 'true');
-          lockBody();
-          const focusTarget = drawer.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
-          (focusTarget || closeBtn || drawer).focus?.({ preventScroll: true });
-        };
-
-        const handleKeydown = (event) => {
-          if (event.key === 'Escape') {
-            close();
-          }
-        };
-
-        openBtn?.addEventListener('click', open);
-        closeBtn?.addEventListener('click', close);
-        overlay?.addEventListener('click', close);
-        drawer.querySelectorAll('a').forEach((link) => link.addEventListener('click', close));
-        document.addEventListener('keydown', handleKeydown);
-      };
-
-      fetch(`/nav.html?v=${NAV_VERSION}`)
-        .then((response) => response.text())
-        .then((html) => {
-          placeholder.outerHTML = html;
-          const root = document.getElementById('global-nav');
-          if (!root) return;
-          markCurrentLinks(root);
-          attachInteractions(root);
-        })
-        .catch(() => {});
-    })();
-  </script>
+  <script type="module" src="/js/modules/nav.js?v=1.1.0"></script>
 
   <!-- HERO Placeholder -->
   <section class="hero">

--- a/stocking.html
+++ b/stocking.html
@@ -5,7 +5,7 @@
   <title>FishkeepingLifeCo — Stocking Calculator</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Global nav / shared styles (same versioning as Media) -->
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.1.0" />
   <!-- Page styles -->
   <link rel="stylesheet" href="css/Style.css?v=1.0.3" />
   <style>
@@ -19,97 +19,7 @@
 
   <!-- Global nav include (same pattern as Media) -->
   <div id="site-nav"></div>
-  <script>
-    (function () {
-      const NAV_VERSION = '1.0.8';
-      const placeholder = document.getElementById('site-nav');
-      if (!placeholder) return;
-
-      const normalizePath = (value) => {
-        try {
-          const url = new URL(value, window.location.origin);
-          const path = url.pathname.replace(/\/+$/, '') || '/';
-          return path === '/' ? '/index.html' : path;
-        } catch (error) {
-          return value;
-        }
-      };
-
-      const markCurrentLinks = (root) => {
-        const current = normalizePath(window.location.pathname || '/');
-        root.querySelectorAll('.links a, #ttg-drawer a').forEach((link) => {
-          const hrefAttr = link.getAttribute('href');
-          if (!hrefAttr) return;
-          if (normalizePath(hrefAttr) === current) {
-            link.setAttribute('aria-current', 'page');
-          }
-        });
-      };
-
-      const attachInteractions = (root) => {
-        const openBtn = root.querySelector('#ttg-nav-open');
-        const closeBtn = root.querySelector('#ttg-nav-close');
-        const overlay = root.querySelector('#ttg-overlay');
-        const drawer = root.querySelector('#ttg-drawer');
-
-        if (!drawer) return;
-
-        const lockBody = () => {
-          document.documentElement.classList.add('ttg-nav-locked');
-          document.body.classList.add('ttg-nav-locked');
-        };
-
-        const unlockBody = () => {
-          document.documentElement.classList.remove('ttg-nav-locked');
-          document.body.classList.remove('ttg-nav-locked');
-        };
-
-        const close = () => {
-          if (root.getAttribute('data-open') !== 'true') return;
-          root.setAttribute('data-open', 'false');
-          overlay?.setAttribute('hidden', '');
-          drawer.setAttribute('aria-hidden', 'true');
-          openBtn?.setAttribute('aria-expanded', 'false');
-          unlockBody();
-          openBtn?.focus({ preventScroll: true });
-        };
-
-        const open = () => {
-          if (root.getAttribute('data-open') === 'true') return;
-          root.setAttribute('data-open', 'true');
-          overlay?.removeAttribute('hidden');
-          drawer.setAttribute('aria-hidden', 'false');
-          openBtn?.setAttribute('aria-expanded', 'true');
-          lockBody();
-          const focusTarget = drawer.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
-          (focusTarget || closeBtn || drawer).focus?.({ preventScroll: true });
-        };
-
-        const handleKeydown = (event) => {
-          if (event.key === 'Escape') {
-            close();
-          }
-        };
-
-        openBtn?.addEventListener('click', open);
-        closeBtn?.addEventListener('click', close);
-        overlay?.addEventListener('click', close);
-        drawer.querySelectorAll('a').forEach((link) => link.addEventListener('click', close));
-        document.addEventListener('keydown', handleKeydown);
-      };
-
-      fetch(`/nav.html?v=${NAV_VERSION}`)
-        .then((response) => response.text())
-        .then((html) => {
-          placeholder.outerHTML = html;
-          const root = document.getElementById('global-nav');
-          if (!root) return;
-          markCurrentLinks(root);
-          attachInteractions(root);
-        })
-        .catch(() => {});
-    })();
-  </script>
+  <script type="module" src="/js/modules/nav.js?v=1.1.0"></script>
 
   <div class="wrap">
     <!-- Tank Setup -->


### PR DESCRIPTION
## Summary
- add a shared nav module that injects the global header on tool pages and skips the home route
- refresh nav markup/styles for the translucent header, consistent brand lockup, and left drawer sizing/spacing
- update product pages to load the module/CSS version so active-link highlights and typography stay in sync

## Testing
- browser_container.run_playwright_script (stocking drawer screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68d38c9ea7448332b9c738aa91c4a1b5