### PR TITLE
Refactor nav drawer and add Playwright coverage

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,4 +1,3 @@
-<!-- Updated: Adopted shared nav/footer includes and unified translucent drawer usage on the About page. -->
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -7,143 +6,55 @@
   <title>The Tank Guide — About</title>
   <meta name="description" content="Learn about The Tank Guide mission, story, and future vision." />
   <link rel="icon" href="/favicon.ico" />
-  <link rel="stylesheet" href="css/style.css?v=1.4.2" />
+  <link rel="stylesheet" href="css/style.css?v=1.5.0" />
   <style>
-    :root {
-      --ttg-nav-bg: rgba(10, 16, 30, 0.72);
-      --ttg-nav-link: rgba(243, 246, 255, 0.85);
-    }
-
-    *, *::before, *::after {
-      box-sizing: border-box;
-    }
-
-    html,
-    body {
-      margin: 0;
-      padding: 0;
-      font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
-      color: #f5f8ff;
-      background:
-        radial-gradient(1200px 800px at 75% -10%, #36c2cc 0%, rgba(54, 194, 204, 0) 60%),
-        radial-gradient(1200px 900px at -10% 120%, #0077c7 0%, rgba(0, 119, 199, 0) 60%),
-        linear-gradient(140deg, #0077c7 0%, #0b6ea6 40%, #0a4d87 100%);
-    }
-
-    a {
-      color: inherit;
-    }
-
-    main {
-      padding: 0 20px 80px;
-    }
-
-    .hero {
-      padding: 96px 0 40px;
-      text-align: center;
-    }
-
-    .hero h1 {
-      margin: 0;
-      font-size: clamp(2.4rem, 6vw, 3.6rem);
-      font-weight: 800;
-      letter-spacing: 0.03em;
-    }
-
-    .about-box {
-      max-width: 840px;
-      margin: 0 auto;
-      background: rgba(8, 21, 38, 0.32);
-      border: 1px solid rgba(255, 255, 255, 0.6);
-      border-radius: 18px;
-      padding: clamp(24px, 5vw, 40px);
-      backdrop-filter: blur(10px);
-      -webkit-backdrop-filter: blur(10px);
-      color: rgba(245, 248, 255, 0.92);
-      line-height: 1.65;
-      font-size: clamp(1rem, 1.1vw + 0.9rem, 1.1rem);
-      box-shadow: 0 22px 36px rgba(5, 16, 32, 0.28);
-    }
-
-    .about-box h1,
-    .about-box h2,
-    .about-box h3,
-    .about-box h4,
-    .about-box h5,
-    .about-box h6 {
-      color: #ffffff;
-      margin-top: 1.6em;
-      margin-bottom: 0.6em;
-      line-height: 1.25;
-    }
-
-    .about-box h1:first-child,
-    .about-box h2:first-child,
-    .about-box h3:first-child {
-      margin-top: 0;
-    }
-
-    .about-box p {
-      margin: 0 0 1.1em;
-    }
-
-    .about-box hr {
-      border: none;
-      border-top: 1px solid rgba(255, 255, 255, 0.28);
-      margin: 2.5em auto;
-      max-width: 120px;
-    }
-
-    .about-box strong {
-      color: #ffffff;
-    }
-
-    .about-box ul {
-      margin: 0.8em 0 1.1em 1.2em;
-      padding: 0;
-    }
-
-    .about-box li {
-      margin-bottom: 0.6em;
-    }
-
+    *, *::before, *::after { box-sizing: border-box; }
+    main { max-width: 960px; margin: 0 auto; padding: 0 20px 80px; }
+    .about-box a { color: #ffffff; text-decoration: underline; }
+    .about-box hr { border: none; border-top: 1px solid rgba(255, 255, 255, 0.28); margin: 2.5em auto; max-width: 120px; }
+    .about-box ul { margin: 0.8em 0 1.1em 1.2em; padding: 0; }
+    .about-box li { margin-bottom: 0.6em; }
     @media (min-width: 920px) {
-      main {
-        padding-bottom: 120px;
-      }
-
-      .hero {
-        padding-top: 120px;
-      }
+      main { padding-bottom: 120px; }
     }
   </style>
 </head>
-<body>
-  <div id="site-nav"></div>
-  <script src="js/nav.js?v=1.4.2"></script>
-  <script>
-    fetch('/nav.html?v=1.4.2')
-      .then((response) => response.text())
-      .then((html) => {
-        const host = document.getElementById('site-nav');
-        if (!host) return;
-        host.outerHTML = html;
-        if (typeof window.__initTTGNav === 'function') {
-          window.__initTTGNav();
-        }
-      })
-      .catch((error) => console.error('Failed to load navigation', error));
-  </script>
+<body class="page-background">
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
+        <span class="site-brand__title">The Tank Guide</span>
+        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
+      </a>
+      <nav class="site-links" aria-label="Primary">
+        <a href="index.html" class="nav__link">Home</a>
+        <a href="stocking.html" class="nav__link">Stocking</a>
+        <a href="gear.html" class="nav__link">Gear</a>
+        <a href="params.html" class="nav__link">Cycling Coach</a>
+        <a href="media.html" class="nav__link">Media</a>
+        <a href="about.html" class="nav__link" aria-current="page">About</a>
+      </nav>
+      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
+        <span class="hamburger__bars" aria-hidden="true"></span>
+        <span class="visually-hidden">Open menu</span>
+      </button>
+    </div>
+    <div class="nav-overlay" data-nav="overlay" hidden></div>
+    <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
+      <a href="index.html" class="nav__link">Home</a>
+      <a href="stocking.html" class="nav__link">Stocking</a>
+      <a href="gear.html" class="nav__link">Gear</a>
+      <a href="params.html" class="nav__link">Cycling Coach</a>
+      <a href="media.html" class="nav__link">Media</a>
+      <a href="about.html" class="nav__link" aria-current="page">About</a>
+    </nav>
+  </header>
 
   <main>
-    <section class="hero" aria-labelledby="about-hero-title">
-      <h1 id="about-hero-title">About</h1>
-    </section>
+    <h1 class="about-hero-title">About</h1>
 
-    <section class="about-box" aria-labelledby="about-section-title">
-      <h1 id="about-section-title">About</h1>
-
-      <h3>Owner Story</h3>
+    <section class="about-box" aria-labelledby="about-story">
+      <h2 id="about-story">Owner Story</h2>
       <p>Ever since I was a kid, I was drawn to aquariums. My uncle kept guppies for years, and whenever I visited my grandmother, I’d sit and stare at them. That fascination stuck with me.</p>
       <p>In 2011 or 2012, I caught a marathon of <em>Tanked</em> on Animal Planet. Their massive saltwater builds looked incredible, but freshwater seemed within reach. I decided it was finally time to try again—this time the right way.</p>
       <p>I picked up a 50-gallon kit from a chain store. Tank, stand, hang-on-back filter, gravel, lights—the whole package. After hours of assembling the stand upside down, it broke as I flipped it. I nearly gave up, but I exchanged it and started over.</p>
@@ -155,14 +66,14 @@
 
       <hr />
 
-      <h3>Teaching &amp; Inspiration</h3>
+      <h2>Teaching &amp; Inspiration</h2>
       <p>Outside of aquariums, I’ve also gotten to see the other side of how teachers prepare for their students—especially special education teachers. The sacrifice, patience, and dedication they show left a big impression on me.</p>
       <p>It made me realize that teaching, in any form, is hard work. But it’s also one of the most meaningful things you can do. That spirit drives The Tank Guide. We want every aquarist to feel confident, excited, and empowered to give their fish a healthy home.</p>
       <p>So whether you’re cycling your first tank, fine-tuning a high-tech planted setup, or getting advice before a big upgrade, we’re here to help you every step of the way.</p>
 
       <hr />
 
-      <h3>What’s Next</h3>
+      <h2>What’s Next</h2>
       <p>We’re working on new tooling, more dynamic stocking guidance, and better personalization to match aquarists with the right care plans. Expect more calculators, deeper editorial content, and a growing library of community-driven insights.</p>
       <p>If you’re interested in partnering, sharing feedback, or supporting the project, we’d love to hear from you.</p>
       <ul>
@@ -186,5 +97,6 @@
       })
       .catch((error) => console.error('Failed to load footer', error));
   </script>
+  <script src="js/nav.js?v=1.5.0"></script>
 </body>
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -1,294 +1,18 @@
-/* Updated: Refined nav and drawer styling for translucent overlay, unified spacing, and width rules. */
 :root {
-  --ttg-nav-bg: rgba(10, 16, 30, 0.72);
-  --ttg-nav-text: #f3f6ff;
-  --ttg-nav-link: rgba(243, 246, 255, 0.82);
-  --ttg-nav-overlay: rgba(0, 0, 0, 0.35);
-  --ttg-drawer-bg: rgba(10, 16, 30, 0.88);
-  --ttg-drawer-shadow: 18px 0 36px rgba(5, 12, 22, 0.58);
+  --nav-text: #f3f6ff;
+  --nav-muted: rgba(243, 246, 255, 0.74);
+  --nav-inline-gap: 20px;
 }
 
-#global-nav {
-  position: static;
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
-  color: var(--ttg-nav-text, #eef3ff);
-  background: var(--ttg-nav-bg, rgba(10, 16, 30, 0.72));
-  backdrop-filter: blur(6px) saturate(115%);
-  -webkit-backdrop-filter: blur(6px) saturate(115%);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-  z-index: 9000;
-}
-
-#global-nav a {
-  color: inherit;
-  text-decoration: none;
-}
-
-#global-nav .nav-bar {
-  display: flex;
-  align-items: center;
-  gap: 16px;
-  margin: 0 auto;
-  width: min(100%, 1100px);
-  padding: 16px 20px;
-  padding-block-start: calc(16px + env(safe-area-inset-top));
-  padding-inline-start: calc(20px + env(safe-area-inset-left));
-  padding-inline-end: calc(20px + env(safe-area-inset-right));
-  box-sizing: border-box;
-}
-
-#ttg-nav-open {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 48px;
-  height: 48px;
-  border-radius: 14px;
-  border: none;
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
+html,
+body {
+  margin: 0;
   padding: 0;
-  transition: background 0.2s ease, color 0.2s ease;
 }
 
