### PR TITLE
Fix Stocking page styles, left hamburger, uniform drawer, and shared footer

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — About</title>
   <meta name="description" content="Learn about The Tank Guide mission, story, and future vision." />
   <link rel="icon" href="/favicon.ico" />
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     main { max-width: 960px; margin: 0 auto; padding: 0 20px 80px; }
@@ -18,30 +18,10 @@
       main { padding-bottom: 120px; }
     }
   </style>
-  <script defer src="js/nav.js?v=1.1.0"></script>
+  <script defer src="js/nav.js?v=1.0.7"></script>
 </head>
-<body class="page-background">
-  <header class="site-header">
-    <div class="site-header__inner">
-      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
-        <span class="site-brand__title">The Tank Guide</span>
-        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
-      </a>
-      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
-        <span class="hamburger__bars" aria-hidden="true"></span>
-        <span class="visually-hidden">Menu</span>
-      </button>
-    </div>
-  </header>
-  <div class="nav-overlay" data-nav="overlay"></div>
-  <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site">
-    <a href="index.html" class="nav__link">Home</a>
-    <a href="stocking.html" class="nav__link">Stocking Advisor</a>
-    <a href="gear.html" class="nav__link">Gear</a>
-    <a href="params.html" class="nav__link">Cycling Coach</a>
-    <a href="media.html" class="nav__link">Media</a>
-    <a href="about.html" class="nav__link" aria-current="page">About</a>
-  </nav>
+<body class="theme-light">
+  <div id="site-nav"></div>
 
   <main>
     <h1 class="about-hero-title">About</h1>
@@ -83,8 +63,8 @@
     (async () => {
       const host = document.getElementById('site-footer');
       if (!host) return;
-      const res = await fetch('footer.html', { cache: 'no-cache' });
-      host.innerHTML = await res.text();
+      const res = await fetch('footer.html?v=1.0.7', { cache: 'no-cache' });
+      host.outerHTML = await res.text();
     })();
   </script>
 </body>

--- a/css/style.css
+++ b/css/style.css
@@ -30,6 +30,21 @@ body {
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
 }
 
+body.theme-dark {
+  --page-bg: radial-gradient(140% 100% at 0% 0%, #091421 0%, #0b1b2b 45%, #0a0f18 100%);
+  background: var(--page-bg);
+  color: #eef3ff;
+  min-height: 100vh;
+  background-attachment: fixed;
+}
+
+body.theme-light {
+  --page-bg: radial-gradient(140% 100% at 0% 0%, #0e5e8b 0%, #1477a8 45%, #1a8fc2 100%);
+  background: var(--page-bg);
+  color: #eef3ff;
+  min-height: 100vh;
+}
+
 .visually-hidden {
   position: absolute;
   width: 1px;
@@ -58,42 +73,86 @@ body {
   background-attachment: fixed;
 }
 
-header.site-header {
-  position: static;
-  padding: 16px 20px;
-  background: rgba(10, 16, 24, 0.28);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
-  backdrop-filter: blur(6px);
-  -webkit-backdrop-filter: blur(6px);
-}
-
-.site-header__inner {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  margin: 0 auto;
-  width: min(1100px, 100%);
+#global-nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10000;
+  background: rgba(10, 14, 22, 0.35);
+  backdrop-filter: saturate(1.4) blur(6px);
+  -webkit-backdrop-filter: saturate(1.4) blur(6px);
+  color: var(--nav-text);
 }
 
 #global-nav .inner {
   display: flex;
   align-items: center;
+  gap: 12px;
+  height: 64px;
+  margin: 0 auto;
+  padding: 0 20px;
+  width: min(1100px, 100%);
 }
 
 #global-nav #ttg-nav-open {
   order: 0;
   margin: 0;
-  left: auto;
-  right: auto;
+  flex-shrink: 0;
 }
 
 #global-nav .brand {
   order: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  color: inherit;
+  text-decoration: none;
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.35);
 }
 
 #global-nav .links {
   order: 2;
   margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--nav-inline-gap);
