### PR TITLE
Unify nav drawer behavior and styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Global navigation now loads consistently across non-home pages with a translucent bar, left-drawer menu, and safe-area aware overlay refresh.
+- Slide-out navigation drawer unified across Stocking, Gear, Cycling Coach, and Media pages with consistent styling/behavior, and removed the drawer from the homepage.
 
 ---
 

--- a/css/style.css
+++ b/css/style.css
@@ -142,8 +142,8 @@
 #global-nav .links a[aria-current="page"] {
   color: #ffffff;
   text-decoration: underline;
-  text-underline-offset: 0.4em;
-  text-decoration-thickness: 0.16em;
+  text-underline-offset: 0.35em;
+  text-decoration-thickness: 2px;
   font-weight: 600;
 }
 
@@ -174,7 +174,7 @@
   position: fixed;
   top: 0;
   left: 0;
-  width: clamp(280px, 45vw, 360px);
+  width: 45vw;
   height: 100dvh;
   transform: translateX(-100%);
   transition: transform 0.25s ease;
@@ -184,12 +184,13 @@
   box-shadow: 18px 0 40px rgba(0, 0, 0, 0.38);
   display: flex;
   flex-direction: column;
-  padding: 24px;
-  padding-top: calc(24px + env(safe-area-inset-top));
-  padding-left: calc(24px + env(safe-area-inset-left));
-  padding-right: calc(24px + env(safe-area-inset-right));
+  padding: 28px;
+  padding-top: calc(28px + env(safe-area-inset-top));
+  padding-left: calc(28px + env(safe-area-inset-left));
+  padding-right: calc(28px + env(safe-area-inset-right));
   z-index: 5100;
   overflow-y: auto;
+  box-sizing: border-box;
 }
 
 #ttg-drawer header {
@@ -197,6 +198,7 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  margin-bottom: 24px;
 }
 
 #ttg-drawer header strong {
@@ -215,6 +217,7 @@
   line-height: 1;
   cursor: pointer;
   transition: background 0.2s ease;
+  flex-shrink: 0;
 }
 
 #ttg-nav-close:hover,
@@ -225,13 +228,12 @@
 #ttg-drawer nav {
   display: flex;
   flex-direction: column;
-  gap: 6px;
-  margin-top: 24px;
+  gap: 10px;
 }
 
 #ttg-drawer a {
   display: block;
-  padding: 10px 0;
+  padding: 12px 4px;
   border-radius: 10px;
   color: inherit;
   text-decoration: none;
@@ -247,8 +249,8 @@
 #ttg-drawer a[aria-current="page"] {
   font-weight: 600;
   text-decoration: underline;
-  text-underline-offset: 0.4em;
-  text-decoration-thickness: 0.16em;
+  text-underline-offset: 0.35em;
+  text-decoration-thickness: 2px;
 }
 
 #global-nav[data-open="true"] #ttg-overlay {

--- a/gear.html
+++ b/gear.html
@@ -5,7 +5,7 @@
   <title>The Tank Guide — Gear (Guided)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Build your aquarium setup step by step — tanks, filtration, lighting, and more." />
-  <link rel="stylesheet" href="css/style.css?v=1.1.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.2.0" />
   <link rel="icon" href="/favicon.ico" />
 
   <style>
@@ -63,7 +63,7 @@
 
   <!-- Global nav include (shared across pages) -->
   <div id="site-nav"></div>
