### PR TITLE
fix(nav): force hamburger to left via markup order + flex ordering; remove right-alignment overrides; no behavior/theme changes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -60,7 +60,21 @@ header.site-header {
   width: min(1100px, 100%);
 }
 
-.site-header__inner > .hamburger {
+#global-nav .site-header__inner {
+  display: flex;
+  align-items: center;
+}
+
+#global-nav #ttg-nav-open {
+  order: 0;
+}
+
+#global-nav .site-brand {
+  order: 1;
+}
+
+#global-nav .site-links {
+  order: 2;
   margin-left: auto;
 }
 


### PR DESCRIPTION
## Summary
- enforce a canonical flex order for the global nav so the hamburger button always renders first
- remove the previous right-alignment rule on the hamburger and let the desktop links take the auto margin instead

## Testing
- not run (static changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d4837c0d1883329d162f84ca7f0809