+}
+
+#global-nav .links .nav__link {
+  color: var(--nav-muted);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 10px 0;
+  position: relative;
+}
+
+#global-nav .links .nav__link:hover,
+#global-nav .links .nav__link:focus-visible {
+  color: #ffffff;
+}
+
+#global-nav .links .nav__link[aria-current="page"] {
+  color: #ffffff;
+}
+
+#global-nav .links .nav__link[aria-current="page"]::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 6px;
+  height: 2px;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 999px;
+}
+
+@media (max-width: 920px) {
+  #global-nav .links {
+    display: none;
+  }
 }
 
 .site-brand {
@@ -102,8 +161,8 @@ header.site-header {
   display: flex;
   flex-direction: column;
   gap: 2px;
-  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.35);
   min-width: 0;
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.35);
 }
 
 .site-brand__title {
@@ -169,85 +228,113 @@ header.site-header {
   top: 6px;
 }
 
-[data-nav="overlay"] {
+#global-nav #ttg-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.45);
-  opacity: 0;
+  background: rgba(0, 0, 0, 0.35);
+  z-index: 10001;
+  display: none;
   pointer-events: none;
-  transition: opacity 0.2s ease;
-  z-index: 9998;
 }
 
-[data-nav="overlay"].is-open {
-  opacity: 1;
+#global-nav[data-open="true"] #ttg-overlay,
+#global-nav #ttg-overlay.is-open {
+  display: block;
   pointer-events: auto;
 }
 
-[data-nav="drawer"] {
+#global-nav #ttg-drawer {
   position: fixed;
-  top: 0;
-  right: 0;
-  height: 100vh;
-  width: min(84vw, 360px);
-  transform: translateX(100%);
+  inset: 0 auto 0 0;
+  width: min(45vw, 420px);
+  max-width: 420px;
+  transform: translateX(-100%);
   transition: transform 0.25s ease;
-  background: rgba(16, 18, 24, 0.9);
-  backdrop-filter: blur(6px);
-  border-left: 1px solid rgba(255, 255, 255, 0.15);
-  z-index: 9999;
+  background: rgba(10, 14, 22, 0.82);
+  backdrop-filter: saturate(1.2) blur(6px);
+  -webkit-backdrop-filter: saturate(1.2) blur(6px);
+  z-index: 10002;
   display: flex;
   flex-direction: column;
-  padding: 32px 24px;
-  gap: 12px;
+  color: var(--nav-text);
+  min-height: 100vh;
 }
 
-[data-nav="drawer"].is-open {
+#global-nav[data-open="true"] #ttg-drawer,
+#global-nav #ttg-drawer.is-open {
   transform: translateX(0);
 }
 
-.nav__link {
-  color: var(--nav-muted);
-  text-decoration: none;
-  font-weight: 500;
-  font-size: 1rem;
-  position: relative;
-  display: inline-block;
-  padding: 6px 0;
-  transition: color 0.2s ease;
+#global-nav #ttg-drawer .drawer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 22px 12px;
 }
 
-[data-nav="drawer"] .nav__link {
-  display: block;
-  font-size: 1.05rem;
-  padding: 10px 0;
+#global-nav #ttg-drawer .drawer-title {
+  font-size: 1.12rem;
+  font-weight: 700;
 }
 
-.nav__link:hover,
-.nav__link:focus-visible {
-  color: #ffffff;
-}
-
-.nav__link[aria-current="page"] {
-  color: #ffffff;
-  font-weight: 600;
-}
-
-.nav__link[aria-current="page"]::after {
-  content: "";
-  display: block;
-  height: 2px;
-  margin-top: 6px;
-  background: rgba(255, 255, 255, 0.9);
-}
-
-header.site-header a:focus-visible,
-header.site-header button:focus-visible,
-[data-nav="drawer"] a:focus-visible,
-[data-nav="drawer"] button:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.65);
-  outline-offset: 4px;
+#global-nav #ttg-drawer .drawer-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
   border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+#global-nav #ttg-drawer .drawer-close:hover,
+#global-nav #ttg-drawer .drawer-close:focus-visible {
+  background: rgba(255, 255, 255, 0.16);
+  border-color: rgba(255, 255, 255, 0.32);
+}
+
+#global-nav #ttg-drawer .drawer-links {
+  display: flex;
+  flex-direction: column;
+  padding: 12px 0 24px;
+  overflow-y: auto;
+}
+
+#global-nav #ttg-drawer .drawer-links .nav__link {
+  display: block;
+  padding: 16px 22px;
+  line-height: 1.25;
+  font-size: 1.05rem;
+  color: rgba(243, 246, 255, 0.85);
+  text-decoration: none;
+  border-radius: 12px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+#global-nav #ttg-drawer .drawer-links .nav__link:hover,
+#global-nav #ttg-drawer .drawer-links .nav__link:focus-visible {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+#global-nav #ttg-drawer .drawer-links .nav__link[aria-current="page"] {
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.18);
+}
+
+#global-nav a:focus-visible,
+#global-nav button:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.55);
+  outline-offset: 3px;
+  border-radius: 12px;
+}
+
+.global-nav-spacer {
+  height: 64px;
 }
 
 html[data-scroll-lock="on"],
