### PR TITLE
Make global navigation non-sticky

### DIFF
--- a/about.html
+++ b/about.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — About</title>
   <meta name="description" content="Learn about The Tank Guide mission, story, and future vision." />
   <link rel="icon" href="/favicon.ico" />
-  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <style>
     *, *::before, *::after { box-sizing: border-box; }
     main { max-width: 960px; margin: 0 auto; padding: 0 20px 80px; }
@@ -18,7 +18,7 @@
       main { padding-bottom: 120px; }
     }
   </style>
-  <script defer src="js/nav.js?v=1.0.7"></script>
+  <script defer src="js/nav.js?v=1.0.8"></script>
 </head>
 <body class="theme-light">
   <div id="site-nav"></div>
@@ -63,7 +63,7 @@
     (async () => {
       const host = document.getElementById('site-footer');
       if (!host) return;
-      const res = await fetch('footer.html?v=1.0.7', { cache: 'no-cache' });
+      const res = await fetch('footer.html?v=1.0.8', { cache: 'no-cache' });
       host.outerHTML = await res.text();
     })();
   </script>

--- a/css/style.css
+++ b/css/style.css
@@ -74,10 +74,7 @@ body.theme-light {
 }
 
 #global-nav {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
+  position: relative;
   z-index: 10000;
   background: rgba(10, 14, 22, 0.35);
   backdrop-filter: saturate(1.4) blur(6px);
@@ -331,10 +328,6 @@ body.theme-light {
   outline: 2px solid rgba(255, 255, 255, 0.55);
   outline-offset: 3px;
   border-radius: 12px;
-}
-
-.global-nav-spacer {
-  height: 64px;
 }
 
 html[data-scroll-lock="on"],

--- a/gear.html
+++ b/gear.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — Gear (Guided)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Build your aquarium setup step by step — tanks, filtration, lighting, and more." />
-  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <link rel="icon" href="/favicon.ico" />
 
   <style>
@@ -55,7 +55,7 @@
     .muted{color:var(--muted);}
     /* ... rest of your CSS unchanged ... */
   </style>
-  <script defer src="js/nav.js?v=1.0.7"></script>
+  <script defer src="js/nav.js?v=1.0.8"></script>
 </head>
 <body class="theme-dark">
   <div id="site-nav"></div>
@@ -211,7 +211,7 @@
     (async () => {
       const host = document.getElementById('site-footer');
       if (!host) return;
-      const res = await fetch('footer.html?v=1.0.7', { cache: 'no-cache' });
+        const res = await fetch('footer.html?v=1.0.8', { cache: 'no-cache' });
       host.outerHTML = await res.text();
     })();
   </script>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <title>The Tank Guide — A product of FishKeepingLifeCo</title>
   <meta name="description" content="Smart tools and guides to plan, stock, and set up your aquarium — all in one place." />
 