-#ttg-nav-open:hover,
-#ttg-nav-open:focus-visible {
-  background: rgba(255, 255, 255, 0.16);
-}
-
-#ttg-nav-open .hamburger-bars {
-  position: relative;
-  display: block;
-  width: 20px;
-  height: 2px;
-  border-radius: 2px;
-  background: currentColor;
-}
-
-#ttg-nav-open .hamburger-bars::before,
-#ttg-nav-open .hamburger-bars::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  width: 20px;
-  height: 2px;
-  border-radius: 2px;
-  background: currentColor;
-}
-
-#ttg-nav-open .hamburger-bars::before {
-  top: -6px;
-}
-
-#ttg-nav-open .hamburger-bars::after {
-  top: 6px;
-}
-
-#global-nav .brand {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  justify-content: center;
-  gap: 4px;
-  line-height: 1.15;
-  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.38);
-}
-
-#global-nav .brand-title {
-  font-weight: 800;
-  font-size: 1.12rem;
-}
-
-#global-nav .brand-sub {
-  opacity: 0.9;
-  font-size: 0.9rem;
-  font-weight: 500;
-  letter-spacing: 0.01em;
-}
-
-#global-nav .brand-sub-em {
-  font-weight: 600;
-}
-
-
-#global-nav .links {
-  display: none;
-  align-items: center;
-  gap: 20px;
-  margin-left: auto;
-}
-
-#global-nav .links a {
-  display: inline-flex;
-  align-items: center;
-  padding-block: 10px;
-  color: var(--ttg-nav-link, rgba(243, 246, 255, 0.82));
-  font-size: 0.98rem;
-  font-weight: 500;
-  transition: color 0.2s ease;
-  text-decoration: none;
-  text-underline-offset: 6px;
-}
-
-#global-nav .links a:hover,
-#global-nav .links a:focus-visible {
-  color: #ffffff;
-  text-decoration: underline;
-}
-
-#global-nav .links a[aria-current="page"] {
-  color: #ffffff;
-  font-weight: 600;
-  text-decoration: underline;
-  text-decoration-thickness: 2px;
-}
-
-
-#ttg-overlay {
-  position: fixed;
-  inset: 0;
-  background: var(--ttg-nav-overlay, rgba(0, 0, 0, 0.35));
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.28s ease;
-  z-index: 10010;
-  backdrop-filter: blur(2px);
-  -webkit-backdrop-filter: blur(2px);
-}
-
-#ttg-drawer {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: clamp(280px, 45vw, 360px);
-  height: 100dvh;
-  transform: translateX(-100%);
-  transition: transform 0.32s ease;
-  background: var(--ttg-drawer-bg, rgba(5, 12, 22, 0.86));
-  color: #f8fbff;
-  box-shadow: var(--ttg-drawer-shadow, 16px 0 32px rgba(5, 12, 22, 0.55));
-  display: flex;
-  flex-direction: column;
-  padding: 24px;
-  padding-top: calc(24px + env(safe-area-inset-top));
-  padding-left: calc(24px + env(safe-area-inset-left));
-  padding-right: calc(24px + env(safe-area-inset-right));
-  z-index: 10011;
-  overflow-y: auto;
-  box-sizing: border-box;
-  backdrop-filter: blur(6px) saturate(115%);
-  -webkit-backdrop-filter: blur(6px) saturate(115%);
-}
-
-#ttg-drawer .drawer-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 18px;
-}
-
-#ttg-drawer .drawer-label {
-  margin: 0;
-  font-size: 1rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-}
-
-#ttg-nav-close {
-  width: 40px;
-  height: 40px;
-  border-radius: 12px;
-  border: none;
-  background: rgba(255, 255, 255, 0.16);
-  color: inherit;
-  font-size: 1.5rem;
-  line-height: 1;
-  cursor: pointer;
-  transition: background 0.2s ease;
-  flex-shrink: 0;
-}
-
-#ttg-nav-close:hover,
-#ttg-nav-close:focus-visible {
-  background: rgba(255, 255, 255, 0.26);
-}
-
-#ttg-drawer .drawer {
-  display: flex;
-  flex-direction: column;
-  gap: 28px;
-}
-
-#ttg-drawer .drawer-section {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-#ttg-drawer .drawer-section-label {
-  margin: 0;
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  font-variant: small-caps;
-  color: rgba(243, 246, 255, 0.62);
-}
-
-#ttg-drawer .drawer-links {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-#ttg-drawer .drawer a {
-  display: block;
-  padding-block: 0;
-  color: var(--ttg-nav-link, rgba(243, 246, 255, 0.82));
-  text-decoration: none;
-  font-size: 1rem;
-  line-height: 1.4;
-  font-weight: 500;
-  min-height: 44px;
-  transition: color 0.2s ease;
-}
-
-#ttg-drawer .drawer a:hover,
-#ttg-drawer .drawer a:focus-visible {
-  color: #ffffff;
-  text-decoration: underline;
-  text-decoration-thickness: 2px;
-  text-underline-offset: 6px;
-}
-
-#ttg-drawer .drawer a[aria-current="page"] {
-  color: #ffffff;
-  font-weight: 600;
-  text-decoration: underline;
-  text-decoration-thickness: 2px;
-  text-underline-offset: 6px;
-}
-
-#global-nav[data-open="true"] #ttg-overlay {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-#global-nav[data-open="true"] #ttg-drawer {
-  transform: translateX(0);
-}
-
-#global-nav button:focus-visible,
-#global-nav a:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.65);
-  outline-offset: 4px;
-  border-radius: 12px;
-}
-
-#ttg-drawer .drawer a:focus-visible {
-  outline-offset: 4px;
+body {
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  color: var(--nav-text);
 }
 
 .visually-hidden {
@@ -303,58 +27,229 @@
   border: 0;
 }
 
