### PR TITLE
Refactor global navigation and add JS initializer

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,5 @@
 :root {
-  --ttg-nav-bg: rgba(8, 22, 38, 0.32);
+  --ttg-nav-bg: transparent;
   --ttg-nav-text: #f3f6ff;
   --ttg-nav-link: rgba(243, 246, 255, 0.82);
   --ttg-nav-overlay: rgba(0, 0, 0, 0.35);
@@ -8,14 +8,17 @@
 }
 
 #global-nav {
-  position: relative;
-  z-index: 2;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10000;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
-  color: var(--ttg-nav-text, #f3f6ff);
-  background: var(--ttg-nav-bg, rgba(8, 22, 38, 0.32));
-  backdrop-filter: blur(20px) saturate(140%);
-  -webkit-backdrop-filter: blur(20px) saturate(140%);
-  box-shadow: 0 12px 36px rgba(6, 18, 36, 0.18);
+  color: var(--ttg-nav-text, #eef3ff);
+  background: var(--ttg-nav-bg, transparent);
+  backdrop-filter: blur(8px) saturate(120%);
+  -webkit-backdrop-filter: blur(8px) saturate(120%);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
 #global-nav a {
@@ -33,6 +36,7 @@
   padding-block-start: calc(16px + env(safe-area-inset-top));
   padding-inline-start: calc(20px + env(safe-area-inset-left));
   padding-inline-end: calc(20px + env(safe-area-inset-right));
+  box-sizing: border-box;
 }
 
 #ttg-nav-open {
@@ -87,8 +91,9 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  gap: 2px;
-  line-height: 1.1;
+  justify-content: center;
+  gap: 4px;
+  line-height: 1.15;
   text-shadow: 0 1px 8px rgba(0, 0, 0, 0.38);
 }
 
@@ -99,13 +104,60 @@
 
 #global-nav .brand-sub {
   opacity: 0.9;
-  font-size: 0.92rem;
+  font-size: 0.9rem;
   font-weight: 500;
   letter-spacing: 0.01em;
 }
 
 #global-nav .brand-sub-em {
   font-weight: 600;
+}
+
+
+#global-nav .links {
+  display: none;
+  align-items: center;
+  gap: 20px;
+  margin-left: auto;
+}
+
+#global-nav .links a {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 0;
+  color: var(--ttg-nav-link, rgba(243, 246, 255, 0.82));
+  font-size: 0.98rem;
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+#global-nav .links a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -6px;
+  height: 2px;
+  background: transparent;
+  transform-origin: left;
+  transform: scaleX(0);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+#global-nav .links a:hover,
+#global-nav .links a:focus-visible {
+  color: #ffffff;
+}
+
+#global-nav .links a[aria-current="page"] {
+  color: #ffffff;
+  font-weight: 600;
+}
+
+#global-nav .links a[aria-current="page"]::after {
+  background: currentColor;
+  transform: scaleX(1);
 }
 
 
@@ -116,7 +168,7 @@
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.28s ease;
-  z-index: 10000;
+  z-index: 10001;
 }
 
 #ttg-drawer {
@@ -136,7 +188,7 @@
   padding-top: calc(24px + env(safe-area-inset-top));
   padding-left: calc(24px + env(safe-area-inset-left));
   padding-right: calc(24px + env(safe-area-inset-right));
-  z-index: 10001;
+  z-index: 10002;
   overflow-y: auto;
   box-sizing: border-box;
   backdrop-filter: blur(28px) saturate(130%);
@@ -177,13 +229,13 @@
   background: rgba(255, 255, 255, 0.26);
 }
 
-#ttg-drawer nav {
+#ttg-drawer .drawer {
   display: flex;
   flex-direction: column;
   gap: 8px;
 }
 
-#ttg-drawer a {
+#ttg-drawer .drawer a {
   display: block;
   padding: 16px 20px;
   border-radius: 12px;
@@ -196,12 +248,12 @@
   min-height: 44px;
 }
 
-#ttg-drawer a:hover {
+#ttg-drawer .drawer a:hover {
   color: #ffffff;
   background: rgba(255, 255, 255, 0.14);
 }
 
