### PR TITLE
Fix navigation drawer behavior and unify footers

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — About</title>
   <meta name="description" content="Learn about The Tank Guide mission, story, and future vision." />
   <link rel="icon" href="/favicon.ico" />
-  <link rel="stylesheet" href="css/style.css?v=1.5.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     main { max-width: 960px; margin: 0 auto; padding: 0 20px 80px; }
@@ -18,37 +18,23 @@
       main { padding-bottom: 120px; }
     }
   </style>
+  <script defer src="js/nav.js?v=1.0.7"></script>
 </head>
 <body class="page-background">
-  <header class="site-header">
-    <div class="site-header__inner">
-      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
-        <span class="site-brand__title">The Tank Guide</span>
-        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
-      </a>
-      <nav class="site-links" aria-label="Primary">
-        <a href="index.html" class="nav__link">Home</a>
-        <a href="stocking.html" class="nav__link">Stocking</a>
-        <a href="gear.html" class="nav__link">Gear</a>
-        <a href="params.html" class="nav__link">Cycling Coach</a>
-        <a href="media.html" class="nav__link">Media</a>
-        <a href="about.html" class="nav__link" aria-current="page">About</a>
-      </nav>
-      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
-        <span class="hamburger__bars" aria-hidden="true"></span>
-        <span class="visually-hidden">Open menu</span>
-      </button>
-    </div>
-    <div class="nav-overlay" data-nav="overlay" hidden></div>
-    <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
-      <a href="index.html" class="nav__link">Home</a>
-      <a href="stocking.html" class="nav__link">Stocking</a>
-      <a href="gear.html" class="nav__link">Gear</a>
-      <a href="params.html" class="nav__link">Cycling Coach</a>
-      <a href="media.html" class="nav__link">Media</a>
-      <a href="about.html" class="nav__link" aria-current="page">About</a>
-    </nav>
-  </header>
+  <div id="global-nav"></div>
+  <script>
+    fetch('nav.html?v=1.0.7')
+      .then(response => response.text())
+      .then(html => {
+        const mount = document.getElementById('global-nav');
+        if (mount) {
+          mount.outerHTML = html;
+          if (window.initTTGNav) {
+            window.initTTGNav();
+          }
+        }
+      });
+  </script>
 
   <main>
     <h1 class="about-hero-title">About</h1>
@@ -77,7 +63,7 @@
       <p>We’re working on new tooling, more dynamic stocking guidance, and better personalization to match aquarists with the right care plans. Expect more calculators, deeper editorial content, and a growing library of community-driven insights.</p>
       <p>If you’re interested in partnering, sharing feedback, or supporting the project, we’d love to hear from you.</p>
       <ul>
-        <li>Have an idea to improve the experience? <a href="/feedback.html">Send feedback</a>.</li>
+        <li>Have an idea to improve the experience? <a href="https://thetankguide.com/feedback" target="_blank" rel="noopener">Send feedback</a>.</li>
         <li>Curious about updates? Follow along on social or bookmark this page.</li>
         <li>Want to collaborate? Reach out—we’re building this for the community.</li>
       </ul>
@@ -85,18 +71,16 @@
     </section>
   </main>
 
-  <footer id="site-footer"></footer>
+  <div id="site-footer"></div>
   <script>
-    fetch('footer.html')
-      .then((response) => response.text())
-      .then((data) => {
+    fetch('footer.html?v=1.0.7')
+      .then(response => response.text())
+      .then(html => {
         const footer = document.getElementById('site-footer');
         if (footer) {
-          footer.innerHTML = data;
+          footer.outerHTML = html;
         }
-      })
-      .catch((error) => console.error('Failed to load footer', error));
+      });
   </script>
-  <script src="js/nav.js?v=1.5.0"></script>
 </body>
 </html>

--- a/css/Style.css
+++ b/css/Style.css
@@ -165,7 +165,7 @@ td.empty-cell{ background:rgba(255,255,255,.05); border:1px dashed var(--line); 
 }
 
 .follow-strip a svg {
-  width: 16px;   /* control final size */
-  height: 16px;
+  width: 24px;   /* control final size */
+  height: 24px;
   fill: currentColor; /* use text color */
 }