+.page-background {
+  background:
+    radial-gradient(1200px 800px at 75% -10%, #36c2cc 0%, rgba(54, 194, 204, 0) 60%),
+    radial-gradient(1200px 900px at -10% 120%, #0077c7 0%, rgba(0, 119, 199, 0) 60%),
+    linear-gradient(140deg, #0077c7 0%, #0b6ea6 40%, #0a4d87 100%);
+  min-height: 100vh;
+}
+
+.site-header {
+  position: static;
+  z-index: 1;
+  padding: 18px 20px;
+  background: rgba(10, 16, 30, 0.62);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+}
+
+.site-header__inner {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  margin: 0 auto;
+  width: min(1100px, 100%);
+}
+
+.site-brand {
+  color: inherit;
+  text-decoration: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.35);
+}
+
+.site-brand__title {
+  font-weight: 800;
+  font-size: 1.12rem;
+}
+
+.site-brand__subtitle {
+  font-size: 0.92rem;
+  opacity: 0.85;
+}
+
+.site-brand__em {
+  font-weight: 600;
+}
+
+.hamburger {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  background: rgba(12, 24, 40, 0.4);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.hamburger:hover,
+.hamburger:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.32);
+}
+
+.hamburger__bars {
+  position: relative;
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: currentColor;
+  border-radius: 2px;
+}
+
+.hamburger__bars::before,
+.hamburger__bars::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 20px;
+  height: 2px;
+  background: currentColor;
+  border-radius: 2px;
+}
+
+.hamburger__bars::before {
+  top: -6px;
+}
+
+.hamburger__bars::after {
+  top: 6px;
+}
+
+.site-links {
+  display: none;
+  margin-left: auto;
+  align-items: center;
+  gap: var(--nav-inline-gap);
+}
+
+.nav__link {
+  color: var(--nav-muted);
+  text-decoration: none;
+  font-weight: 500;
+  font-size: 0.98rem;
+  position: relative;
+  padding: 6px 0;
+  transition: color 0.2s ease;
+}
+
+.nav__link:hover,
+.nav__link:focus-visible {
+  color: #ffffff;
+}
+
+.nav__link[aria-current="page"] {
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.nav__link[aria-current="page"]::after {
+  content: "";
+  display: block;
+  height: 2px;
+  margin-top: 6px;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+[data-nav="overlay"] {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 9998;
+}
+
+[data-nav="overlay"].is-open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+[data-nav="drawer"] {
+  position: fixed;
+  top: 0;
+  right: 0;
+  height: 100vh;
+  width: min(84vw, 360px);
+  transform: translateX(100%);
+  transition: transform 0.25s ease;
+  z-index: 9999;
+  backdrop-filter: blur(6px);
+  background: rgba(20, 20, 24, 0.86);
+  border-left: 1px solid rgba(255, 255, 255, 0.12);
+  display: flex;
+  flex-direction: column;
+  padding: 24px;
+  gap: 12px;
+  outline: none;
+}
+
+[data-nav="drawer"].is-open {
+  transform: translateX(0);
+}
+
+[data-nav="drawer"] .nav__link {
+  color: rgba(243, 246, 255, 0.9);
+  font-size: 1.02rem;
+}
+
+[data-nav="drawer"] .nav__link + .nav__link {
+  margin-top: 12px;
+}
+
+html[data-scroll-lock="on"],
+html[data-scroll-lock="on"] body {
+  overflow: hidden;
+}
+
+.about-box {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: clamp(16px, 4vw, 32px);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 14px;
+  color: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(4px);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.about-hero-title {
+  text-align: center;
+  color: #ffffff;
+  margin: 6vh 0 3vh;
+  font-size: clamp(2.4rem, 6vw, 3.6rem);
+  font-weight: 800;
+}
+
 @media (min-width: 920px) {
-  #ttg-nav-open {
+  .hamburger {
     display: none;
   }
 
-  #global-nav .links {
+  .site-links {
     display: flex;
   }
 }
 
-@media (max-width: 919.98px) {
-  #global-nav .links {
-    display: none;
-  }
-}
-
-/* Footer social strip (consistent across pages) */
-#site-footer .follow-strip {
+[data-nav="drawer"] .nav__group {
   display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 12px;
-  padding: 16px 0 10px;
-  font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.85);
+  flex-direction: column;
 }
 
-#site-footer .follow-strip .follow-label {
-  font-weight: 600;
-  margin-right: 6px;
-}
-
-#site-footer .follow-strip .social {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 26px;
-  height: 26px;
-  border-radius: 999px;
-  background: #ffffff;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  color: #0a3a57;
-  transition: background 0.2s ease;
-}
-
-#site-footer .follow-strip .social:hover {
-  background: #f7f7f7;
-}
-
-#site-footer .follow-strip .social svg {
-  width: 16px;
-  height: 16px;
-  display: block;
-  fill: currentColor;
+.site-header a:focus-visible,
+.site-header button:focus-visible,
+[data-nav="drawer"] a:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 4px;
+  border-radius: 12px;
 }

--- a/gear.html
+++ b/gear.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — Gear (Guided)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Build your aquarium setup step by step — tanks, filtration, lighting, and more." />
-  <link rel="stylesheet" href="css/style.css?v=1.4.2" />
+  <link rel="stylesheet" href="css/style.css?v=1.5.0" />
   <link rel="icon" href="/favicon.ico" />
 
   <style>
@@ -30,10 +30,6 @@
       padding:0;
       color:var(--fg);
       font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