-#ttg-drawer a[aria-current="page"] {
+#ttg-drawer .drawer a[aria-current="page"] {
   color: #ffffff;
   font-weight: 600;
   box-shadow: inset 0 -2px 0 rgba(255, 255, 255, 0.7);
@@ -223,8 +275,13 @@
   border-radius: 12px;
 }
 
-#ttg-drawer a:focus-visible {
+#ttg-drawer .drawer a:focus-visible {
   border-radius: 12px;
+}
+
+#global-nav-spacer {
+  width: 100%;
+  height: 0;
 }
 
 .visually-hidden {
@@ -237,6 +294,22 @@
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+@media (min-width: 920px) {
+  #ttg-nav-open {
+    display: none;
+  }
+
+  #global-nav .links {
+    display: flex;
+  }
+}
+
+@media (max-width: 919.98px) {
+  #global-nav .links {
+    display: none;
+  }
 }
 
 /* Footer social strip (consistent across pages) */

--- a/gear.html
+++ b/gear.html
@@ -5,7 +5,7 @@
   <title>The Tank Guide — Gear (Guided)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Build your aquarium setup step by step — tanks, filtration, lighting, and more." />
-  <link rel="stylesheet" href="css/style.css?v=1.2.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.3.0" />
   <link rel="icon" href="/favicon.ico" />
 
   <style>
@@ -63,12 +63,19 @@
 
   <!-- Global nav include (shared across pages) -->
   <div id="site-nav"></div>
+  <script src="js/nav.js?v=1.1.0"></script>
   <script>
