### PR TITLE
fix: align drawer hamburger to the left

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -60,20 +60,23 @@ header.site-header {
   width: min(1100px, 100%);
 }
 
-#global-nav .site-header__inner {
+#global-nav .inner {
   display: flex;
-  align-items: left;
+  align-items: center;
 }
 
 #global-nav #ttg-nav-open {
   order: 0;
+  margin: 0;
+  left: auto;
+  right: auto;
 }
 
-#global-nav .site-brand {
+#global-nav .brand {
   order: 1;
 }
 
-#global-nav .site-links {
+#global-nav .links {
   order: 2;
   margin-left: auto;
 }

--- a/nav.html
+++ b/nav.html
@@ -1,14 +1,14 @@
 <header id="global-nav" class="site-header">
-  <div class="site-header__inner">
+  <div class="site-header__inner inner">
     <button id="ttg-nav-open" class="hamburger" type="button" aria-controls="ttg-drawer" aria-expanded="false" aria-label="Open menu">
       <span class="hamburger__bars" aria-hidden="true"></span>
       <span class="visually-hidden">Open menu</span>
     </button>
-    <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
+    <a class="site-brand brand" href="index.html" aria-label="The Tank Guide — Home">
       <span class="site-brand__title">The Tank Guide</span>
       <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
     </a>
-    <nav class="site-links" aria-label="Primary">
+    <nav class="site-links links" aria-label="Primary">
       <a href="index.html" class="nav__link">Home</a>
       <a href="stocking.html" class="nav__link">Stocking Advisor</a>
       <a href="gear.html" class="nav__link">Gear</a>


### PR DESCRIPTION
## Summary
- add shared helper classes in the nav markup so the hamburger precedes the brand and links in the DOM
- update the global nav flex alignment and ordering styles to keep the hamburger pinned to the left across breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d486d71dc88332a8e403408122bf69