-      background:
-        radial-gradient(1200px 800px at 75% -10%, #36c2cc 0%, rgba(54,194,204,0) 60%),
-        radial-gradient(1200px 900px at -10% 120%, #0077c7 0%, rgba(0,119,199,0) 60%),
-        linear-gradient(140deg,#0a3a57 0%, #0b2746 40%, #0b1020 100%);
     }
 
     .wrap{max-width:1100px;margin:0 auto;padding:0 18px;}
@@ -60,24 +56,37 @@
     /* ... rest of your CSS unchanged ... */
   </style>
 </head>
-<body>
+<body class="page-background">
 
-  <!-- Global nav include (shared across pages) -->
-  <div id="site-nav"></div>
-  <script src="js/nav.js?v=1.4.2"></script>
-  <script>
-    fetch('/nav.html?v=1.4.2')
-      .then(response => response.text())
-      .then(html => {
-        const host = document.getElementById('site-nav');
-        if (!host) return;
-        host.outerHTML = html;
-        if (typeof window.__initTTGNav === 'function') {
-          window.__initTTGNav();
-        }
-      })
-      .catch(error => console.error('Failed to load navigation', error));
-  </script>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
+        <span class="site-brand__title">The Tank Guide</span>
+        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
+      </a>
+      <nav class="site-links" aria-label="Primary">
+        <a href="index.html" class="nav__link">Home</a>
+        <a href="stocking.html" class="nav__link">Stocking</a>
+        <a href="gear.html" class="nav__link" aria-current="page">Gear</a>
+        <a href="params.html" class="nav__link">Cycling Coach</a>
+        <a href="media.html" class="nav__link">Media</a>
+        <a href="about.html" class="nav__link">About</a>
+      </nav>
+      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
+        <span class="hamburger__bars" aria-hidden="true"></span>
+        <span class="visually-hidden">Open menu</span>
+      </button>
+    </div>
+    <div class="nav-overlay" data-nav="overlay" hidden></div>
+    <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
+      <a href="index.html" class="nav__link">Home</a>
+      <a href="stocking.html" class="nav__link">Stocking</a>
+      <a href="gear.html" class="nav__link" aria-current="page">Gear</a>
+      <a href="params.html" class="nav__link">Cycling Coach</a>
+      <a href="media.html" class="nav__link">Media</a>
+      <a href="about.html" class="nav__link">About</a>
+    </nav>
+  </header>
 
   <!-- Hero -->
   <section class="hero">
@@ -341,6 +350,7 @@
       });
   </script>
 
+  <script src="js/nav.js?v=1.5.0"></script>
   <script type="module" src="js/gear.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <title>The Tank Guide — A product of FishKeepingLifeCo</title>
   <meta name="description" content="Smart tools and guides to plan, stock, and set up your aquarium — all in one place." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.4.1" />
+  <link rel="stylesheet" href="css/style.css?v=1.5.0" />
 
   <style>
     :root{
@@ -22,7 +22,7 @@
       --link-line: rgba(255,255,255,.22);
     }
     *{box-sizing:border-box}
-    html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
+    html,body{margin:0;padding:0;color:var(--fg);font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
     a{color:inherit;text-decoration:none}
 
     /* Hero gradient */
@@ -80,7 +80,37 @@
     .seo-intro strong{color:var(--fg)}
   </style>
 </head>
-<body>
+<body class="page-background">
+
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
+        <span class="site-brand__title">The Tank Guide</span>
+        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
+      </a>
+      <nav class="site-links" aria-label="Primary">
+        <a href="index.html" class="nav__link" aria-current="page">Home</a>
+        <a href="stocking.html" class="nav__link">Stocking</a>
+        <a href="gear.html" class="nav__link">Gear</a>
+        <a href="params.html" class="nav__link">Cycling Coach</a>
+        <a href="media.html" class="nav__link">Media</a>
+        <a href="about.html" class="nav__link">About</a>
+      </nav>
+      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
+        <span class="hamburger__bars" aria-hidden="true"></span>
+        <span class="visually-hidden">Open menu</span>
+      </button>
+    </div>
+    <div class="nav-overlay" data-nav="overlay" hidden></div>
+    <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
+      <a href="index.html" class="nav__link" aria-current="page">Home</a>
+      <a href="stocking.html" class="nav__link">Stocking</a>
+      <a href="gear.html" class="nav__link">Gear</a>
+      <a href="params.html" class="nav__link">Cycling Coach</a>
+      <a href="media.html" class="nav__link">Media</a>
+      <a href="about.html" class="nav__link">About</a>
+    </nav>
+  </header>
 
   <!-- HERO -->
   <header class="hero">
@@ -147,8 +177,9 @@
       document.getElementById("site-footer").innerHTML = data;
     });
 </script>
