### PR TITLE
Fix featured resource cover image path

### DIFF
--- a/media.html
+++ b/media.html
@@ -223,7 +223,7 @@
       <h2 id="featured-resource-title" class="center">Featured Resource</h2>
       <div class="resource-card">
         <a class="resource-cover-link" href="https://www.amazon.com/dp/B0BGN98F57?tag=fklife-20" target="_blank" rel="noopener">
-          <img class="resource-cover" src="assets/media/ebook-cover.jpg" alt="Cover of The Tank Guide eBook" loading="lazy" />
+          <img class="resource-cover" src="assets/books/book-cover-web.jpg" alt="Cover of The Tank Guide eBook" loading="lazy" />
         </a>
         <div class="resource-content">
           <p class="resource-title">The Tank Guide: Cycling &amp; Stocking Companion</p>


### PR DESCRIPTION
## Summary
- update the Featured Resource image on the media page to use the existing book cover asset
- ensure the cover remains wrapped in the outbound Amazon link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d497c68a6483328df5eb4c9a220634