@@ -275,8 +362,8 @@ html[data-scroll-lock="on"] body {
 }
 
 .follow-strip .social svg {
-  width: 24px;
-  height: 24px;
+  width: 1.25rem;
+  height: 1.25rem;
   display: block;
 }
 

--- a/gear.html
+++ b/gear.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — Gear (Guided)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Build your aquarium setup step by step — tanks, filtration, lighting, and more." />
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
   <link rel="icon" href="/favicon.ico" />
 
   <style>
@@ -55,31 +55,10 @@
     .muted{color:var(--muted);}
     /* ... rest of your CSS unchanged ... */
   </style>
-  <script defer src="js/nav.js?v=1.1.0"></script>
+  <script defer src="js/nav.js?v=1.0.7"></script>
 </head>
-<body class="page-background bg--dark">
-
-  <header class="site-header">
-    <div class="site-header__inner">
-      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
-        <span class="site-brand__title">The Tank Guide</span>
-        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
-      </a>
-      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
-        <span class="hamburger__bars" aria-hidden="true"></span>
-        <span class="visually-hidden">Menu</span>
-      </button>
-    </div>
-  </header>
-  <div class="nav-overlay" data-nav="overlay"></div>
-  <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site">
-    <a href="index.html" class="nav__link">Home</a>
-    <a href="stocking.html" class="nav__link">Stocking Advisor</a>
-    <a href="gear.html" class="nav__link" aria-current="page">Gear</a>
-    <a href="params.html" class="nav__link">Cycling Coach</a>
-    <a href="media.html" class="nav__link">Media</a>
-    <a href="about.html" class="nav__link">About</a>
-  </nav>
+<body class="theme-dark">
+  <div id="site-nav"></div>
 
   <!-- Hero -->
   <section class="hero">