-  <!-- Load data and logic with updated version for cache busting -->
-  <script src="js/fish-data.js?v=1.0.3"></script>
-  <script type="module" src="js/modules/app.js?v=1.0.3"></script>
+<script src="js/nav.js?v=1.5.0"></script>
+<!-- Load data and logic with updated version for cache busting -->
+<script src="js/fish-data.js?v=1.0.3"></script>
+<script type="module" src="js/modules/app.js?v=1.0.3"></script>
 </body>
 </html>

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,160 +1,141 @@
-// Updated: Streamlined navigation initialization for consistent drawer behavior, focus handoff, and scroll locking.
 (function () {
-  const OVERLAY_HIDE_DELAY = 320;
-
-  function normalizePath(path) {
-    try {
-      path = new URL(path, window.location.origin).pathname;
-    } catch (error) {
-      path = path || '/';
-    }
-
-    path = path.replace(/index\.html$/i, '');
-    path = path.replace(/\/+$/g, '');
-
-    if (!path) {
-      return '/';
-    }
-
-    return path;
-  }
-
-  function syncActiveLinks(root) {
-    const current = normalizePath(window.location.pathname);
-    const linkNodes = root.querySelectorAll('.links a, #ttg-drawer a');
-
-    linkNodes.forEach((link) => {
-      const target = normalizePath(link.getAttribute('href') || '');
-      if (target === current) {
-        link.setAttribute('aria-current', 'page');
-      } else {
-        link.removeAttribute('aria-current');
-      }
-    });
-  }
-
-  window.__initTTGNav = function __initTTGNav() {
-    const root = document.getElementById('global-nav');
-    if (!root || root.dataset.ttgNavReady === 'true') {
-      return;
-    }
-
-    const overlay = root.querySelector('#ttg-overlay');
-    const drawer = root.querySelector('#ttg-drawer');
-    const openBtn = root.querySelector('#ttg-nav-open');
-    const closeBtn = root.querySelector('#ttg-nav-close');
-    const body = document.body;
-    let previousFocus = null;
-    let overlayHideTimer = null;
-    let scrollPosition = 0;
-    const prevBodyStyles = {
-      position: '',
-      top: '',
-      width: '',
-      left: '',
-      right: '',
-      overflow: '',
-    };
-
-    if (!overlay || !drawer || !openBtn) {
-      return;
-    }
-
-    root.dataset.ttgNavReady = 'true';
-    openBtn.setAttribute('aria-expanded', 'false');
-    drawer.setAttribute('aria-hidden', 'true');
-    overlay.hidden = true;
-
-    function lockBodyScroll() {
-      scrollPosition = window.scrollY || window.pageYOffset || 0;
-      prevBodyStyles.position = body.style.position || '';
-      prevBodyStyles.top = body.style.top || '';
-      prevBodyStyles.left = body.style.left || '';
-      prevBodyStyles.right = body.style.right || '';
-      prevBodyStyles.width = body.style.width || '';
-      prevBodyStyles.overflow = body.style.overflow || '';
-      body.style.position = 'fixed';
-      body.style.top = `-${scrollPosition}px`;
-      body.style.left = '0';
-      body.style.right = '0';
-      body.style.width = '100%';
-      body.style.overflow = 'hidden';
-    }
-
-    function unlockBodyScroll() {
-      body.style.position = prevBodyStyles.position;
-      body.style.top = prevBodyStyles.top;
-      body.style.left = prevBodyStyles.left;
-      body.style.right = prevBodyStyles.right;
-      body.style.width = prevBodyStyles.width;
-      body.style.overflow = prevBodyStyles.overflow;
-      window.scrollTo(0, scrollPosition);
-    }
-
-    function openDrawer() {
-      if (root.dataset.open === 'true') return;
-      window.clearTimeout(overlayHideTimer);
-      overlay.hidden = false;
-      previousFocus = document.activeElement;
-      root.dataset.open = 'true';
-      drawer.setAttribute('aria-hidden', 'false');
-      openBtn.setAttribute('aria-expanded', 'true');
-      lockBodyScroll();
-      window.requestAnimationFrame(() => {
-        const target = drawer.querySelector('.drawer a') || drawer;
-        if (typeof target.focus === 'function') {
-          target.focus({ preventScroll: true });
-        }
-      });
-    }
-
-    function closeDrawer(options = {}) {
-      if (root.dataset.open !== 'true') return;
-      const { returnFocus = true } = options;
-      root.dataset.open = 'false';
-      drawer.setAttribute('aria-hidden', 'true');
-      openBtn.setAttribute('aria-expanded', 'false');
-      unlockBodyScroll();
-      overlayHideTimer = window.setTimeout(() => {
-        if (root.dataset.open !== 'true') {
-          overlay.hidden = true;
-        }
-      }, OVERLAY_HIDE_DELAY);
-      if (returnFocus && previousFocus) {
-        window.requestAnimationFrame(() => {
-          if (typeof previousFocus.focus === 'function') {
-            previousFocus.focus();
-          } else {
-            openBtn.focus();
-          }
-        });
-      }
-      previousFocus = null;
-    }
-
-    openBtn.addEventListener('click', openDrawer);
-    if (closeBtn) {
-      closeBtn.addEventListener('click', () => closeDrawer());
-    }
-    overlay.addEventListener('click', () => closeDrawer());
-    drawer.addEventListener('click', (event) => {
-      const link = event.target.closest('a');
-      if (link) {
-        closeDrawer({ returnFocus: false });
-      }
-    });
-
-    document.addEventListener('keydown', (event) => {
-      if (root.dataset.open === 'true' && event.key === 'Escape') {
-        event.preventDefault();
-        closeDrawer();
-        return;
-      }
-    });
-
-    syncActiveLinks(root);
-    window.addEventListener('popstate', () => syncActiveLinks(root));
-    window.addEventListener('hashchange', () => syncActiveLinks(root));
-    window.addEventListener('pageshow', () => syncActiveLinks(root));
+  const btn = document.querySelector('[data-nav="hamburger"]');
+  const drawer = document.querySelector('[data-nav="drawer"]');
+  const overlay = document.querySelector('[data-nav="overlay"]');
+  const links = drawer ? drawer.querySelectorAll('a, button') : [];
+  const html = document.documentElement;
+  const body = document.body;
+  let previousFocus = null;
+  let overlayHideTimer = null;
+  const previousBodyStyles = {
+    overflow: '',
+    position: '',
   };
+
+  if (!btn || !drawer || !overlay) {
+    return;
+  }
+
+  const focusables = () => Array.from(links).filter((el) => !el.hasAttribute('disabled'));
+
+  function showOverlay() {
+    window.clearTimeout(overlayHideTimer);
+    overlay.hidden = false;
+    overlay.classList.add('is-open');
+  }
+
+  function hideOverlay() {
+    overlay.classList.remove('is-open');
+    overlayHideTimer = window.setTimeout(() => {
+      if (!drawer.classList.contains('is-open')) {
+        overlay.hidden = true;
+      }
+    }, 200);
+  }
+
+  function openDrawer() {
+    if (drawer.classList.contains('is-open')) {
+      return;
+    }
+
+    previousBodyStyles.overflow = body.style.overflow;
+    previousBodyStyles.position = body.style.position;
+
+    showOverlay();
+    drawer.classList.add('is-open');
+    btn.setAttribute('aria-expanded', 'true');
+    html.setAttribute('data-scroll-lock', 'on');
+    body.style.overflow = 'hidden';
+    if (!previousBodyStyles.position) {
+      body.style.position = 'relative';
+    }
+
+    previousFocus = document.activeElement;
+
+    const [firstFocusable] = focusables();
+    window.requestAnimationFrame(() => {
+      if (firstFocusable && typeof firstFocusable.focus === 'function') {
+        firstFocusable.focus({ preventScroll: true });
+      } else if (typeof drawer.focus === 'function') {
+        drawer.focus({ preventScroll: true });
+      }
+    });
+  }
+
+  function closeDrawer() {
+    if (!drawer.classList.contains('is-open')) {
+      return;
+    }
+
+    hideOverlay();
+    drawer.classList.remove('is-open');
+    btn.setAttribute('aria-expanded', 'false');
+    html.removeAttribute('data-scroll-lock');
+    body.style.overflow = previousBodyStyles.overflow;
+    body.style.position = previousBodyStyles.position;
+
+    const focusTarget = previousFocus && typeof previousFocus.focus === 'function' ? previousFocus : btn;
+    previousFocus = null;
+    window.requestAnimationFrame(() => {
+      focusTarget.focus({ preventScroll: true });
+    });
+  }
+
+  function toggleDrawer() {
+    if (drawer.classList.contains('is-open')) {
+      closeDrawer();
+    } else {
+      openDrawer();
+    }
+  }
+
+  btn.addEventListener('click', (event) => {
+    event.preventDefault();
+    toggleDrawer();
+  });
+
+  overlay.addEventListener('click', () => {
+    closeDrawer();
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && drawer.classList.contains('is-open')) {
+      event.preventDefault();
+      closeDrawer();
+    }
+  });
+
+  drawer.addEventListener('click', (event) => {
+    const link = event.target.closest('a');
+    if (link) {
+      closeDrawer();
+    }
+  });
+
+  drawer.addEventListener('keydown', (event) => {
+    if (event.key !== 'Tab' || !drawer.classList.contains('is-open')) {
+      return;
+    }
+
+    const focusableItems = focusables();
+    if (focusableItems.length === 0) {
+      event.preventDefault();
+      drawer.focus({ preventScroll: true });
+      return;
+    }
+
+    const first = focusableItems[0];
+    const last = focusableItems[focusableItems.length - 1];
+    const active = document.activeElement;
+
+    if (event.shiftKey) {
+      if (active === first || active === drawer) {
+        event.preventDefault();
+        last.focus({ preventScroll: true });
+      }
+    } else if (active === last) {
+      event.preventDefault();
+      first.focus({ preventScroll: true });
+    }
+  });
 })();

--- a/media.html
+++ b/media.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — Media Hub</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Media Hub — Watch • Read • Explore. Aquarium videos and blogs for every aquarist." />
-  <link rel="stylesheet" href="css/style.css?v=1.4.2" />
+  <link rel="stylesheet" href="css/style.css?v=1.5.0" />
   <link rel="icon" href="/favicon.ico" />
   <meta property="og:title" content="The Tank Guide — Media Hub" />
   <meta property="og:description" content="Watch • Read • Explore — videos and blogs for every aquarist." />