-    // Keep this exact version across all subpages; bump only if you must.
-    fetch('/nav.html?v=1.0.6').then(r => r.text()).then(html => {
-      const host = document.getElementById('site-nav');
-      host.outerHTML = html; // nav.html includes init code and runs itself
-    });
+    fetch('/nav.html?v=1.1.0')
+      .then(response => response.text())
+      .then(html => {
+        const host = document.getElementById('site-nav');
+        if (!host) return;
+        host.outerHTML = html;
+        if (typeof window.__initTTGNav === 'function') {
+          window.__initTTGNav();
+        }
+      })
+      .catch(error => console.error('Failed to load navigation', error));
   </script>
 
   <!-- Hero -->

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — A product of FishKeepingLifeCo</title>
   <meta name="description" content="Smart tools and guides to plan, stock, and set up your aquarium — all in one place." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.2.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.3.0" />
 
   <style>
     :root{

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,0 +1,145 @@
+(function () {
+  const OVERLAY_HIDE_DELAY = 320;
+
+  function normalizePath(path) {
+    try {
+      path = new URL(path, window.location.origin).pathname;
+    } catch (error) {
+      path = path || '/';
+    }
+
+    path = path.replace(/index\.html$/i, '');
+    path = path.replace(/\/+$/g, '');
+
+    if (!path) {
+      return '/';
+    }
+
+    return path;
+  }
+
+  function syncActiveLinks(root) {
+    const current = normalizePath(window.location.pathname);
+    const linkNodes = root.querySelectorAll('.links a, #ttg-drawer a');
+
+    linkNodes.forEach((link) => {
+      const target = normalizePath(link.getAttribute('href') || '');
+      if (target === current) {
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.removeAttribute('aria-current');
+      }
+    });
+  }
+
+  function setSpacerHeight(root) {
+    const spacer = document.getElementById('global-nav-spacer');
+    if (!spacer) return;
+    const height = root.offsetHeight;
+    if (height > 0) {
+      spacer.style.height = `${height}px`;
+    }
+  }
+
+  window.__initTTGNav = function __initTTGNav() {
+    const root = document.getElementById('global-nav');
+    if (!root || root.dataset.ttgNavReady === 'true') {
+      return;
+    }
+
+    const overlay = root.querySelector('#ttg-overlay');
+    const drawer = root.querySelector('#ttg-drawer');
+    const openBtn = root.querySelector('#ttg-nav-open');
+    const closeBtn = root.querySelector('#ttg-nav-close');
+    const drawerLinks = Array.from(drawer ? drawer.querySelectorAll('a') : []);
+    const docEl = document.documentElement;
+    const body = document.body;
+    let previousFocus = null;
+    let prevDocOverflow = docEl.style.overflow || '';
+    let prevBodyOverflow = body.style.overflow || '';
+    let overlayHideTimer = null;
+
+    if (!overlay || !drawer || !openBtn) {
+      return;
+    }
+
+    root.dataset.ttgNavReady = 'true';
+    openBtn.setAttribute('aria-expanded', 'false');
+    drawer.setAttribute('aria-hidden', 'true');
+    overlay.hidden = true;
+    setSpacerHeight(root);
+
+    function openDrawer() {
+      if (root.dataset.open === 'true') return;
+      window.clearTimeout(overlayHideTimer);
+      overlay.hidden = false;
+      previousFocus = document.activeElement;
+      prevDocOverflow = docEl.style.overflow || '';
+      prevBodyOverflow = body.style.overflow || '';
+      root.dataset.open = 'true';
+      drawer.setAttribute('aria-hidden', 'false');
+      openBtn.setAttribute('aria-expanded', 'true');
+      docEl.style.overflow = 'hidden';
+      body.style.overflow = 'hidden';
+      if (drawerLinks.length) {
+        window.requestAnimationFrame(() => {
+          drawerLinks[0].focus();
+        });
+      } else {
+        drawer.focus();
+      }
+    }
+
+    function closeDrawer(options = {}) {
+      if (root.dataset.open !== 'true') return;
+      const { returnFocus = true } = options;
+      root.dataset.open = 'false';
+      drawer.setAttribute('aria-hidden', 'true');
+      openBtn.setAttribute('aria-expanded', 'false');
+      docEl.style.overflow = prevDocOverflow;
+      body.style.overflow = prevBodyOverflow;
+      overlayHideTimer = window.setTimeout(() => {
+        if (root.dataset.open !== 'true') {
+          overlay.hidden = true;
+        }
+      }, OVERLAY_HIDE_DELAY);
+      if (returnFocus && previousFocus) {
+        window.requestAnimationFrame(() => {
+          if (typeof previousFocus.focus === 'function') {
+            previousFocus.focus();
+          } else {
+            openBtn.focus();
+          }
+        });
+      }
+      previousFocus = null;
+    }
+
+    openBtn.addEventListener('click', openDrawer);
+    if (closeBtn) {
+      closeBtn.addEventListener('click', () => closeDrawer());
+    }
+    overlay.addEventListener('click', () => closeDrawer());
+    drawer.addEventListener('click', (event) => {
+      const link = event.target.closest('a');
+      if (link) {
+        closeDrawer({ returnFocus: false });
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && root.dataset.open === 'true') {
+        event.preventDefault();
+        closeDrawer();
+      }
+    });
+
+    syncActiveLinks(root);
+    window.addEventListener('popstate', () => syncActiveLinks(root));
+    window.addEventListener('hashchange', () => syncActiveLinks(root));
+    window.addEventListener('pageshow', () => syncActiveLinks(root));
+    window.addEventListener('resize', () => setSpacerHeight(root));
+    window.addEventListener('load', () => setSpacerHeight(root));
+    window.addEventListener('pageshow', () => setSpacerHeight(root));
+  };
+})();

--- a/media.html
+++ b/media.html
@@ -5,7 +5,7 @@
   <title>The Tank Guide — Media Hub</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Media Hub — Watch • Read • Explore. Aquarium videos and blogs for every aquarist." />
-  <link rel="stylesheet" href="css/style.css?v=1.2.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.3.0" />
   <link rel="icon" href="/favicon.ico" />
   <meta property="og:title" content="The Tank Guide — Media Hub" />
   <meta property="og:description" content="Watch • Read • Explore — videos and blogs for every aquarist." />
@@ -94,12 +94,19 @@
 
   <!-- Global nav include -->
   <div id="site-nav"></div>
+  <script src="js/nav.js?v=1.1.0"></script>
   <script>
-    // Keep this exact version across all subpages; bump only if you must.
-    fetch('/nav.html?v=1.0.6').then(r => r.text()).then(html => {
-      const host = document.getElementById('site-nav');
-      host.outerHTML = html; // nav.html includes init code and runs itself
-    });
+    fetch('/nav.html?v=1.1.0')
+      .then(response => response.text())
+      .then(html => {
+        const host = document.getElementById('site-nav');
+        if (!host) return;
+        host.outerHTML = html;
+        if (typeof window.__initTTGNav === 'function') {
+          window.__initTTGNav();
+        }
+      })
+      .catch(error => console.error('Failed to load navigation', error));
   </script>
 
   <!-- Hero -->

--- a/nav.html
+++ b/nav.html
@@ -9,6 +9,16 @@
       <span class="brand-title">The Tank Guide</span>
       <span class="brand-sub">a product of <span class="brand-sub-em">FishKeepingLifeCo</span></span>
     </a>
+
+    <nav class="links" aria-label="Primary">
+      <a href="/index.html">Home</a>
+      <a href="/stocking.html">Stocking Advisor</a>
+      <a href="/gear.html">Gear</a>
+      <a href="/params.html">Cycling Coach</a>
+      <a href="/media.html">Media</a>
+      <a href="/about.html">About</a>
+      <a href="/feedback.html">Feedback</a>
+    </nav>
   </div>
 
   <div id="ttg-overlay" hidden></div>
@@ -20,7 +30,7 @@
         <span aria-hidden="true">×</span>
       </button>
     </div>
-    <nav>
+    <nav class="drawer" aria-label="Primary navigation">
       <a href="/index.html">Home</a>
       <a href="/stocking.html">Stocking Advisor</a>
       <a href="/gear.html">Gear</a>
@@ -30,112 +40,5 @@
       <a href="/feedback.html">Feedback</a>
     </nav>
   </aside>
-
-  <script>
-    (function () {
-      const root = document.getElementById('global-nav');
-      if (!root) return;
-
-      const overlay = root.querySelector('#ttg-overlay');
-      const drawer = root.querySelector('#ttg-drawer');
-      const openBtn = root.querySelector('#ttg-nav-open');
-      const closeBtn = root.querySelector('#ttg-nav-close');
-      const drawerLinks = Array.from(drawer.querySelectorAll('a'));
-      const docEl = document.documentElement;
-      const body = document.body;
-      let previousFocus = null;
-      let prevDocOverflow = docEl.style.overflow || '';
-      let prevBodyOverflow = body.style.overflow || '';
-      let overlayHideTimer = null;
-
-      function normalize(path) {
-        try {
-          path = new URL(path, window.location.origin).pathname;
-        } catch (err) {
-          path = path || '/';
-        }
-
-        path = path.replace(/index\.html$/i, '');
-        path = path.replace(/\/+$/g, '');
-        if (!path) {
-          return '/';
-        }
-        return path;
-      }
-
-      function syncActive() {
-        const current = normalize(window.location.pathname);
-        drawerLinks.forEach((link) => {
-          const target = normalize(link.getAttribute('href') || '');
-          if (target === current) {
-            link.setAttribute('aria-current', 'page');
-          } else {
-            link.removeAttribute('aria-current');
-          }
-        });
-      }
-
-      function openDrawer() {
-        if (root.dataset.open === 'true') return;
-        window.clearTimeout(overlayHideTimer);
-        overlay.hidden = false;
-        previousFocus = document.activeElement;
-        prevDocOverflow = docEl.style.overflow || '';
-        prevBodyOverflow = body.style.overflow || '';
-        root.dataset.open = 'true';
-        drawer.setAttribute('aria-hidden', 'false');
-        openBtn.setAttribute('aria-expanded', 'true');
-        docEl.style.overflow = 'hidden';
-        body.style.overflow = 'hidden';
-        if (drawerLinks.length) {
-          window.requestAnimationFrame(() => {
-            drawerLinks[0].focus();
-          });
-        }
-      }
-
-      function closeDrawer(options = {}) {
-        if (root.dataset.open !== 'true') return;
-        const { returnFocus = true } = options;
-        root.dataset.open = 'false';
-        drawer.setAttribute('aria-hidden', 'true');
-        openBtn.setAttribute('aria-expanded', 'false');
-        docEl.style.overflow = prevDocOverflow;
-        body.style.overflow = prevBodyOverflow;
-        overlayHideTimer = window.setTimeout(() => {
-          if (root.dataset.open !== 'true') {
-            overlay.hidden = true;
-          }
-        }, 280);
-        if (returnFocus && previousFocus) {
-          window.requestAnimationFrame(() => {
-            if (typeof previousFocus.focus === 'function') {
-              previousFocus.focus();
-            } else {
-              openBtn.focus();
-            }
-          });
-        }
-      }
-
-      openBtn.addEventListener('click', openDrawer);
-      closeBtn.addEventListener('click', () => closeDrawer());
-      overlay.addEventListener('click', () => closeDrawer());
-      drawer.addEventListener('click', (event) => {
-        const link = event.target.closest('a');
-        if (link) {
-          closeDrawer({ returnFocus: false });
-        }
-      });
-
-      document.addEventListener('keydown', (event) => {
-        if (event.key === 'Escape' && root.dataset.open === 'true') {
-          event.preventDefault();
-          closeDrawer();
-        }
-      });
-
-      syncActive();
-    })();
-  </script>
 </header>
+<div id="global-nav-spacer" aria-hidden="true"></div>

--- a/params.html
+++ b/params.html
@@ -6,7 +6,7 @@
   <title>Cycling Coach — The Tank Guide</title>
   <meta name="description" content="Cycling Coach is under construction — coming soon to help you master the nitrogen cycle." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.2.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.3.0" />
 
   <style>
     :root{
@@ -57,12 +57,19 @@
 
   <!-- Global nav include (shared across pages) -->
   <div id="site-nav"></div>
+  <script src="js/nav.js?v=1.1.0"></script>
   <script>
-    // Keep this exact version across all subpages; bump only if you must.
-    fetch('/nav.html?v=1.0.6').then(r => r.text()).then(html => {
-      const host = document.getElementById('site-nav');
-      host.outerHTML = html; // nav.html includes init code and runs itself
-    });
+    fetch('/nav.html?v=1.1.0')
+      .then(response => response.text())
+      .then(html => {
+        const host = document.getElementById('site-nav');
+        if (!host) return;
+        host.outerHTML = html;
+        if (typeof window.__initTTGNav === 'function') {
+          window.__initTTGNav();
+        }
+      })
+      .catch(error => console.error('Failed to load navigation', error));
   </script>
 
   <!-- HERO Placeholder -->

--- a/stocking.html
+++ b/stocking.html
@@ -5,7 +5,7 @@
   <title>FishkeepingLifeCo — Stocking Calculator</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Global nav / shared styles (same versioning as Media) -->
-  <link rel="stylesheet" href="css/style.css?v=1.2.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.3.0" />
   <!-- Page styles -->
   <link rel="stylesheet" href="css/Style.css?v=1.0.3" />
   <style>
@@ -19,12 +19,19 @@
 
   <!-- Global nav include (same pattern as Media) -->
   <div id="site-nav"></div>
+  <script src="js/nav.js?v=1.1.0"></script>
   <script>
-    // Keep this exact version across all subpages; bump only if you must.
-    fetch('/nav.html?v=1.0.6').then(r => r.text()).then(html => {
-      const host = document.getElementById('site-nav');
-      host.outerHTML = html; // nav.html includes init code and runs itself
-    });
+    fetch('/nav.html?v=1.1.0')
+      .then(response => response.text())
+      .then(html => {
+        const host = document.getElementById('site-nav');
+        if (!host) return;
+        host.outerHTML = html;
+        if (typeof window.__initTTGNav === 'function') {
+          window.__initTTGNav();
+        }
+      })
+      .catch(error => console.error('Failed to load navigation', error));
   </script>
 
   <div class="wrap">


### PR DESCRIPTION
## Summary
- rebuild the shared nav markup to include desktop links, overlay, and spacer elements
- restyle the nav/drawer/overlay for left-side drawer, translucent bar, and consistent spacing
- add a reusable nav initializer script and update subpages to load it while keeping the homepage nav-free

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4032f63688332b5e20a9b31670fab