-  <script type="module" src="/js/modules/nav.js?v=1.1.0"></script>
+  <script type="module" src="/js/modules/nav.js?v=1.2.0"></script>
 
   <!-- Hero -->
   <section class="hero">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — A product of FishKeepingLifeCo</title>
   <meta name="description" content="Smart tools and guides to plan, stock, and set up your aquarium — all in one place." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.1.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.2.0" />
 
   <style>
     :root{

--- a/js/modules/nav.js
+++ b/js/modules/nav.js
@@ -1,4 +1,4 @@
-const NAV_VERSION = '1.1.0';
+const NAV_VERSION = '1.2.0';
 const NAV_ENDPOINT = `/nav.html?v=${NAV_VERSION}`;
 const SKIP_PATHS = new Set(['/', '/index.html']);
 
@@ -57,8 +57,8 @@ const attachInteractions = (root) => {
     drawer.setAttribute('aria-hidden', 'false');
     openBtn?.setAttribute('aria-expanded', 'true');
     lockBody();
-    const focusTarget = drawer.querySelector('a, button, [tabindex]:not([tabindex="-1"])');
-    (focusTarget || closeBtn || drawer).focus?.({ preventScroll: true });
+    const firstLink = drawer.querySelector('nav a');
+    (firstLink || closeBtn || drawer).focus?.({ preventScroll: true });
   };
 
   const handleKeydown = (event) => {

--- a/media.html
+++ b/media.html
@@ -5,7 +5,7 @@
   <title>The Tank Guide — Media Hub</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Media Hub — Watch • Read • Explore. Aquarium videos and blogs for every aquarist." />
-  <link rel="stylesheet" href="css/style.css?v=1.1.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.2.0" />
   <link rel="icon" href="/favicon.ico" />
   <meta property="og:title" content="The Tank Guide — Media Hub" />
   <meta property="og:description" content="Watch • Read • Explore — videos and blogs for every aquarist." />
@@ -94,7 +94,7 @@
 
   <!-- Global nav include -->
   <div id="site-nav"></div>
-  <script type="module" src="/js/modules/nav.js?v=1.1.0"></script>
+  <script type="module" src="/js/modules/nav.js?v=1.2.0"></script>
 
   <!-- Hero -->
   <section class="hero">

--- a/params.html
+++ b/params.html
@@ -6,7 +6,7 @@
   <title>Cycling Coach — The Tank Guide</title>
   <meta name="description" content="Cycling Coach is under construction — coming soon to help you master the nitrogen cycle." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.1.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.2.0" />
 
   <style>
     :root{
@@ -57,7 +57,7 @@
 
   <!-- Global nav include (shared across pages) -->
   <div id="site-nav"></div>
-  <script type="module" src="/js/modules/nav.js?v=1.1.0"></script>
+  <script type="module" src="/js/modules/nav.js?v=1.2.0"></script>
 
   <!-- HERO Placeholder -->
   <section class="hero">

--- a/stocking.html
+++ b/stocking.html
@@ -5,7 +5,7 @@
   <title>FishkeepingLifeCo — Stocking Calculator</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Global nav / shared styles (same versioning as Media) -->
-  <link rel="stylesheet" href="css/style.css?v=1.1.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.2.0" />
   <!-- Page styles -->
   <link rel="stylesheet" href="css/Style.css?v=1.0.3" />
   <style>
@@ -19,7 +19,7 @@
 
   <!-- Global nav include (same pattern as Media) -->
   <div id="site-nav"></div>
-  <script type="module" src="/js/modules/nav.js?v=1.1.0"></script>
+  <script type="module" src="/js/modules/nav.js?v=1.2.0"></script>
 
   <div class="wrap">
     <!-- Tank Setup -->

--- a/verification.log
+++ b/verification.log
@@ -1,0 +1,38 @@
+Page: index -> PASS
+  nav_absent: ok
+Page: stocking -> PASS
+  width_ratio_45: ok
+  focus_first_link: ok
+  aria_open: ok
+  overlay_visible: ok
+  body_locked: ok
+  overlay_close: ok
+  escape_close: ok
+  link_close: ok
+Page: gear -> PASS
+  width_ratio_45: ok
+  focus_first_link: ok
+  aria_open: ok
+  overlay_visible: ok
+  body_locked: ok
+  overlay_close: ok
+  escape_close: ok
+  link_close: ok
+Page: params -> PASS
+  width_ratio_45: ok
+  focus_first_link: ok
+  aria_open: ok
+  overlay_visible: ok
+  body_locked: ok
+  overlay_close: ok
+  escape_close: ok
+  link_close: ok
+Page: media -> PASS
+  width_ratio_45: ok
+  focus_first_link: ok
+  aria_open: ok
+  overlay_visible: ok
+  body_locked: ok
+  overlay_close: ok
+  escape_close: ok
+  link_close: ok


### PR DESCRIPTION
## Summary
- make the mobile drawer share the same 45% width, padding, overlay, and active-link styling across stocking, gear, params, and media
- focus the first drawer link when opened, return focus to the trigger on close, and lock page scrolling while the overlay is visible
- bump shared CSS/JS cache-busting versions and keep the homepage free of the navigation include

## Testing
- python playwright script verifying nav behavior on index, stocking, gear, params, media

------
https://chatgpt.com/codex/tasks/task_e_68d3eea1b6048332b9bd167f239ea1ce