--- a/css/style.css
+++ b/css/style.css
@@ -2,6 +2,7 @@
   --nav-text: #f3f6ff;
   --nav-muted: rgba(243, 246, 255, 0.74);
   --nav-inline-gap: 20px;
+  --global-nav-height: 76px;
 }
 
 html,
@@ -27,7 +28,8 @@ body {
   border: 0;
 }
 
-.page-background {
+.page-background,
+.theme-dark {
   background:
     radial-gradient(1200px 800px at 75% -10%, #36c2cc 0%, rgba(54, 194, 204, 0) 60%),
     radial-gradient(1200px 900px at -10% 120%, #0077c7 0%, rgba(0, 119, 199, 0) 60%),
@@ -35,11 +37,21 @@ body {
   min-height: 100vh;
 }
 
+#global-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+}
+
+.global-nav-spacer {
+  height: var(--global-nav-height);
+}
+
 .site-header {
-  position: static;
-  z-index: 1;
-  padding: 18px 20px;
-  background: rgba(10, 16, 30, 0.62);
+  padding: 16px 20px;
+  background: rgba(10, 16, 24, 0.28);
   border-bottom: 1px solid rgba(255, 255, 255, 0.12);
   backdrop-filter: blur(6px);
   -webkit-backdrop-filter: blur(6px);
@@ -48,7 +60,7 @@ body {
 .site-header__inner {
   display: flex;
   align-items: center;
-  gap: 20px;
+  gap: 18px;
   margin: 0 auto;
   width: min(1100px, 100%);
 }
@@ -60,6 +72,7 @@ body {
   flex-direction: column;
   gap: 2px;
   text-shadow: 0 1px 8px rgba(0, 0, 0, 0.35);
+  min-width: 0;
 }
 
 .site-brand__title {
@@ -77,7 +90,6 @@ body {
 }
 
 .hamburger {
-  margin-left: auto;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -85,10 +97,11 @@ body {
   height: 48px;
   border-radius: 14px;
   border: 1px solid rgba(255, 255, 255, 0.16);
-  background: rgba(12, 24, 40, 0.4);
+  background: rgba(12, 24, 40, 0.42);
   color: inherit;
   cursor: pointer;
   transition: background 0.2s ease, border-color 0.2s ease;
+  flex-shrink: 0;
 }
 
 .hamburger:hover,
@@ -127,9 +140,24 @@ body {
 
 .site-links {
   display: none;
-  margin-left: auto;
   align-items: center;
   gap: var(--nav-inline-gap);
+  margin-left: auto;
+}
+
+.site-header--home .site-header__inner {
+  flex-wrap: wrap;
+}
+
+.site-header--home .site-links {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.site-header--home .site-links .nav__link {
+  padding: 6px 10px;
 }
 
 .nav__link {
@@ -160,56 +188,114 @@ body {
   background: rgba(255, 255, 255, 0.9);
 }
 
-[data-nav="overlay"] {
+#ttg-overlay {
   position: fixed;
   inset: 0;
+  display: none;
   background: rgba(0, 0, 0, 0.45);
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s ease;
-  z-index: 9998;
+  backdrop-filter: saturate(120%) blur(2px);
+  z-index: 10000;
 }
 
-[data-nav="overlay"].is-open {
-  opacity: 1;
-  pointer-events: auto;
-}
-
-[data-nav="drawer"] {
+#ttg-drawer {
   position: fixed;
   top: 0;
-  right: 0;
+  left: 0;
   height: 100vh;
-  width: min(84vw, 360px);
-  transform: translateX(100%);
-  transition: transform 0.25s ease;
-  z-index: 9999;
-  backdrop-filter: blur(6px);
-  background: rgba(20, 20, 24, 0.86);
-  border-left: 1px solid rgba(255, 255, 255, 0.12);
-  display: flex;
-  flex-direction: column;
-  padding: 24px;
-  gap: 12px;
-  outline: none;
+  width: 45vw;
+  max-width: 22rem;
+  transform: translateX(-100%);
+  transition: transform 0.24s ease-out;
+  z-index: 10001;
 }
 
-[data-nav="drawer"].is-open {
+#global-nav[data-open="true"] #ttg-overlay {
+  display: block;
+}
+
+#global-nav[data-open="true"] #ttg-drawer {
   transform: translateX(0);
 }
 
-[data-nav="drawer"] .nav__link {
-  color: rgba(243, 246, 255, 0.9);
-  font-size: 1.02rem;
+.drawer {
+  background: rgba(12, 18, 32, 0.92);
+  color: #f1f4ff;
+  border-right: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  flex-direction: column;
+  padding: 12px 0 28px;
+  backdrop-filter: blur(8px);
 }
 
-[data-nav="drawer"] .nav__link + .nav__link {
-  margin-top: 12px;
+.drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 20px 4px;
 }
 
-html[data-scroll-lock="on"],
-html[data-scroll-lock="on"] body {
-  overflow: hidden;
+.drawer__title {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.drawer-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(18, 24, 38, 0.7);
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.5rem;
+  line-height: 1;
+}
+
+.drawer-close:hover,
+.drawer-close:focus-visible {
+  background: rgba(255, 255, 255, 0.15);
+  border-color: rgba(255, 255, 255, 0.35);
+}
+
+.drawer-links {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+}
+
+.drawer a {
+  display: block;
+  padding: 16px 20px;
+  line-height: 1.25;
+  text-decoration: none;
+  color: inherit;
+}
+
+.drawer h2,
+.drawer h3 {
+  display: none;
+}
+
+.site-header a:focus-visible,
+.site-header button:focus-visible,
+.drawer a:focus-visible,
+.drawer button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.65);
+  outline-offset: 4px;
+  border-radius: 12px;
+}
+
+@media (min-width: 920px) {
+  .hamburger {
+    display: none;
+  }
+
+  .site-links {
+    display: flex;
+  }
 }
 
 .about-box {
@@ -231,25 +317,8 @@ html[data-scroll-lock="on"] body {
   font-weight: 800;
 }
 
-@media (min-width: 920px) {
-  .hamburger {
-    display: none;
-  }
-
-  .site-links {
-    display: flex;
-  }
-}
-
-[data-nav="drawer"] .nav__group {
-  display: flex;
-  flex-direction: column;
-}
-
-.site-header a:focus-visible,
-.site-header button:focus-visible,
-[data-nav="drawer"] a:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.65);
-  outline-offset: 4px;
-  border-radius: 12px;
+.follow-strip .social svg {
+  width: 24px;
+  height: 24px;
+  display: block;
 }

--- a/gear.html
+++ b/gear.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — Gear (Guided)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Build your aquarium setup step by step — tanks, filtration, lighting, and more." />
-  <link rel="stylesheet" href="css/style.css?v=1.5.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
   <link rel="icon" href="/favicon.ico" />
 
   <style>
@@ -55,38 +55,24 @@
     .muted{color:var(--muted);}
     /* ... rest of your CSS unchanged ... */
   </style>
+  <script defer src="js/nav.js?v=1.0.7"></script>
 </head>
-<body class="page-background">
+<body class="page-background theme-dark">
 
-  <header class="site-header">
-    <div class="site-header__inner">
-      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
-        <span class="site-brand__title">The Tank Guide</span>
-        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
-      </a>
-      <nav class="site-links" aria-label="Primary">
-        <a href="index.html" class="nav__link">Home</a>
-        <a href="stocking.html" class="nav__link">Stocking</a>
-        <a href="gear.html" class="nav__link" aria-current="page">Gear</a>
-        <a href="params.html" class="nav__link">Cycling Coach</a>
-        <a href="media.html" class="nav__link">Media</a>
-        <a href="about.html" class="nav__link">About</a>
-      </nav>
-      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
-        <span class="hamburger__bars" aria-hidden="true"></span>
-        <span class="visually-hidden">Open menu</span>
-      </button>
-    </div>
-    <div class="nav-overlay" data-nav="overlay" hidden></div>
-    <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
-      <a href="index.html" class="nav__link">Home</a>
-      <a href="stocking.html" class="nav__link">Stocking</a>
-      <a href="gear.html" class="nav__link" aria-current="page">Gear</a>
-      <a href="params.html" class="nav__link">Cycling Coach</a>
-      <a href="media.html" class="nav__link">Media</a>
-      <a href="about.html" class="nav__link">About</a>
-    </nav>
-  </header>
+  <div id="global-nav"></div>
+  <script>
+    fetch('nav.html?v=1.0.7')
+      .then(response => response.text())
+      .then(html => {
+        const mount = document.getElementById('global-nav');
+        if (mount) {
+          mount.outerHTML = html;
+          if (window.initTTGNav) {
+            window.initTTGNav();
+          }
+        }
+      });
+  </script>
 
   <!-- Hero -->
   <section class="hero">
@@ -335,22 +321,18 @@
 
   <div id="gear-error" class="warning" role="alert" hidden></div>
 
-  <!-- Footer include -->
-  <footer id="site-footer"></footer>
+  <div id="site-footer"></div>
   <script>
-    fetch("footer.html")
+    fetch('footer.html?v=1.0.7')
       .then(response => response.text())
       .then(html => {
-        const host = document.getElementById("site-footer");
-        if (host) host.innerHTML = html;
-      })
-      .catch(() => {
-        const diag = (window.__gearDiag = window.__gearDiag || { scriptsLoaded: true, dataLoaded: false, errors: [] });
-        diag.errors.push("footer_fetch_failed");
+        const footer = document.getElementById('site-footer');
+        if (footer) {
+          footer.outerHTML = html;
+        }
       });
   </script>
 
-  <script src="js/nav.js?v=1.5.0"></script>
   <script type="module" src="js/gear.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <title>The Tank Guide — A product of FishKeepingLifeCo</title>
   <meta name="description" content="Smart tools and guides to plan, stock, and set up your aquarium — all in one place." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.5.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
 
   <style>
     :root{
@@ -82,7 +82,7 @@
 </head>
 <body class="page-background">
 
-  <header class="site-header">
+  <header class="site-header site-header--home">
     <div class="site-header__inner">
       <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
         <span class="site-brand__title">The Tank Guide</span>
@@ -90,26 +90,14 @@
       </a>
       <nav class="site-links" aria-label="Primary">
         <a href="index.html" class="nav__link" aria-current="page">Home</a>
-        <a href="stocking.html" class="nav__link">Stocking</a>
+        <a href="stocking.html" class="nav__link">Stocking Advisor</a>
         <a href="gear.html" class="nav__link">Gear</a>
         <a href="params.html" class="nav__link">Cycling Coach</a>
         <a href="media.html" class="nav__link">Media</a>
         <a href="about.html" class="nav__link">About</a>
+        <a href="https://thetankguide.com/feedback" class="nav__link" target="_blank" rel="noopener">Feedback</a>
       </nav>
-      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
-        <span class="hamburger__bars" aria-hidden="true"></span>
-        <span class="visually-hidden">Open menu</span>
-      </button>
     </div>
-    <div class="nav-overlay" data-nav="overlay" hidden></div>
-    <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
-      <a href="index.html" class="nav__link" aria-current="page">Home</a>
-      <a href="stocking.html" class="nav__link">Stocking</a>
-      <a href="gear.html" class="nav__link">Gear</a>
-      <a href="params.html" class="nav__link">Cycling Coach</a>
-      <a href="media.html" class="nav__link">Media</a>
-      <a href="about.html" class="nav__link">About</a>
-    </nav>
   </header>
 
   <!-- HERO -->
@@ -168,16 +156,17 @@
   </div>
 </section>
 
-<!-- Footer -->
-<footer id="site-footer"></footer>
+<div id="site-footer"></div>
 <script>
-  fetch("footer.html")
+  fetch('footer.html?v=1.0.7')
     .then(response => response.text())
-    .then(data => {
-      document.getElementById("site-footer").innerHTML = data;
+    .then(html => {
+      const footer = document.getElementById('site-footer');
+      if (footer) {
+        footer.outerHTML = html;
+      }
     });
 </script>
-<script src="js/nav.js?v=1.5.0"></script>
 <!-- Load data and logic with updated version for cache busting -->
 <script src="js/fish-data.js?v=1.0.3"></script>
 <script type="module" src="js/modules/app.js?v=1.0.3"></script>

--- a/media.html
+++ b/media.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — Media Hub</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Media Hub — Watch • Read • Explore. Aquarium videos and blogs for every aquarist." />
-  <link rel="stylesheet" href="css/style.css?v=1.5.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
   <link rel="icon" href="/favicon.ico" />
   <meta property="og:title" content="The Tank Guide — Media Hub" />
   <meta property="og:description" content="Watch • Read • Explore — videos and blogs for every aquarist." />
@@ -166,38 +166,24 @@
     }
 
   </style>
+  <script defer src="js/nav.js?v=1.0.7"></script>
 </head>
 <body class="page-background">
 
-  <header class="site-header">
-    <div class="site-header__inner">
-      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
-        <span class="site-brand__title">The Tank Guide</span>
-        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
-      </a>
-      <nav class="site-links" aria-label="Primary">
-        <a href="index.html" class="nav__link">Home</a>
-        <a href="stocking.html" class="nav__link">Stocking</a>
-        <a href="gear.html" class="nav__link">Gear</a>
-        <a href="params.html" class="nav__link">Cycling Coach</a>
-        <a href="media.html" class="nav__link" aria-current="page">Media</a>
-        <a href="about.html" class="nav__link">About</a>
-      </nav>
-      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
-        <span class="hamburger__bars" aria-hidden="true"></span>
-        <span class="visually-hidden">Open menu</span>
-      </button>
-    </div>
-    <div class="nav-overlay" data-nav="overlay" hidden></div>
-    <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
-      <a href="index.html" class="nav__link">Home</a>
-      <a href="stocking.html" class="nav__link">Stocking</a>
-      <a href="gear.html" class="nav__link">Gear</a>
-      <a href="params.html" class="nav__link">Cycling Coach</a>
-      <a href="media.html" class="nav__link" aria-current="page">Media</a>
-      <a href="about.html" class="nav__link">About</a>
-    </nav>
-  </header>
+  <div id="global-nav"></div>
+  <script>
+    fetch('nav.html?v=1.0.7')
+      .then(response => response.text())
+      .then(html => {
+        const mount = document.getElementById('global-nav');
+        if (mount) {
+          mount.outerHTML = html;
+          if (window.initTTGNav) {
+            window.initTTGNav();
+          }
+        }
+      });
+  </script>
 
   <!-- Hero -->
   <section class="hero">
@@ -277,16 +263,17 @@
     </section>
   </main>
 
-<!-- Footer -->
-<footer id="site-footer"></footer>
+<div id="site-footer"></div>
 <script>
-  fetch("footer.html")
+  fetch('footer.html?v=1.0.7')
     .then(response => response.text())
-    .then(data => {
-      document.getElementById("site-footer").innerHTML = data;
+    .then(html => {
+      const footer = document.getElementById('site-footer');
+      if (footer) {
+        footer.outerHTML = html;
+      }
     });
 </script>
-<script src="js/nav.js?v=1.5.0"></script>
 <!-- Load data and logic with updated version for cache busting -->
 <script src="js/fish-data.js?v=1.0.3"></script>
 <script type="module" src="js/modules/app.js?v=1.0.3"></script>

--- a/nav.html
+++ b/nav.html
@@ -1,29 +1,40 @@
-<header class="site-header">
+<header id="global-nav" class="site-header">
   <div class="site-header__inner">
+    <button id="ttg-nav-open" class="hamburger" type="button" aria-controls="ttg-drawer" aria-expanded="false" aria-label="Open menu">
+      <span class="hamburger__bars" aria-hidden="true"></span>
+      <span class="visually-hidden">Open menu</span>
+    </button>
     <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
       <span class="site-brand__title">The Tank Guide</span>
       <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
     </a>
     <nav class="site-links" aria-label="Primary">
       <a href="index.html" class="nav__link">Home</a>
-      <a href="stocking.html" class="nav__link">Stocking</a>
+      <a href="stocking.html" class="nav__link">Stocking Advisor</a>
       <a href="gear.html" class="nav__link">Gear</a>
       <a href="params.html" class="nav__link">Cycling Coach</a>
       <a href="media.html" class="nav__link">Media</a>
       <a href="about.html" class="nav__link">About</a>
+      <a href="https://thetankguide.com/feedback" class="nav__link" target="_blank" rel="noopener">Feedback</a>
     </nav>
-    <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
-      <span class="hamburger__bars" aria-hidden="true"></span>
-      <span class="visually-hidden">Open menu</span>
-    </button>
   </div>
-  <div class="nav-overlay" data-nav="overlay" hidden></div>
-  <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
-    <a href="index.html" class="nav__link">Home</a>
-    <a href="stocking.html" class="nav__link">Stocking</a>
-    <a href="gear.html" class="nav__link">Gear</a>
-    <a href="params.html" class="nav__link">Cycling Coach</a>
-    <a href="media.html" class="nav__link">Media</a>
-    <a href="about.html" class="nav__link">About</a>
+  <div id="ttg-overlay" aria-hidden="true"></div>
+  <nav id="ttg-drawer" class="drawer" aria-label="Site">
+    <div class="drawer__header">
+      <span class="drawer__title">The Tank Guide</span>
+      <button id="ttg-nav-close" class="drawer-close" type="button" aria-label="Close menu">
+        <span aria-hidden="true">×</span>
+      </button>
+    </div>
+    <ul class="drawer-links">
+      <li><a href="index.html" class="nav__link">Home</a></li>
+      <li><a href="stocking.html" class="nav__link">Stocking Advisor</a></li>
+      <li><a href="gear.html" class="nav__link">Gear</a></li>
+      <li><a href="params.html" class="nav__link">Cycling Coach</a></li>
+      <li><a href="media.html" class="nav__link">Media</a></li>
+      <li><a href="about.html" class="nav__link">About</a></li>
+      <li><a href="https://thetankguide.com/feedback" class="nav__link" target="_blank" rel="noopener">Feedback</a></li>
+    </ul>
   </nav>
 </header>
+<div class="global-nav-spacer" aria-hidden="true"></div>

--- a/params.html
+++ b/params.html
@@ -7,7 +7,7 @@
   <title>Cycling Coach — The Tank Guide</title>
   <meta name="description" content="Cycling Coach is under construction — coming soon to help you master the nitrogen cycle." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.5.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
 
   <style>
     :root{
@@ -53,38 +53,24 @@
     #site-footer{border-top:1px solid var(--line); margin-top:40px;}
 
   </style>
+  <script defer src="js/nav.js?v=1.0.7"></script>
 </head>
-<body class="page-background">
+<body class="page-background theme-dark">
 
-  <header class="site-header">
-    <div class="site-header__inner">
-      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
-        <span class="site-brand__title">The Tank Guide</span>
-        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
-      </a>
-      <nav class="site-links" aria-label="Primary">
-        <a href="index.html" class="nav__link">Home</a>
-        <a href="stocking.html" class="nav__link">Stocking</a>
-        <a href="gear.html" class="nav__link">Gear</a>
-        <a href="params.html" class="nav__link" aria-current="page">Cycling Coach</a>
-        <a href="media.html" class="nav__link">Media</a>
-        <a href="about.html" class="nav__link">About</a>
-      </nav>
-      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
-        <span class="hamburger__bars" aria-hidden="true"></span>
-        <span class="visually-hidden">Open menu</span>
-      </button>
-    </div>
-    <div class="nav-overlay" data-nav="overlay" hidden></div>
-    <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
-      <a href="index.html" class="nav__link">Home</a>
-      <a href="stocking.html" class="nav__link">Stocking</a>
-      <a href="gear.html" class="nav__link">Gear</a>
-      <a href="params.html" class="nav__link" aria-current="page">Cycling Coach</a>
-      <a href="media.html" class="nav__link">Media</a>
-      <a href="about.html" class="nav__link">About</a>
-    </nav>
-  </header>
+  <div id="global-nav"></div>
+  <script>
+    fetch('nav.html?v=1.0.7')
+      .then(response => response.text())
+      .then(html => {
+        const mount = document.getElementById('global-nav');
+        if (mount) {
+          mount.outerHTML = html;
+          if (window.initTTGNav) {
+            window.initTTGNav();
+          }
+        }
+      });
+  </script>
 
   <!-- HERO Placeholder -->
   <section class="hero">
@@ -104,14 +90,17 @@
     </div>
   </section>
 
-  <!-- FOOTER include -->
-  <footer id="site-footer"></footer>
+  <div id="site-footer"></div>
   <script>
-    fetch('/footer.html')
-      .then(r => r.text())
-      .then(html => { document.getElementById('site-footer').innerHTML = html; });
+    fetch('footer.html?v=1.0.7')
+      .then(response => response.text())
+      .then(html => {
+        const footer = document.getElementById('site-footer');
+        if (footer) {
+          footer.outerHTML = html;
+        }
+      });
   </script>
-  <script src="js/nav.js?v=1.5.0"></script>
 
 </body>
 </html>

--- a/stocking.html
+++ b/stocking.html
@@ -6,7 +6,7 @@
   <title>FishkeepingLifeCo — Stocking Calculator</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <!-- Global nav / shared styles (same versioning as Media) -->
-  <link rel="stylesheet" href="css/style.css?v=1.5.0" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
   <!-- Page styles -->
   <link rel="stylesheet" href="css/Style.css?v=1.0.3" />
   <style>
@@ -15,38 +15,24 @@
       --ttg-nav-link: rgba(243, 247, 255, 0.85);
     }
   </style>
+  <script defer src="js/nav.js?v=1.0.7"></script>
 </head>
-<body class="page-background">
+<body class="page-background theme-dark">
 
-  <header class="site-header">
-    <div class="site-header__inner">
-      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
-        <span class="site-brand__title">The Tank Guide</span>
-        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
-      </a>
-      <nav class="site-links" aria-label="Primary">
-        <a href="index.html" class="nav__link">Home</a>
-        <a href="stocking.html" class="nav__link" aria-current="page">Stocking</a>
-        <a href="gear.html" class="nav__link">Gear</a>
-        <a href="params.html" class="nav__link">Cycling Coach</a>
-        <a href="media.html" class="nav__link">Media</a>
-        <a href="about.html" class="nav__link">About</a>
-      </nav>
-      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
-        <span class="hamburger__bars" aria-hidden="true"></span>
-        <span class="visually-hidden">Open menu</span>
-      </button>
-    </div>
-    <div class="nav-overlay" data-nav="overlay" hidden></div>
-    <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site" tabindex="-1">
-      <a href="index.html" class="nav__link">Home</a>
-      <a href="stocking.html" class="nav__link" aria-current="page">Stocking</a>
-      <a href="gear.html" class="nav__link">Gear</a>
-      <a href="params.html" class="nav__link">Cycling Coach</a>
-      <a href="media.html" class="nav__link">Media</a>
-      <a href="about.html" class="nav__link">About</a>
-    </nav>
-  </header>
+  <div id="global-nav"></div>
+  <script>
+    fetch('nav.html?v=1.0.7')
+      .then(response => response.text())
+      .then(html => {
+        const mount = document.getElementById('global-nav');
+        if (mount) {
+          mount.outerHTML = html;
+          if (window.initTTGNav) {
+            window.initTTGNav();
+          }
+        }
+      });
+  </script>
 
   <div class="wrap">
     <!-- Tank Setup -->
@@ -162,15 +148,18 @@
       </div>
     </section>
 
-    <!-- Footer -->
-    <footer id="site-footer"></footer>
+    <div id="site-footer"></div>
     <script>
-      fetch("footer.html")
+      fetch('footer.html?v=1.0.7')
         .then(response => response.text())
-        .then(data => { document.getElementById("site-footer").innerHTML = data; });
+        .then(html => {
+          const footer = document.getElementById('site-footer');
+          if (footer) {
+            footer.outerHTML = html;
+          }
+        });
     </script>
   </div>
-  <script src="js/nav.js?v=1.5.0"></script>
   <!-- Load data and logic with updated version for cache busting -->
   <script src="js/fish-data.js?v=1.0.3"></script>
   <script type="module" src="js/modules/app.js?v=1.0.3"></script>


### PR DESCRIPTION
## Summary
- refactor the shared navigation include so the hamburger opens a left-side drawer above the overlay with uniform link layout and new feedback link
- update nav.js and global styles to handle drawer toggling, active-link detection, and restore dark themes plus a static home header without a drawer
- standardize footer includes and social icon sizing across all pages while reapplying the dark gradient on Stocking, Gear, and Cycling Coach

## Testing
- `npm test` *(fails: playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d473959c2083328d47467218da4ba0