-  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
 
   <style>
     :root{
@@ -143,7 +143,7 @@
   (async () => {
     const host = document.getElementById('site-footer');
     if (!host) return;
-    const res = await fetch('footer.html?v=1.0.7', { cache: 'no-cache' });
+    const res = await fetch('footer.html?v=1.0.8', { cache: 'no-cache' });
     host.outerHTML = await res.text();
   })();
 </script>

--- a/js/modules/nav.js
+++ b/js/modules/nav.js
@@ -1,4 +1,4 @@
-const NAV_VERSION = '1.3.0';
+const NAV_VERSION = '1.3.1';
 const NAV_ENDPOINT = `/nav.html?v=${NAV_VERSION}`;
 const SKIP_PATHS = new Set(['/', '/index.html']);
 const OVERLAY_HIDE_DELAY = 320;

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,5 +1,5 @@
 (() => {
-  const NAV_VERSION = '1.0.7';
+  const NAV_VERSION = '1.0.8';
   const NAV_PLACEHOLDER_ID = 'site-nav';
   const HOME_PATH = '/index.html';
 

--- a/media.html
+++ b/media.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — Media Hub</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="Media Hub — Watch • Read • Explore. Aquarium videos and blogs for every aquarist." />
-  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <link rel="icon" href="/favicon.ico" />
   <meta property="og:title" content="The Tank Guide — Media Hub" />
   <meta property="og:description" content="Watch • Read • Explore — videos and blogs for every aquarist." />
@@ -166,7 +166,7 @@
     }
 
   </style>
-  <script defer src="js/nav.js?v=1.0.7"></script>
+  <script defer src="js/nav.js?v=1.0.8"></script>
 </head>
 <body class="theme-light">
   <div id="site-nav"></div>
@@ -239,7 +239,7 @@
     (async () => {
       const host = document.getElementById('site-footer');
       if (!host) return;
-      const res = await fetch('footer.html?v=1.0.7', { cache: 'no-cache' });
+      const res = await fetch('footer.html?v=1.0.8', { cache: 'no-cache' });
       host.outerHTML = await res.text();
     })();
   </script>

--- a/nav.html
+++ b/nav.html
@@ -45,4 +45,3 @@
   </aside>
   <div id="ttg-overlay" data-nav="overlay" aria-hidden="true"></div>
 </header>
-<div class="global-nav-spacer" aria-hidden="true"></div>

--- a/params.html
+++ b/params.html
@@ -7,7 +7,7 @@
   <meta name="description" content="Master the nitrogen cycle for your aquarium with detailed schedules and alerts." />
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <link rel="stylesheet" href="css/params.css?v=1.0.4" />
-  <script defer src="js/nav.js?v=1.1.0"></script>
+  <script defer src="js/nav.js?v=1.0.8"></script>
 </head>
 <body class="page-background bg--dark">
 

--- a/stocking.html
+++ b/stocking.html
@@ -4,8 +4,8 @@
   <meta charset="UTF-8" />
   <title>FishkeepingLifeCo — Stocking Calculator</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="stylesheet" href="css/style.css?v=1.0.7" />
-  <script src="js/nav.js?v=1.0.7" defer></script>
+  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <script src="js/nav.js?v=1.0.8" defer></script>
 </head>
 <body class="theme-dark">
   <div id="site-nav"></div>
@@ -130,7 +130,7 @@
       (async () => {
         const host = document.getElementById('site-footer');
         if (!host) return;
-        const res = await fetch('footer.html?v=1.0.7', { cache: 'no-cache' });
+        const res = await fetch('footer.html?v=1.0.8', { cache: 'no-cache' });
         host.outerHTML = await res.text();
       })();
     </script>

--- a/tests/nav.spec.mjs
+++ b/tests/nav.spec.mjs
@@ -90,7 +90,7 @@ async function gotoAndVerify(page, route, theme) {
   });
 
   const cssResponsePromise = page.waitForResponse((response) =>
-    response.url().includes('css/style.css?v=1.0.7')
+    response.url().includes('css/style.css?v=1.0.8')
   );
 
   await page.goto(`${baseURL}${route}`);
@@ -100,7 +100,7 @@ async function gotoAndVerify(page, route, theme) {
   const nav = page.locator('#global-nav');
   await expect(nav, `${route} should render the shared nav`).toBeVisible();
   const navPosition = await nav.evaluate((element) => window.getComputedStyle(element).position);
-  expect(navPosition).toBe('fixed');
+  expect(navPosition).toBe('relative');
 
   const hamburger = page.locator('#ttg-nav-open');
   const brand = page.locator('#global-nav .brand');
@@ -157,7 +157,7 @@ test('stocking, gear, and media share the nav layout', async ({ page }) => {
 
 test('index page remains free of the global nav', async ({ page }) => {
   const cssResponsePromise = page.waitForResponse((response) =>
-    response.url().includes('css/style.css?v=1.0.7')
+    response.url().includes('css/style.css?v=1.0.8')
   );
   await page.goto(`${baseURL}/index.html`);
   const cssResponse = await cssResponsePromise;


### PR DESCRIPTION
## Summary
- let the shared navigation bar scroll naturally by dropping its fixed positioning and spacer markup
- bump nav-related asset query strings to v1.0.8 so pages load the refreshed styles and footer includes
- update nav utilities and tests to expect the new positioning while keeping drawer behavior intact

## Testing
- npm test *(fails: Playwright chromium binaries unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d495143e2c8332a45b208e8b386998