### PR TITLE
Update book links and button text

### DIFF
--- a/media.html
+++ b/media.html
@@ -222,13 +222,13 @@
     <section class="section" id="featured-resource" aria-labelledby="featured-resource-title">
       <h2 id="featured-resource-title" class="center">Featured Resource</h2>
       <div class="resource-card">
-        <a class="resource-cover-link" href="https://www.amazon.com/dp/B0BGN98F57?tag=fklife-20" target="_blank" rel="noopener">
+        <a class="resource-cover-link" href="https://amzn.to/3Kh34I1" target="_blank" rel="noopener">
           <img class="resource-cover" src="assets/books/book-cover-web.jpg" alt="Cover of The Tank Guide eBook" loading="lazy" />
         </a>
         <div class="resource-content">
           <p class="resource-title">The Tank Guide: Cycling &amp; Stocking Companion</p>
           <p class="resource-desc">Printable schedules, stocking charts, and troubleshooting checklists for freshwater aquariums — made to pair with our tools.</p>
-          <a class="btn btn-amazon" href="https://www.amazon.com/dp/B0BGN98F57?tag=fklife-20" target="_blank" rel="noopener">Get the eBook</a>
+          <a class="btn btn-amazon" href="https://amzn.to/3Kh34I1" target="_blank" rel="noopener">Buy Book On Amazon</a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- point book resource links to the new Amazon short URL
- retitle the featured resource button to invite purchasing on Amazon

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d4a5da7858833296cac35a9b226313