@@ -232,8 +211,8 @@
     (async () => {
       const host = document.getElementById('site-footer');
       if (!host) return;
-      const res = await fetch('footer.html', { cache: 'no-cache' });
-      host.innerHTML = await res.text();
+      const res = await fetch('footer.html?v=1.0.7', { cache: 'no-cache' });
+      host.outerHTML = await res.text();
     })();
   </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <title>The Tank Guide — A product of FishKeepingLifeCo</title>
   <meta name="description" content="Smart tools and guides to plan, stock, and set up your aquarium — all in one place." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
 
   <style>
     :root{
@@ -143,8 +143,8 @@
   (async () => {
     const host = document.getElementById('site-footer');
     if (!host) return;
-    const res = await fetch('footer.html', { cache: 'no-cache' });
-    host.innerHTML = await res.text();
+    const res = await fetch('footer.html?v=1.0.7', { cache: 'no-cache' });
+    host.outerHTML = await res.text();
   })();
 </script>
 <!-- Load data and logic with updated version for cache busting -->

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,124 +1,171 @@
 (() => {
-  function initNav() {
-    const btn = document.querySelector('[data-nav="hamburger"]');
-    const drawer = document.querySelector('[data-nav="drawer"]');
-    const overlay = document.querySelector('[data-nav="overlay"]');
-    const focusables = drawer ? drawer.querySelectorAll('a,button,[tabindex]:not([tabindex="-1"])') : [];
-    let previousFocus = null;
+  const NAV_VERSION = '1.0.7';
+  const NAV_PLACEHOLDER_ID = 'site-nav';
+  const HOME_PATH = '/index.html';
 
-    if (!btn || !drawer || !overlay) {
+  if (window.__TTG_NAV_LOADER__) {
+    return;
+  }
+  window.__TTG_NAV_LOADER__ = true;
+
+  function normalizePath(path) {
+    if (!path) {
+      return HOME_PATH;
+    }
+    try {
+      const url = new URL(path, window.location.origin);
+      let pathname = url.pathname.replace(/\/+$/u, '');
+      if (pathname === '' || pathname === '/') {
+        pathname = HOME_PATH;
+      }
+      return pathname;
+    } catch (error) {
+      console.warn('Failed to normalise path', path, error);
+      return path;
+    }
+  }
+
+  function markActiveLinks(root) {
+    const here = normalizePath(window.location.pathname);
+    const links = root.querySelectorAll('.links a, #ttg-drawer a');
+    links.forEach((link) => {
+      const href = link.getAttribute('href');
+      if (!href) {
+        return;
+      }
+      const target = normalizePath(href);
+      if (target === here || (target === HOME_PATH && here === HOME_PATH)) {
+        link.setAttribute('aria-current', 'page');
+      } else {
+        link.removeAttribute('aria-current');
+      }
+    });
+  }
+
+  function initNav() {
+    const root = document.getElementById('global-nav');
+    if (!root || root.dataset.navReady === 'true') {
       return;
     }
 
-    function isOpen() {
-      return drawer.classList.contains('is-open');
+    const openBtn = root.querySelector('#ttg-nav-open');
+    const closeBtn = root.querySelector('#ttg-nav-close');
+    const overlay = root.querySelector('#ttg-overlay');
+    const drawer = root.querySelector('#ttg-drawer');
+    const focusTargets = drawer ? drawer.querySelectorAll('a, button, [tabindex]:not([tabindex="-1"])') : null;
+
+    if (!openBtn || !overlay || !drawer) {
+      return;
     }
 
-    function focusFirstItem() {
-      if (!focusables || focusables.length === 0) {
-        return;
-      }
-      const first = focusables[0];
-      if (first && typeof first.focus === 'function') {
-        first.focus({ preventScroll: true });
-      }
-    }
+    let previousFocus = null;
 
-    function openDrawer() {
-      if (isOpen()) {
+    const closeDrawer = () => {
+      if (root.getAttribute('data-open') !== 'true') {
         return;
       }
-      previousFocus = document.activeElement;
-      drawer.classList.add('is-open');
-      overlay.classList.add('is-open');
-      btn.setAttribute('aria-expanded', 'true');
-      document.documentElement.dataset.scrollLock = 'on';
-      focusFirstItem();
-    }
-
-    function closeDrawer() {
-      if (!isOpen()) {
-        return;
-      }
+      root.removeAttribute('data-open');
       drawer.classList.remove('is-open');
       overlay.classList.remove('is-open');
-      btn.setAttribute('aria-expanded', 'false');
+      overlay.setAttribute('aria-hidden', 'true');
+      drawer.setAttribute('aria-hidden', 'true');
+      openBtn.setAttribute('aria-expanded', 'false');
       delete document.documentElement.dataset.scrollLock;
-      if (btn && typeof btn.focus === 'function') {
-        btn.focus({ preventScroll: true });
-      } else if (previousFocus && typeof previousFocus.focus === 'function') {
-        previousFocus.focus();
+      document.documentElement.style.overflow = '';
+      document.body.style.overflow = '';
+      const target = openBtn instanceof HTMLElement ? openBtn : previousFocus;
+      if (target && typeof target.focus === 'function') {
+        target.focus({ preventScroll: true });
       }
       previousFocus = null;
-    }
+    };
 
-    function toggleDrawer() {
-      if (isOpen()) {
-        closeDrawer();
-      } else {
-        openDrawer();
-      }
-    }
-
-    function handleKeydown(event) {
-      if (!isOpen()) {
+    const openDrawer = () => {
+      if (root.getAttribute('data-open') === 'true') {
         return;
       }
+      previousFocus = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      root.setAttribute('data-open', 'true');
+      drawer.classList.add('is-open');
+      overlay.classList.add('is-open');
+      overlay.setAttribute('aria-hidden', 'false');
+      drawer.setAttribute('aria-hidden', 'false');
+      openBtn.setAttribute('aria-expanded', 'true');
+      document.documentElement.dataset.scrollLock = 'on';
+      document.documentElement.style.overflow = 'hidden';
+      document.body.style.overflow = 'hidden';
+      window.requestAnimationFrame(() => {
+        if (!focusTargets || focusTargets.length === 0) {
+          return;
+        }
+        const first = focusTargets[0];
+        if (first instanceof HTMLElement) {
+          first.focus({ preventScroll: true });
+        }
+      });
+    };
 
+    const handleKeydown = (event) => {
       if (event.key === 'Escape') {
-        event.preventDefault();
         closeDrawer();
-        return;
       }
+    };
 
-      if (event.key !== 'Tab') {
-        return;
-      }
-
-      if (!focusables || focusables.length === 0) {
-        event.preventDefault();
-        return;
-      }
-
-      const first = focusables[0];
-      const last = focusables[focusables.length - 1];
-      const active = document.activeElement;
-
-      if (event.shiftKey) {
-        if (!drawer.contains(active) || active === first) {
-          event.preventDefault();
-          last.focus();
-        }
-      } else {
-        if (!drawer.contains(active) || active === last) {
-          event.preventDefault();
-          first.focus();
-        }
-      }
-    }
-
-    btn.addEventListener('click', (event) => {
+    openBtn.addEventListener('click', (event) => {
       event.preventDefault();
-      toggleDrawer();
+      openDrawer();
+    });
+
+    closeBtn?.addEventListener('click', (event) => {
+      event.preventDefault();
+      closeDrawer();
     });
 
     overlay.addEventListener('click', () => {
       closeDrawer();
     });
 
-    document.addEventListener('keydown', handleKeydown);
-
     drawer.addEventListener('click', (event) => {
-      const link = event.target.closest('a');
+      const link = event.target instanceof HTMLElement ? event.target.closest('a') : null;
       if (link) {
         closeDrawer();
       }
     });
+
+    if (!root.__ttgEscHandler) {
+      document.addEventListener('keydown', handleKeydown);
+      root.__ttgEscHandler = handleKeydown;
+    }
+
+    markActiveLinks(root);
+    root.dataset.navReady = 'true';
+    drawer.setAttribute('aria-hidden', 'true');
+    overlay.setAttribute('aria-hidden', 'true');
+  }
+
+  async function mountNav() {
+    const host = document.getElementById(NAV_PLACEHOLDER_ID);
+    if (!host) {
+      return;
+    }
+    try {
+      const response = await fetch(`nav.html?v=${NAV_VERSION}`, { cache: 'no-cache' });
+      if (!response.ok) {
+        throw new Error(`Failed to fetch nav: ${response.status}`);
+      }
+      const markup = await response.text();
+      host.outerHTML = markup;
+      initNav();
+    } catch (error) {
+      console.error('Navigation failed to initialise', error);
+    }
   }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initNav);
+    document.addEventListener('DOMContentLoaded', mountNav);
   } else {
-    initNav();
+    mountNav();
   }
+
+  window.ttgInitNav = initNav;
 })();

--- a/media.html
+++ b/media.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — Media Hub</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Media Hub — Watch • Read • Explore. Aquarium videos and blogs for every aquarist." />
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
   <link rel="icon" href="/favicon.ico" />
   <meta property="og:title" content="The Tank Guide — Media Hub" />
   <meta property="og:description" content="Watch • Read • Explore — videos and blogs for every aquarist." />
@@ -166,31 +166,10 @@
     }
 
   </style>
-  <script defer src="js/nav.js?v=1.1.0"></script>
+  <script defer src="js/nav.js?v=1.0.7"></script>
 </head>
-<body class="page-background">
-
-  <header class="site-header">
-    <div class="site-header__inner">
-      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
-        <span class="site-brand__title">The Tank Guide</span>
-        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
-      </a>
-      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
-        <span class="hamburger__bars" aria-hidden="true"></span>
-        <span class="visually-hidden">Menu</span>
-      </button>
-    </div>
-  </header>
-  <div class="nav-overlay" data-nav="overlay"></div>
-  <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site">
-    <a href="index.html" class="nav__link">Home</a>
-    <a href="stocking.html" class="nav__link">Stocking Advisor</a>
-    <a href="gear.html" class="nav__link">Gear</a>
-    <a href="params.html" class="nav__link">Cycling Coach</a>
-    <a href="media.html" class="nav__link" aria-current="page">Media</a>
-    <a href="about.html" class="nav__link">About</a>
-  </nav>
+<body class="theme-light">
+  <div id="site-nav"></div>
 
   <!-- Hero -->
   <section class="hero">
@@ -260,8 +239,8 @@
     (async () => {
       const host = document.getElementById('site-footer');
       if (!host) return;
-      const res = await fetch('footer.html', { cache: 'no-cache' });
-      host.innerHTML = await res.text();
+      const res = await fetch('footer.html?v=1.0.7', { cache: 'no-cache' });
+      host.outerHTML = await res.text();
     })();
   </script>
 </body>

--- a/nav.html
+++ b/nav.html
@@ -1,6 +1,14 @@
-<header id="global-nav" class="site-header">
-  <div class="site-header__inner inner">
-    <button id="ttg-nav-open" class="hamburger" type="button" aria-controls="ttg-drawer" aria-expanded="false" aria-label="Open menu">
+<header id="global-nav">
+  <div class="inner">
+    <button
+      id="ttg-nav-open"
+      class="hamburger"
+      type="button"
+      aria-controls="ttg-drawer"
+      aria-expanded="false"
+      aria-label="Open menu"
+      data-nav="hamburger"
+    >
       <span class="hamburger__bars" aria-hidden="true"></span>
       <span class="visually-hidden">Open menu</span>
     </button>
@@ -18,23 +26,23 @@
       <a href="https://thetankguide.com/feedback" class="nav__link" target="_blank" rel="noopener">Feedback</a>
     </nav>
   </div>
-  <div id="ttg-overlay" aria-hidden="true"></div>
-  <nav id="ttg-drawer" class="drawer" aria-label="Site">
-    <div class="drawer__header">
-      <span class="drawer__title">The Tank Guide</span>
+  <aside id="ttg-drawer" aria-label="Site" data-nav="drawer" aria-hidden="true">
+    <div class="drawer-head">
+      <span class="drawer-title">The Tank Guide</span>
       <button id="ttg-nav-close" class="drawer-close" type="button" aria-label="Close menu">
         <span aria-hidden="true">×</span>
       </button>
     </div>
-    <ul class="drawer-links">
-      <li><a href="index.html" class="nav__link">Home</a></li>
-      <li><a href="stocking.html" class="nav__link">Stocking Advisor</a></li>
-      <li><a href="gear.html" class="nav__link">Gear</a></li>
-      <li><a href="params.html" class="nav__link">Cycling Coach</a></li>
-      <li><a href="media.html" class="nav__link">Media</a></li>
-      <li><a href="about.html" class="nav__link">About</a></li>
-      <li><a href="https://thetankguide.com/feedback" class="nav__link" target="_blank" rel="noopener">Feedback</a></li>
-    </ul>
-  </nav>
+    <nav class="drawer-links" aria-label="Mobile">
+      <a href="index.html" class="nav__link">Home</a>
+      <a href="stocking.html" class="nav__link">Stocking Advisor</a>
+      <a href="gear.html" class="nav__link">Gear</a>
+      <a href="params.html" class="nav__link">Cycling Coach</a>
+      <a href="media.html" class="nav__link">Media</a>
+      <a href="about.html" class="nav__link">About</a>
+      <a href="https://thetankguide.com/feedback" class="nav__link" target="_blank" rel="noopener">Feedback</a>
+    </nav>
+  </aside>
+  <div id="ttg-overlay" data-nav="overlay" aria-hidden="true"></div>
 </header>
 <div class="global-nav-spacer" aria-hidden="true"></div>

--- a/stocking.html
+++ b/stocking.html
@@ -4,104 +4,11 @@
   <meta charset="UTF-8" />
   <title>FishkeepingLifeCo — Stocking Calculator</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <!-- Global nav / shared styles (same versioning as Media) -->
-  <link rel="stylesheet" href="css/style.css?v=1.0.5" />
-  <!-- Page styles -->
-  <link rel="stylesheet" href="css/Style.css?v=1.0.3" />
-
-  <style>
-    /* Keep the fixed nav above content */
-    #global-nav{position:fixed;top:0;left:0;right:0;z-index:10000}
-
-    /* Put hamburger on the LEFT (match Media) */
-    #global-nav .inner{display:flex;align-items:center;gap:12px}
-    #ttg-nav-open{order:0;margin-right:10px}
-    #global-nav .brand{order:1}
-    #global-nav .links{order:2}
-
-    /* Mobile: hide desktop links, show hamburger */
-    @media (max-width: 920px){
-      #global-nav .links{display:none !important;}
-      #ttg-nav-open{display:inline-flex !important;}
-    }
-
-    /* Remove iOS giant focus ring at very top; keep good keyboard ring */
-    #global-nav a, #global-nav button{ -webkit-tap-highlight-color:transparent; }
-    #global-nav a:focus, #global-nav button:focus{ outline:none; }
-    @supports selector(:focus-visible){
-      #global-nav a:focus-visible, #global-nav button:focus-visible{
-        outline:2px solid rgba(255,255,255,.45);
-        outline-offset:2px; border-radius:10px;
-      }
-    }
-
-    /* Ensure drawer overlays content cleanly */
-    #ttg-overlay{ z-index:10001; }
-    #ttg-drawer { z-index:10002; }
-  </style>
+  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
+  <script src="js/nav.js?v=1.0.7" defer></script>
 </head>
-<body>
-
-  <!-- Global nav include (same pattern as Media) -->
+<body class="theme-dark">
   <div id="site-nav"></div>
-  <script>
-    function initNav(){
-      const root = document.getElementById('global-nav');
-      if (!root) return;
-
-      // underline current link (desktop & drawer)
-      const here = location.pathname.replace(/\/+$/,'');
-      const mark = sel => root.querySelectorAll(sel).forEach(a=>{
-        const href = (a.getAttribute('href')||'').replace(/\/+$/,'');
-        if (here === href || (here === '' && href === '/index.html')) {
-          a.setAttribute('aria-current','page');
-        }
-      });
-      mark('.links a');
-      mark('.drawer a, #ttg-drawer a'); // support either class/id
-
-      // drawer controls
-      const openBtn = root.querySelector('#ttg-nav-open');
-      const closeBtn= root.querySelector('#ttg-nav-close');
-      const overlay = root.querySelector('#ttg-overlay');
-      const drawer  = root.querySelector('#ttg-drawer');
-
-      const open = ()=>{
-        root.setAttribute('data-open','true');
-        overlay.hidden = false;
-        drawer.removeAttribute('aria-hidden');
-        document.documentElement.style.overflow = 'hidden';
-        openBtn?.setAttribute('aria-expanded','true');
-        (drawer.querySelector('a')||openBtn).focus();
-      };
-      const close = ()=>{
-        root.removeAttribute('data-open');
-        overlay.hidden = true;
-        drawer.setAttribute('aria-hidden','true');
-        document.documentElement.style.overflow = '';
-        openBtn?.setAttribute('aria-expanded','false');
-        openBtn?.focus();
-      };
-
-      openBtn?.addEventListener('click', open);
-      closeBtn?.addEventListener('click', close);
-      overlay?.addEventListener('click', close);
-      drawer?.querySelectorAll('a').forEach(a=>a.addEventListener('click', close));
-      document.addEventListener('keydown', e=>{ if(e.key==='Escape' && root.getAttribute('data-open')==='true') close(); });
-    }
-
-    fetch('/nav.html?v=1.0.5')
-      .then(r=>r.text())
-      .then(html=>{
-        document.getElementById('site-nav').outerHTML = html;
-        initNav();
-        // iOS sometimes leaves the brand link focused; blur it so no “input” bar appears
-        setTimeout(()=>{ if (document.activeElement && document.activeElement.blur) document.activeElement.blur(); }, 0);
-      });
-  </script>
-
-  <!-- Spacer so fixed header doesn't overlap content -->
-  <div style="height:64px"></div>
 
   <div class="wrap">
     <!-- Tank Setup -->
@@ -220,9 +127,12 @@
     <!-- Footer -->
     <footer id="site-footer"></footer>
     <script>
-      fetch("footer.html")
-        .then(response => response.text())
-        .then(data => { document.getElementById("site-footer").innerHTML = data; });
+      (async () => {
+        const host = document.getElementById('site-footer');
+        if (!host) return;
+        const res = await fetch('footer.html?v=1.0.7', { cache: 'no-cache' });
+        host.outerHTML = await res.text();
+      })();
     </script>
     <!-- Load data and logic with updated version for cache busting -->
     <script src="js/fish-data.js?v=1.0.3"></script>

--- a/tests/nav.spec.mjs
+++ b/tests/nav.spec.mjs
@@ -1,0 +1,166 @@
+import { test, expect } from '@playwright/test';
+import http from 'http';
+import { readFile } from 'fs/promises';
+import { statSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const mimeTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.js': 'application/javascript; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain; charset=utf-8',
+};
+
+let server;
+let baseURL = '';
+
+async function startServer() {
+  const root = path.resolve(__dirname, '..');
+  server = http.createServer(async (req, res) => {
+    try {
+      const requestUrl = new URL(req.url ?? '/', 'http://127.0.0.1');
+      let filePath = requestUrl.pathname;
+      if (filePath.endsWith('/')) {
+        filePath = path.join(filePath, 'index.html');
+      }
+      if (filePath === '/' || filePath === '') {
+        filePath = '/index.html';
+      }
+      const normalised = path
+        .normalize(filePath)
+        .replace(/^([/\\])+/u, '')
+        .replace(/^\.\.(?:[/\\]|$)/gu, '');
+      const diskPath = path.join(root, normalised);
+      let stats;
+      try {
+        stats = statSync(diskPath);
+      } catch {
+        stats = undefined;
+      }
+      if (!stats || stats.isDirectory()) {
+        res.statusCode = 404;
+        res.end('Not found');
+        return;
+      }
+      const data = await readFile(diskPath);
+      const contentType = mimeTypes[path.extname(diskPath).toLowerCase()] ?? 'application/octet-stream';
+      res.setHeader('Content-Type', contentType);
+      res.end(data);
+    } catch (error) {
+      res.statusCode = 500;
+      res.end(String(error));
+    }
+  });
+
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (address && typeof address === 'object') {
+    baseURL = `http://127.0.0.1:${address.port}`;
+  } else {
+    throw new Error('Failed to start static server');
+  }
+}
+
+async function stopServer() {
+  await new Promise((resolve) => server.close(() => resolve()));
+}
+
+test.beforeAll(async () => {
+  await startServer();
+});
+
+test.afterAll(async () => {
+  await stopServer();
+});
+
+async function gotoAndVerify(page, route, theme) {
+  const errors = [];
+  page.on('pageerror', (error) => errors.push(error.message));
+  page.on('console', (message) => {
+    if (message.type() === 'error') {
+      errors.push(message.text());
+    }
+  });
+
+  const cssResponsePromise = page.waitForResponse((response) =>
+    response.url().includes('css/style.css?v=1.0.7')
+  );
+
+  await page.goto(`${baseURL}${route}`);
+  const cssResponse = await cssResponsePromise;
+  expect(cssResponse.status(), `${route} should load css/style.css`).toBe(200);
+
+  const nav = page.locator('#global-nav');
+  await expect(nav, `${route} should render the shared nav`).toBeVisible();
+  const navPosition = await nav.evaluate((element) => window.getComputedStyle(element).position);
+  expect(navPosition).toBe('fixed');
+
+  const hamburger = page.locator('#ttg-nav-open');
+  const brand = page.locator('#global-nav .brand');
+  await expect(hamburger).toBeVisible();
+  await expect(brand).toBeVisible();
+  const [hambBox, brandBox] = await Promise.all([hamburger.boundingBox(), brand.boundingBox()]);
+  expect(hambBox).not.toBeNull();
+  expect(brandBox).not.toBeNull();
+  if (hambBox && brandBox) {
+    expect(hambBox.x).toBeLessThan(brandBox.x);
+  }
+
+  const drawer = page.locator('#ttg-drawer');
+  const overlay = page.locator('#ttg-overlay');
+  await hamburger.click();
+  await expect(nav).toHaveAttribute('data-open', 'true');
+  await expect(drawer).toHaveClass(/is-open/);
+  await expect(overlay).toHaveClass(/is-open/);
+
+  const drawerZ = await drawer.evaluate((element) => Number(window.getComputedStyle(element).zIndex) || 0);
+  const overlayZ = await overlay.evaluate((element) => Number(window.getComputedStyle(element).zIndex) || 0);
+  const card = page.locator('.card').first();
+  let cardZ = 0;
+  if (await card.count()) {
+    cardZ = await card.evaluate((element) => Number(window.getComputedStyle(element).zIndex) || 0);
+  }
+  expect(drawerZ).toBeGreaterThan(cardZ);
+  expect(overlayZ).toBeGreaterThan(cardZ);
+
+  await overlay.click();
+  await expect(nav).not.toHaveAttribute('data-open', 'true');
+  await expect(drawer).not.toHaveClass(/is-open/);
+
+  await hamburger.click();
+  await expect(nav).toHaveAttribute('data-open', 'true');
+  await page.keyboard.press('Escape');
+  await expect(nav).not.toHaveAttribute('data-open', 'true');
+
+  const background = await page.evaluate(() => window.getComputedStyle(document.body).backgroundImage || '');
+  if (theme === 'dark') {
+    expect(background).toMatch(/rgb\(9, 20, 33|rgb\(10, 15, 24/);
+  } else {
+    expect(background).toMatch(/rgb\(14, 94, 139|rgb\(20, 119, 168/);
+  }
+
+  await expect(errors, `${route} should not log console errors`).toEqual([]);
+}
+
+test('stocking, gear, and media share the nav layout', async ({ page }) => {
+  await gotoAndVerify(page, '/stocking.html', 'dark');
+  await gotoAndVerify(page, '/gear.html', 'dark');
+  await gotoAndVerify(page, '/media.html', 'light');
+});
+
+test('index page remains free of the global nav', async ({ page }) => {
+  const cssResponsePromise = page.waitForResponse((response) =>
+    response.url().includes('css/style.css?v=1.0.7')
+  );
+  await page.goto(`${baseURL}/index.html`);
+  const cssResponse = await cssResponsePromise;
+  expect(cssResponse.status(), 'index should load css/style.css').toBe(200);
+  await expect(page.locator('#global-nav')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- rebuild the shared nav markup so the hamburger sits left, the overlay/drawer slide from the left, and the active link state is applied for desktop and mobile
- restore dark `theme-dark` backgrounds for Stocking/Gear, keep Media/About light, and load the shared footer include with the new cache-busting version
- refresh the global stylesheet for translucent nav styling, scoped drawer typography, and consistent social icon sizing, plus add an end-to-end nav Playwright test

## Testing
- `npm test` *(fails: Playwright browsers are not installed in this environment — run `npx playwright install` to download them before re-running)*

## Verification
- Drawer width constrained to `min(45vw, 420px)` with overlay on top of cards
- Links in the drawer use consistent padding/line-height across Stocking, Gear, and Media
- About page now mounts the shared footer include and nav placeholder
- Screenshot: not captured (browser binaries unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d48ce846e483328e5f7bb38b388170