@@ -28,10 +28,6 @@
     html,body{
       margin:0; padding:0;
       color:#eef3ff;
-      background:
-        radial-gradient(1200px 800px at 75% -10%, #36c2cc 0%, rgba(54,194,204,0.0) 60%),
-        radial-gradient(1200px 900px at -10% 120%, #0077c7 0%, rgba(0,119,199,0.0) 60%),
-        linear-gradient(140deg,#0077c7 0%, #0b6ea6 40%, #0a4d87 100%);
     }
 
     .wrap { max-width: 1100px; margin: 0 auto; padding: 0 18px; }
@@ -171,24 +167,37 @@
 
   </style>
 </head>
-<body>
+<body class="page-background">
 
-  <!-- Global nav include -->
-  <div id="site-nav"></div>
-  <script src="js/nav.js?v=1.4.2"></script>
-  <script>
-    fetch('/nav.html?v=1.4.2')
-      .then(response => response.text())
-      .then(html => {
-        const host = document.getElementById('site-nav');
-        if (!host) return;
-        host.outerHTML = html;
-        if (typeof window.__initTTGNav === 'function') {
-          window.__initTTGNav();
-        }
-      })
-      .catch(error => console.error('Failed to load navigation', error));
-  </script>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
+        <span class="site-brand__title">The Tank Guide</span>
+        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
+      </a>
+      <nav class="site-links" aria-label="Primary">
+        <a href="index.html" class="nav__link">Home</a>
+        <a href="stocking.html" class="nav__link">Stocking</a>
+        <a href="gear.html" class="nav__link">Gear</a>
+        <a href="params.html" class="nav__link">Cycling Coach</a>
+        <a href="media.html" class="nav__link" aria-current="page">Media</a>
+        <a href="about.html" class="nav__link">About</a>
+      </nav>
+      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
+        <span class="hamburger__bars" aria-hidden="true"></span>
+        <span class="visually-hidden">Open menu</span>
+      </button>
+    </div>
+    <div class="nav-overlay" data-nav="overlay" hidden></div>
+    <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
+      <a href="index.html" class="nav__link">Home</a>
+      <a href="stocking.html" class="nav__link">Stocking</a>
+      <a href="gear.html" class="nav__link">Gear</a>
+      <a href="params.html" class="nav__link">Cycling Coach</a>
+      <a href="media.html" class="nav__link" aria-current="page">Media</a>
+      <a href="about.html" class="nav__link">About</a>
+    </nav>
+  </header>
 
   <!-- Hero -->
   <section class="hero">
@@ -268,7 +277,7 @@
     </section>
   </main>
 
-  <!-- Footer -->
+<!-- Footer -->
 <footer id="site-footer"></footer>
 <script>
   fetch("footer.html")
@@ -277,8 +286,9 @@
       document.getElementById("site-footer").innerHTML = data;
     });
 </script>
-  <!-- Load data and logic with updated version for cache busting -->
-  <script src="js/fish-data.js?v=1.0.3"></script>
-  <script type="module" src="js/modules/app.js?v=1.0.3"></script>
+<script src="js/nav.js?v=1.5.0"></script>
+<!-- Load data and logic with updated version for cache busting -->
+<script src="js/fish-data.js?v=1.0.3"></script>
+<script type="module" src="js/modules/app.js?v=1.0.3"></script>
 </body>
 </html>

--- a/nav.html
+++ b/nav.html
@@ -1,64 +1,29 @@
-<!-- Updated: Restructured navigation markup to unify drawer grouping, overlay behavior, and translucent styling across subpages. -->
-<header id="global-nav" data-open="false">
-  <div class="nav-bar">
-    <button id="ttg-nav-open" type="button" aria-label="Open menu" aria-haspopup="dialog" aria-controls="ttg-drawer" aria-expanded="false">
-      <span class="hamburger-bars" aria-hidden="true"></span>
+<header class="site-header">
+  <div class="site-header__inner">
+    <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
+      <span class="site-brand__title">The Tank Guide</span>
+      <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
+    </a>
+    <nav class="site-links" aria-label="Primary">
+      <a href="index.html" class="nav__link">Home</a>
+      <a href="stocking.html" class="nav__link">Stocking</a>
+      <a href="gear.html" class="nav__link">Gear</a>
+      <a href="params.html" class="nav__link">Cycling Coach</a>
+      <a href="media.html" class="nav__link">Media</a>
+      <a href="about.html" class="nav__link">About</a>
+    </nav>
+    <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
+      <span class="hamburger__bars" aria-hidden="true"></span>
       <span class="visually-hidden">Open menu</span>
     </button>
-
-    <a class="brand" href="/index.html" aria-label="The Tank Guide — Home">
-      <span class="brand-title">The Tank Guide</span>
-      <span class="brand-sub">a product of <span class="brand-sub-em">FishKeepingLifeCo</span></span>
-    </a>
-
-    <nav class="links" aria-label="Primary">
-      <a href="/index.html">Home</a>
-      <a href="/stocking.html">Stocking Advisor</a>
-      <a href="/gear.html">Gear</a>
-      <a href="/params.html">Cycling Coach</a>
-      <a href="/media.html">Media</a>
-      <a href="/about.html">About</a>
-      <a href="/feedback.html">Feedback</a>
-    </nav>
   </div>
-
-  <div id="ttg-overlay" hidden></div>
-
-  <aside id="ttg-drawer" role="dialog" aria-modal="true" aria-label="Primary navigation" aria-hidden="true" tabindex="-1">
-    <div class="drawer-header">
-      <p class="drawer-label">Menu</p>
-      <button id="ttg-nav-close" type="button" aria-label="Close menu">
-        <span aria-hidden="true">×</span>
-      </button>
-    </div>
-    <nav class="drawer" aria-label="Primary navigation">
-      <div class="drawer-section" role="group" aria-labelledby="drawer-group-start">
-        <p class="drawer-section-label" id="drawer-group-start">Start Here</p>
-        <div class="drawer-links">
-          <a href="/index.html">Home</a>
-          <a href="/stocking.html">Stocking Advisor</a>
-        </div>
-      </div>
-      <div class="drawer-section" role="group" aria-labelledby="drawer-group-tools">
-        <p class="drawer-section-label" id="drawer-group-tools">Tools</p>
-        <div class="drawer-links">
-          <a href="/gear.html">Gear</a>
-          <a href="/params.html">Cycling Coach</a>
-        </div>
-      </div>
-      <div class="drawer-section" role="group" aria-labelledby="drawer-group-explore">
-        <p class="drawer-section-label" id="drawer-group-explore">Explore</p>
-        <div class="drawer-links">
-          <a href="/media.html">Media</a>
-        </div>
-      </div>
-      <div class="drawer-section" role="group" aria-labelledby="drawer-group-support">
-        <p class="drawer-section-label" id="drawer-group-support">About &amp; Support</p>
-        <div class="drawer-links">
-          <a href="/about.html">About</a>
-          <a href="/feedback.html">Feedback</a>
-        </div>
-      </div>
-    </nav>
-  </aside>
+  <div class="nav-overlay" data-nav="overlay" hidden></div>
+  <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
+    <a href="index.html" class="nav__link">Home</a>
+    <a href="stocking.html" class="nav__link">Stocking</a>
+    <a href="gear.html" class="nav__link">Gear</a>
+    <a href="params.html" class="nav__link">Cycling Coach</a>
+    <a href="media.html" class="nav__link">Media</a>
+    <a href="about.html" class="nav__link">About</a>
+  </nav>
 </header>

--- a/params.html
+++ b/params.html
@@ -7,7 +7,7 @@
   <title>Cycling Coach — The Tank Guide</title>
   <meta name="description" content="Cycling Coach is under construction — coming soon to help you master the nitrogen cycle." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.4.2" />
+  <link rel="stylesheet" href="css/style.css?v=1.5.0" />
 
   <style>
     :root{
@@ -23,7 +23,7 @@
       --ttg-nav-link: rgba(243, 247, 255, 0.85);
     }
     *{box-sizing:border-box}
-    html,body{margin:0;padding:0;background:var(--bg);color:var(--fg);font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
+    html,body{margin:0;padding:0;color:var(--fg);font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
     a{color:inherit;text-decoration:none}
 
     /* Hero (now solid dark gradient, no cyan highlights) */
@@ -54,24 +54,37 @@
 
   </style>
 </head>
-<body>
+<body class="page-background">
 
-  <!-- Global nav include (shared across pages) -->
-  <div id="site-nav"></div>
-  <script src="js/nav.js?v=1.4.2"></script>
-  <script>
-    fetch('/nav.html?v=1.4.2')
-      .then(response => response.text())
-      .then(html => {
-        const host = document.getElementById('site-nav');
-        if (!host) return;
-        host.outerHTML = html;
-        if (typeof window.__initTTGNav === 'function') {
-          window.__initTTGNav();
-        }
-      })
-      .catch(error => console.error('Failed to load navigation', error));
-  </script>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
+        <span class="site-brand__title">The Tank Guide</span>
+        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
+      </a>
+      <nav class="site-links" aria-label="Primary">
+        <a href="index.html" class="nav__link">Home</a>
+        <a href="stocking.html" class="nav__link">Stocking</a>
+        <a href="gear.html" class="nav__link">Gear</a>
+        <a href="params.html" class="nav__link" aria-current="page">Cycling Coach</a>
+        <a href="media.html" class="nav__link">Media</a>
+        <a href="about.html" class="nav__link">About</a>
+      </nav>
+      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
+        <span class="hamburger__bars" aria-hidden="true"></span>
+        <span class="visually-hidden">Open menu</span>
+      </button>
+    </div>
+    <div class="nav-overlay" data-nav="overlay" hidden></div>
+    <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
+      <a href="index.html" class="nav__link">Home</a>
+      <a href="stocking.html" class="nav__link">Stocking</a>
+      <a href="gear.html" class="nav__link">Gear</a>
+      <a href="params.html" class="nav__link" aria-current="page">Cycling Coach</a>
+      <a href="media.html" class="nav__link">Media</a>
+      <a href="about.html" class="nav__link">About</a>
+    </nav>
+  </header>
 
   <!-- HERO Placeholder -->
   <section class="hero">
@@ -98,6 +111,7 @@
       .then(r => r.text())
       .then(html => { document.getElementById('site-footer').innerHTML = html; });
   </script>
+  <script src="js/nav.js?v=1.5.0"></script>
 
 </body>
 </html>

--- a/stocking.html
+++ b/stocking.html
@@ -6,7 +6,7 @@
   <title>FishkeepingLifeCo — Stocking Calculator</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Global nav / shared styles (same versioning as Media) -->
-  <link rel="stylesheet" href="css/style.css?v=1.4.2" />
+  <link rel="stylesheet" href="css/style.css?v=1.5.0" />
   <!-- Page styles -->
   <link rel="stylesheet" href="css/Style.css?v=1.0.3" />
   <style>
@@ -16,24 +16,37 @@
     }
   </style>
 </head>
-<body>
+<body class="page-background">
 
-  <!-- Global nav include (same pattern as Media) -->
-  <div id="site-nav"></div>
-  <script src="js/nav.js?v=1.4.2"></script>
-  <script>
-    fetch('/nav.html?v=1.4.2')
-      .then(response => response.text())
-      .then(html => {
-        const host = document.getElementById('site-nav');
-        if (!host) return;
-        host.outerHTML = html;
-        if (typeof window.__initTTGNav === 'function') {
-          window.__initTTGNav();
-        }
-      })
-      .catch(error => console.error('Failed to load navigation', error));
-  </script>
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
+        <span class="site-brand__title">The Tank Guide</span>
+        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
+      </a>
+      <nav class="site-links" aria-label="Primary">
+        <a href="index.html" class="nav__link">Home</a>
+        <a href="stocking.html" class="nav__link" aria-current="page">Stocking</a>
+        <a href="gear.html" class="nav__link">Gear</a>
+        <a href="params.html" class="nav__link">Cycling Coach</a>
+        <a href="media.html" class="nav__link">Media</a>
+        <a href="about.html" class="nav__link">About</a>
+      </nav>
+      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
+        <span class="hamburger__bars" aria-hidden="true"></span>
+        <span class="visually-hidden">Open menu</span>
+      </button>
+    </div>
+    <div class="nav-overlay" data-nav="overlay" hidden></div>
+    <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
+      <a href="index.html" class="nav__link">Home</a>
+      <a href="stocking.html" class="nav__link" aria-current="page">Stocking</a>
+      <a href="gear.html" class="nav__link">Gear</a>
+      <a href="params.html" class="nav__link">Cycling Coach</a>
+      <a href="media.html" class="nav__link">Media</a>
+      <a href="about.html" class="nav__link">About</a>
+    </nav>
+  </header>
 
   <div class="wrap">
     <!-- Tank Setup -->
@@ -156,9 +169,10 @@
         .then(response => response.text())
         .then(data => { document.getElementById("site-footer").innerHTML = data; });
     </script>
-    <!-- Load data and logic with updated version for cache busting -->
-    <script src="js/fish-data.js?v=1.0.3"></script>
-    <script type="module" src="js/modules/app.js?v=1.0.3"></script>
   </div>
+  <script src="js/nav.js?v=1.5.0"></script>
+  <!-- Load data and logic with updated version for cache busting -->
+  <script src="js/fish-data.js?v=1.0.3"></script>
+  <script type="module" src="js/modules/app.js?v=1.0.3"></script>
 </body>
 </html>

--- a/tests/gear.spec.ts
+++ b/tests/gear.spec.ts
@@ -2,7 +2,8 @@ import { test, expect } from '@playwright/test';
 import * as http from 'http';
 import { readFile } from 'fs/promises';
 import { statSync } from 'fs';
-import * as path from 'path';
+import { dirname, extname, join, normalize, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
 const mimeTypes: Record<string, string> = {
   '.html': 'text/html; charset=utf-8',
@@ -14,26 +15,28 @@ const mimeTypes: Record<string, string> = {
   '.txt': 'text/plain; charset=utf-8',
 };
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
 let baseURL = '';
 let server: http.Server;
 
 test.beforeAll(async () => {
-  const root = path.resolve(__dirname, '..');
+  const root = resolve(__dirname, '..');
   server = http.createServer(async (req, res) => {
     try {
       const requestUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
       let filePath = requestUrl.pathname;
       if (filePath.endsWith('/')) {
-        filePath = path.join(filePath, 'index.html');
+        filePath = join(filePath, 'index.html');
       }
       if (filePath === '/' || filePath === '') {
         filePath = '/index.html';
       }
-      const normalised = path
-        .normalize(filePath)
+      const normalised = normalize(filePath)
         .replace(/^([/\\])+/u, '')
         .replace(/^\.\.(?:[/\\]|$)/gu, '');
-      const diskPath = path.join(root, normalised);
+      const diskPath = join(root, normalised);
       let fileStat: ReturnType<typeof statSync> | undefined;
       try {
         fileStat = statSync(diskPath);
@@ -46,7 +49,7 @@ test.beforeAll(async () => {
         return;
       }
       const data = await readFile(diskPath);
-      const contentType = mimeTypes[path.extname(diskPath).toLowerCase()] ?? 'application/octet-stream';
+      const contentType = mimeTypes[extname(diskPath).toLowerCase()] ?? 'application/octet-stream';
       res.setHeader('Content-Type', contentType);
       res.end(data);
     } catch (error) {

--- a/tests/nav.spec.ts
+++ b/tests/nav.spec.ts
@@ -1,0 +1,166 @@
+import { test, expect } from '@playwright/test';
+import * as http from 'http';
+import { readFile } from 'fs/promises';
+import { statSync } from 'fs';
+import { dirname, extname, join, normalize, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const mimeTypes: Record<string, string> = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+let baseURL = '';
+let server: http.Server;
+
+async function startServer() {
+  const root = resolve(__dirname, '..');
+  server = http.createServer(async (req, res) => {
+    try {
+      const requestUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
+      let filePath = requestUrl.pathname;
+      if (filePath.endsWith('/')) {
+        filePath = join(filePath, 'index.html');
+      }
+      if (filePath === '/' || filePath === '') {
+        filePath = '/index.html';
+      }
+      const normalised = normalize(filePath)
+        .replace(/^([/\\])+/u, '')
+        .replace(/^\.\.(?:[/\\]|$)/gu, '');
+      const diskPath = join(root, normalised);
+      let stats: ReturnType<typeof statSync> | undefined;
+      try {
+        stats = statSync(diskPath);
+      } catch {
+        stats = undefined;
+      }
+      if (!stats || stats.isDirectory()) {
+        res.statusCode = 404;
+        res.end('Not found');
+        return;
+      }
+      const data = await readFile(diskPath);
+      const contentType = mimeTypes[extname(diskPath).toLowerCase()] ?? 'application/octet-stream';
+      res.setHeader('Content-Type', contentType);
+      res.end(data);
+    } catch (error) {
+      res.statusCode = 500;
+      res.end(String(error));
+    }
+  });
+
+  await new Promise<void>((resolveServer) => server.listen(0, '127.0.0.1', resolveServer));
+  const address = server.address();
+  if (address && typeof address === 'object') {
+    baseURL = `http://127.0.0.1:${address.port}`;
+  } else {
+    throw new Error('Failed to start static server');
+  }
+}
+
+async function stopServer() {
+  await new Promise<void>((resolveServer) => server.close(() => resolveServer()));
+}
+
+test.beforeAll(async () => {
+  await startServer();
+});
+
+test.afterAll(async () => {
+  await stopServer();
+});
+
+async function gotoAbout(page) {
+  const errors: string[] = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      errors.push(message.text());
+    }
+  });
+  await page.goto(`${baseURL}/about.html`);
+  return errors;
+}
+
+test('drawer opens on hamburger click and locks scroll', async ({ page }) => {
+  const errors = await gotoAbout(page);
+  await expect(errors).toEqual([]);
+
+  const hamburger = page.locator('[data-nav="hamburger"]');
+  const drawer = page.locator('[data-nav="drawer"]');
+  const overlay = page.locator('[data-nav="overlay"]');
+
+  await hamburger.click();
+  await expect(drawer).toHaveClass(/is-open/);
+  await expect(overlay).toHaveClass(/is-open/);
+
+  await expect(page.locator('html')).toHaveAttribute('data-scroll-lock', 'on');
+  const bodyOverflow = await page.evaluate(() => document.body.style.overflow);
+  expect(bodyOverflow).toBe('hidden');
+});
+
+test('overlay click closes the drawer', async ({ page }) => {
+  await gotoAbout(page);
+  const hamburger = page.locator('[data-nav="hamburger"]');
+  const drawer = page.locator('[data-nav="drawer"]');
+  const overlay = page.locator('[data-nav="overlay"]');
+
+  await hamburger.click();
+  await expect(drawer).toHaveClass(/is-open/);
+  await overlay.click();
+  await expect(drawer).not.toHaveClass(/is-open/);
+  await expect(page.locator('html')).not.toHaveAttribute('data-scroll-lock', 'on');
+});
+
+test('escape key closes the drawer and restores focus', async ({ page }) => {
+  await gotoAbout(page);
+  const hamburger = page.locator('[data-nav="hamburger"]');
+  const drawer = page.locator('[data-nav="drawer"]');
+
+  await hamburger.click();
+  await expect(drawer).toHaveClass(/is-open/);
+
+  await page.keyboard.press('Escape');
+  await expect(drawer).not.toHaveClass(/is-open/);
+  await page.waitForFunction(() => document.activeElement?.dataset.nav === 'hamburger');
+  const expanded = await hamburger.getAttribute('aria-expanded');
+  expect(expanded).toBe('false');
+});
+
+test('About link is marked active inline and in the drawer', async ({ page }) => {
+  await gotoAbout(page);
+  const inlineActive = page.locator('.site-links .nav__link[aria-current="page"]');
+  await expect(inlineActive).toHaveText('About');
+
+  await page.locator('[data-nav="hamburger"]').click();
+  const drawerActive = page.locator('[data-nav="drawer"] .nav__link[aria-current="page"]');
+  await expect(drawerActive).toHaveText('About');
+});
+
+test('nav layers sit above main content', async ({ page }) => {
+  await gotoAbout(page);
+  await page.locator('[data-nav="hamburger"]').click();
+
+  const { overlayZ, drawerZ } = await page.evaluate(() => {
+    const overlayEl = document.querySelector('[data-nav="overlay"]');
+    const drawerEl = document.querySelector('[data-nav="drawer"]');
+    const overlayStyle = overlayEl ? window.getComputedStyle(overlayEl).zIndex : '0';
+    const drawerStyle = drawerEl ? window.getComputedStyle(drawerEl).zIndex : '0';
+    return {
+      overlayZ: Number(overlayStyle || '0'),
+      drawerZ: Number(drawerStyle || '0'),
+    };
+  });
+
+  expect(overlayZ).toBeGreaterThanOrEqual(9998);
+  expect(drawerZ).toBeGreaterThan(overlayZ);
+});


### PR DESCRIPTION
## Summary
- replace the legacy nav include with a shared header markup and a new nav.js that manages overlay state, focus trapping, and scroll locking
- update the global styles so the drawer, overlay, backgrounds, and About page presentation stay consistent across every page
- fix the Playwright gear spec path usage and add a dedicated nav spec that exercises drawer open/close behaviour and active link state

## Testing
- npm test *(fails: Playwright browsers unavailable in the restricted environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d46c71fffc8332b1e4a727c93fd28c