### PR TITLE
Build Cycling Coach interactive assessment page

### DIFF
--- a/css/params.css
+++ b/css/params.css
@@ -1,0 +1,517 @@
+:root {
+  --panel-bg: rgba(12, 25, 40, 0.72);
+  --panel-line: rgba(255, 255, 255, 0.14);
+  --panel-shadow: 0 18px 36px rgba(4, 12, 22, 0.48);
+  --muted: rgba(235, 241, 255, 0.78);
+  --badge-good: rgba(51, 181, 117, 0.28);
+  --badge-good-text: #56f0a5;
+  --badge-warn: rgba(255, 197, 61, 0.28);
+  --badge-warn-text: #ffd76a;
+  --badge-bad: rgba(231, 91, 91, 0.32);
+  --badge-bad-text: #ffb8b8;
+  --badge-neutral: rgba(255, 255, 255, 0.16);
+  --badge-neutral-text: #f3f6ff;
+  --accent: #4fd2ff;
+  --btn-bg: #f5f9ff;
+  --btn-fg: #07263d;
+  --ghost-bg: rgba(255, 255, 255, 0.12);
+}
+
+body.theme-dark.cycling-coach {
+  --page-bg:
+    radial-gradient(1000px 700px at 15% -10%, rgba(50, 120, 200, 0.28), transparent 65%),
+    radial-gradient(1100px 800px at 85% 110%, rgba(24, 90, 160, 0.32), transparent 70%),
+    linear-gradient(180deg, #08182c 0%, #08192d 30%, #061222 100%);
+  background: var(--page-bg);
+  min-height: 100vh;
+}
+
+.cycling-coach {
+  position: relative;
+  padding: 96px 18px 80px;
+  color: #eef3ff;
+}
+
+@media (max-width: 640px) {
+  .cycling-coach {
+    padding-top: 76px;
+  }
+}
+
+.planted-overlay {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background:
+    radial-gradient(120% 100% at 20% 10%, rgba(74, 179, 120, 0.32), transparent 65%),
+    radial-gradient(120% 120% at 80% 90%, rgba(66, 180, 140, 0.25), transparent 70%);
+  opacity: 0;
+  transition: opacity 220ms ease;
+  z-index: 0;
+}
+
+body.planted-mode .planted-overlay {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .planted-overlay {
+    transition: none;
+  }
+}
+
+.coach {
+  position: relative;
+  z-index: 1;
+  width: min(1080px, 100%);
+  margin: 0 auto;
+  display: grid;
+  gap: 24px;
+}
+
+.coach__header {
+  text-align: left;
+  display: grid;
+  gap: 8px;
+}
+
+.coach__eyebrow {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.coach__title {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 800;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.coach__leaf {
+  display: none;
+  font-size: 1.8rem;
+}
+
+body.planted-mode .coach__leaf {
+  display: inline-block;
+}
+
+.coach__lede {
+  margin: 0;
+  color: var(--muted);
+  max-width: 640px;
+}
+
+.panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-line);
+  border-radius: 18px;
+  box-shadow: var(--panel-shadow);
+  backdrop-filter: blur(10px);
+}
+
+.panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 20px 24px 0;
+}
+
+.panel__header--toggle {
+  padding-bottom: 12px;
+}
+
+.panel__title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.panel__toggle {
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  padding: 6px 16px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.panel__body {
+  padding: 20px 24px 24px;
+  display: grid;
+  gap: 18px;
+}
+
+.panel__body--advanced {
+  padding-top: 0;
+}
+
+.field-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.field-grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+}
+
+.field label {
+  font-weight: 600;
+}
+
+.field input,
+.field select {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(5, 15, 25, 0.6);
+  color: inherit;
+  font-size: 1rem;
+}
+
+.field input:focus-visible,
+.field select:focus-visible {
+  outline: 2px solid rgba(79, 210, 255, 0.6);
+  outline-offset: 2px;
+}
+
+.field__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.field__controls--temp {
+  align-items: stretch;
+}
+
+.field--checkbox {
+  align-items: center;
+}
+
+.checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-weight: 600;
+}
+
+.checkbox input {
+  width: 20px;
+  height: 20px;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn--primary {
+  background: var(--btn-bg);
+  color: var(--btn-fg);
+  box-shadow: 0 10px 24px rgba(9, 30, 54, 0.35);
+}
+
+.btn--ghost {
+  background: var(--ghost-bg);
+  color: inherit;
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-1px);
+}
+
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.tooltip {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.1);
+  color: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.tooltip--inline {
+  width: 24px;
+  height: 24px;
+  font-size: 0.9rem;
+}
+
+.tooltip::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 10px);
+  transform: translateX(-50%);
+  background: rgba(8, 22, 34, 0.95);
+  color: #f5f9ff;
+  padding: 8px 10px;
+  border-radius: 10px;
+  width: max-content;
+  max-width: 220px;
+  font-weight: 500;
+  font-size: 0.85rem;
+  line-height: 1.35;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s ease;
+  z-index: 20;
+}
+
+.tooltip:focus::after,
+.tooltip:hover::after {
+  opacity: 1;
+}
+
+.unit-toggle {
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  background: rgba(255, 255, 255, 0.12);
+  color: inherit;
+  border-radius: 10px;
+  padding: 0 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.advanced-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  padding-top: 8px;
+}
+
+.advanced__result {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+}
+
+.advanced__value {
+  font-size: 1.1rem;
+}
+
+.advanced__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.advanced__badge--warn {
+  background: rgba(231, 91, 91, 0.3);
+  color: #ffe1e1;
+}
+
+.advanced__note {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.advanced__note a {
+  color: #90ddff;
+  text-decoration: underline;
+}
+
+.status-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  background: var(--badge-neutral);
+  color: var(--badge-neutral-text);
+}
+
+.status-badge[data-state="good"] {
+  background: var(--badge-good);
+  color: var(--badge-good-text);
+}
+
+.status-badge[data-state="warn"] {
+  background: var(--badge-warn);
+  color: var(--badge-warn-text);
+}
+
+.status-badge[data-state="bad"] {
+  background: var(--badge-bad);
+  color: var(--badge-bad-text);
+}
+
+.results__summary {
+  margin: 0;
+  color: var(--muted);
+}
+
+.results__actions {
+  display: grid;
+  gap: 12px;
+}
+
+.actions__intro {
+  margin: 0;
+  font-weight: 700;
+}
+
+.actions__list,
+.challenge__actions {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+}
+
+.actions__note {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.challenge {
+  margin-top: 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  padding-top: 16px;
+  display: grid;
+  gap: 16px;
+}
+
+.challenge__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.challenge__subtext {
+  margin: 0;
+  color: var(--muted);
+}
+
+.challenge__timer {
+  display: grid;
+  gap: 8px;
+  color: var(--muted);
+}
+
+.timer__track {
+  width: 100%;
+  height: 8px;
+  background: rgba(255, 255, 255, 0.14);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.timer__fill {
+  display: block;
+  height: 100%;
+  width: 100%;
+  background: linear-gradient(90deg, rgba(81, 196, 255, 0.7), rgba(126, 235, 175, 0.7));
+  animation: breathe 5s ease-in-out infinite;
+}
+
+@keyframes breathe {
+  0%, 100% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+.challenge__form {
+  display: grid;
+  gap: 16px;
+}
+
+.challenge__result {
+  display: grid;
+  gap: 12px;
+}
+
+.challenge__status {
+  margin: 0;
+  font-weight: 700;
+}
+
+.disclaimer {
+  background: rgba(255, 255, 255, 0.12);
+  border-radius: 14px;
+  padding: 16px 20px;
+  color: var(--muted);
+}
+
+.about {
+  display: grid;
+  gap: 8px;
+}
+
+.about__title {
+  margin: 0;
+}
+
+.about__text {
+  margin: 0;
+  color: var(--muted);
+  max-width: 720px;
+}
+
+@media (max-width: 520px) {
+  .panel__header,
+  .panel__body {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .tooltip::after {
+    max-width: 180px;
+  }
+}

--- a/js/params.js
+++ b/js/params.js
@@ -1,0 +1,446 @@
+const form = document.getElementById('coach-form');
+const ammoniaInput = document.getElementById('ammonia');
+const nitriteInput = document.getElementById('nitrite');
+const nitrateInput = document.getElementById('nitrate');
+const methodSelect = document.getElementById('cycle-method');
+const plantedCheckbox = document.getElementById('planted');
+const assessBtn = document.getElementById('assess');
+const clearBtn = document.getElementById('clear');
+const statusBadge = document.getElementById('status-badge');
+const summaryLine = document.getElementById('summary');
+const actionsContainer = document.getElementById('actions-container');
+const actionList = document.getElementById('action-list');
+const challengeBlock = document.getElementById('challenge');
+const challengeStartBtn = document.getElementById('challenge-start');
+const challengeForm = document.getElementById('challenge-form');
+const challengeCheckBtn = document.getElementById('challenge-check');
+const challengeResult = document.getElementById('challenge-result');
+const challengeStatus = document.getElementById('challenge-status');
+const challengeActions = document.getElementById('challenge-actions');
+const challengeAmmonia = document.getElementById('challenge-ammonia');
+const challengeNitrite = document.getElementById('challenge-nitrite');
+const coachLeaf = document.getElementById('coach-leaf');
+const advancedToggle = document.getElementById('advanced-toggle');
+const advancedContent = document.getElementById('advanced-content');
+const phInput = document.getElementById('ph');
+const tempInput = document.getElementById('temperature');
+const tempUnitBtn = document.getElementById('temp-unit');
+const nh3Value = document.getElementById('nh3-value');
+const nh3Badge = document.getElementById('nh3-badge');
+
+const STATUS = {
+  INCOMPLETE: 'Incomplete',
+  IN_PROGRESS: 'In Progress',
+  URGENT: 'Urgent',
+  CYCLED: 'Cycled (likely)',
+  MIXED: 'Mixed',
+};
+
+const STATUS_ICON = {
+  [STATUS.CYCLED]: '🟢',
+  [STATUS.IN_PROGRESS]: '🟡',
+  [STATUS.URGENT]: '🔴',
+  [STATUS.INCOMPLETE]: '⚪',
+  [STATUS.MIXED]: '⚪',
+};
+
+const ACTION_SETS = {
+  fishless: {
+    inProgress: {
+      early: [
+        'Keep ammonia at ~1–2 ppm to feed bacteria',
+        'Test daily or every other day',
+        'Watch for nitrite to start appearing',
+        'Maintain good aeration and stable temperature',
+      ],
+      spike: [
+        'Keep ammonia at ~1–2 ppm',
+        'Test daily or every other day',
+        'Expect nitrite to stay high for a while — this is normal',
+        'Nitrates will begin to appear; keep them under 40 ppm with water changes',
+      ],
+      nearly: [
+        'Keep ammonia at ~1–2 ppm',
+        'Test daily or every other day',
+        'Watch for nitrite to drop to 0',
+        'Keep nitrates under 40 ppm with water changes',
+      ],
+    },
+    cycled: [
+      'Dose ammonia up to ~2 ppm',
+      'Start the 24-hour challenge below',
+      'Do not add fish yet',
+      'Keep nitrates under 40 ppm with a large water change before stocking',
+    ],
+    challenge: {
+      pass: [
+        'Your tank processed 2 ppm of ammonia in 24 hours (ammonia and nitrite both 0)',
+        'Do a large water change to reduce nitrates under 40 ppm',
+        'You are ready to begin stocking responsibly — congratulations on building a stable cycle',
+      ],
+      fail: [
+        'Ammonia or nitrite did not drop to 0 in 24 hours',
+        'Keep dosing ammonia at ~1–2 ppm',
+        'Test daily or every other day',
+        'Don’t worry — this is normal, try the challenge again in a few days',
+      ],
+    },
+  },
+  fishIn: {
+    inProgress: [
+      'Test ammonia and nitrite daily',
+      'Feed lightly — don’t overfeed during cycling',
+      'Hold off on adding new fish until cycle is complete',
+      'Keep nitrates under 40 ppm with regular water changes',
+      'You may use a water conditioner that temporarily detoxifies ammonia/nitrite (supportive, not a substitute for water changes)',
+    ],
+    urgent: [
+      'Do a 25–50% water change now',
+      'Recommended: test every 12 hours, especially after water changes',
+      'Feed lightly until levels improve',
+      'Pause adding new fish until cycle is stable',
+      'Keep nitrates under 40 ppm with regular water changes',
+      'Optionally dose a water conditioner to temporarily detoxify ammonia/nitrite — still perform water changes as the main fix',
+    ],
+  },
+};
+
+const NITRATE_HYGIENE = {
+  planted: 'Keep nitrates under 40 ppm for fish safety, but don’t chase zero — plants need some nitrate to grow.',
+  standard: 'Keep nitrates under 40 ppm with regular water changes. Many aquarists aim for 20 ppm or less for extra safety.',
+};
+
+const challengeState = {
+  active: false,
+  result: null,
+};
+
+let tempUnit = 'F';
+
+function clampNumber(value, min = 0) {
+  if (Number.isNaN(value)) return Number.NaN;
+  return value < min ? min : value;
+}
+
+function parseInput(input) {
+  if (!input) return Number.NaN;
+  const value = clampNumber(parseFloat(input.value), 0);
+  return Number.isFinite(value) ? value : Number.NaN;
+}
+
+function formatNumber(value, decimals) {
+  if (Number.isNaN(value)) return '—';
+  return Number(value.toFixed(decimals)).toString();
+}
+
+function getInputs() {
+  return {
+    ammonia: parseInput(ammoniaInput),
+    nitrite: parseInput(nitriteInput),
+    nitrate: parseInput(nitrateInput),
+    method: methodSelect.value === 'fish-in' ? 'fishIn' : 'fishless',
+    planted: plantedCheckbox.checked,
+  };
+}
+
+function allProvided({ ammonia, nitrite, nitrate }) {
+  return ![ammonia, nitrite, nitrate].some((value) => Number.isNaN(value));
+}
+
+function isZero(value) {
+  return Math.abs(value) < 0.00001;
+}
+
+function determineStatus(inputs) {
+  if (!allProvided(inputs)) {
+    return STATUS.INCOMPLETE;
+  }
+
+  const { ammonia, nitrite, nitrate, method } = inputs;
+
+  if (method === 'fishIn' && (ammonia >= 0.25 || nitrite >= 0.25)) {
+    return STATUS.URGENT;
+  }
+
+  if (isZero(ammonia) && isZero(nitrite) && nitrate > 0) {
+    return STATUS.CYCLED;
+  }
+
+  if (isZero(ammonia) && isZero(nitrite) && isZero(nitrate)) {
+    return STATUS.MIXED;
+  }
+
+  return STATUS.IN_PROGRESS;
+}
+
+function fishlessStage({ ammonia, nitrite, nitrate }) {
+  if (nitrite >= 1 || nitrate >= 80) {
+    return 'spike';
+  }
+  if (nitrite > 0) {
+    return 'nearly';
+  }
+  return 'early';
+}
+
+function buildActions(inputs, status) {
+  const { method, planted } = inputs;
+  const nitrateLine = planted ? NITRATE_HYGIENE.planted : NITRATE_HYGIENE.standard;
+  let items = [];
+
+  if (status === STATUS.IN_PROGRESS) {
+    if (method === 'fishless') {
+      const stage = fishlessStage(inputs);
+      items = ACTION_SETS.fishless.inProgress[stage];
+    } else {
+      items = ACTION_SETS.fishIn.inProgress;
+    }
+  } else if (status === STATUS.URGENT) {
+    items = ACTION_SETS.fishIn.urgent;
+  } else if (status === STATUS.CYCLED && method === 'fishless') {
+    items = ACTION_SETS.fishless.cycled;
+  } else {
+    items = [];
+  }
+
+  if (items.length > 0) {
+    items = [...items, nitrateLine];
+  }
+
+  return items;
+}
+
+function renderActions(items) {
+  actionList.innerHTML = '';
+  if (!items.length) {
+    actionsContainer.hidden = true;
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  items.forEach((text) => {
+    const li = document.createElement('li');
+    li.textContent = text;
+    fragment.appendChild(li);
+  });
+  actionList.appendChild(fragment);
+  actionsContainer.hidden = false;
+}
+
+function updateSummary(inputs) {
+  const ammoniaText = formatNumber(inputs.ammonia, 2);
+  const nitriteText = formatNumber(inputs.nitrite, 2);
+  const nitrateText = formatNumber(inputs.nitrate, 1);
+  const methodText = inputs.method === 'fishless' ? 'Fishless' : 'Fish-in';
+  const plantedText = inputs.planted ? 'Yes' : 'No';
+  summaryLine.textContent = `TAN: ${ammoniaText} ppm • NO₂⁻: ${nitriteText} ppm • NO₃⁻: ${nitrateText} ppm • Method: ${methodText} • Planted: ${plantedText}`;
+}
+
+function updateStatusBadge(status) {
+  statusBadge.textContent = `${STATUS_ICON[status] ?? '⚪'} ${status}`;
+  statusBadge.dataset.state = '';
+  if (status === STATUS.CYCLED) {
+    statusBadge.dataset.state = 'good';
+  } else if (status === STATUS.URGENT) {
+    statusBadge.dataset.state = 'bad';
+  } else if (status === STATUS.IN_PROGRESS) {
+    statusBadge.dataset.state = 'warn';
+  } else {
+    statusBadge.dataset.state = 'neutral';
+  }
+}
+
+function resetChallenge() {
+  challengeState.active = false;
+  challengeState.result = null;
+  challengeForm.hidden = true;
+  challengeResult.hidden = true;
+  challengeStartBtn.hidden = false;
+  challengeStatus.textContent = '';
+  challengeActions.innerHTML = '';
+  challengeAmmonia.value = '';
+  challengeNitrite.value = '';
+}
+
+function toggleChallenge(visible) {
+  if (!challengeBlock) return;
+  if (!visible) {
+    challengeBlock.hidden = true;
+    resetChallenge();
+    return;
+  }
+  challengeBlock.hidden = false;
+}
+
+function setChallengeResult(passed, planted) {
+  const entries = passed ? ACTION_SETS.fishless.challenge.pass : ACTION_SETS.fishless.challenge.fail;
+  const nitrateLine = planted ? NITRATE_HYGIENE.planted : NITRATE_HYGIENE.standard;
+  challengeStatus.textContent = passed ? 'PASS' : 'FAIL';
+  challengeActions.innerHTML = '';
+  const fragment = document.createDocumentFragment();
+  entries.concat([nitrateLine]).forEach((text) => {
+    const li = document.createElement('li');
+    li.textContent = text;
+    fragment.appendChild(li);
+  });
+  challengeActions.appendChild(fragment);
+  challengeResult.hidden = false;
+}
+
+function calculateNh3(ammonia, ph, tempC) {
+  if (Number.isNaN(ammonia) || Number.isNaN(ph) || Number.isNaN(tempC)) {
+    return Number.NaN;
+  }
+  const pKa = 0.0901821 + 2729.92 / (273.15 + tempC);
+  const fraction = 1 / (Math.pow(10, pKa - ph) + 1);
+  return ammonia * fraction;
+}
+
+function updateAdvanced() {
+  const ammonia = parseInput(ammoniaInput);
+  const ph = parseInput(phInput);
+  const temperatureRaw = parseInput(tempInput);
+  if (Number.isNaN(temperatureRaw)) {
+    nh3Value.textContent = '—';
+    nh3Badge.textContent = '';
+    nh3Badge.className = 'advanced__badge';
+    return;
+  }
+  const tempC = tempUnit === 'F' ? ((temperatureRaw - 32) * 5) / 9 : temperatureRaw;
+  const nh3 = calculateNh3(ammonia, ph, tempC);
+  if (Number.isNaN(nh3)) {
+    nh3Value.textContent = '—';
+    nh3Badge.textContent = '';
+    nh3Badge.className = 'advanced__badge';
+    return;
+  }
+  nh3Value.textContent = Number(nh3.toFixed(3)).toString();
+  if (nh3 >= 0.02) {
+    nh3Badge.textContent = 'Caution';
+    nh3Badge.className = 'advanced__badge advanced__badge--warn';
+  } else {
+    nh3Badge.textContent = '';
+    nh3Badge.className = 'advanced__badge';
+  }
+}
+
+function handleAssess() {
+  const inputs = getInputs();
+  updateSummary(inputs);
+  const status = determineStatus(inputs);
+  updateStatusBadge(status);
+
+  if (status === STATUS.INCOMPLETE) {
+    renderActions([]);
+    toggleChallenge(false);
+    return;
+  }
+
+  const actions = buildActions(inputs, status);
+  renderActions(actions);
+
+  const showChallenge = status === STATUS.CYCLED && inputs.method === 'fishless';
+  toggleChallenge(showChallenge);
+  if (!showChallenge) {
+    resetChallenge();
+  }
+}
+
+function handleClear() {
+  form.reset();
+  plantedCheckbox.dispatchEvent(new Event('change'));
+  summaryLine.textContent = 'TAN: — ppm • NO₂⁻: — ppm • NO₃⁻: — ppm • Method: Fishless • Planted: No';
+  updateStatusBadge(STATUS.INCOMPLETE);
+  renderActions([]);
+  toggleChallenge(false);
+  nh3Value.textContent = '—';
+  nh3Badge.textContent = '';
+  nh3Badge.className = 'advanced__badge';
+}
+
+function handlePlantedToggle() {
+  const planted = plantedCheckbox.checked;
+  document.body.classList.toggle('planted-mode', planted);
+  if (coachLeaf) {
+    coachLeaf.style.display = '';
+  }
+}
+
+function handleAdvancedToggle() {
+  const isOpen = advancedContent.hidden === false;
+  if (isOpen) {
+    advancedContent.hidden = true;
+    advancedToggle.setAttribute('aria-expanded', 'false');
+    advancedToggle.textContent = 'Open';
+  } else {
+    advancedContent.hidden = false;
+    advancedToggle.setAttribute('aria-expanded', 'true');
+    advancedToggle.textContent = 'Close';
+  }
+}
+
+function handleTempUnitToggle() {
+  const current = parseInput(tempInput);
+  if (tempUnit === 'F') {
+    tempUnit = 'C';
+    tempUnitBtn.textContent = '°C';
+    if (!Number.isNaN(current)) {
+      const converted = ((current - 32) * 5) / 9;
+      tempInput.value = Number(converted.toFixed(2));
+    }
+  } else {
+    tempUnit = 'F';
+    tempUnitBtn.textContent = '°F';
+    if (!Number.isNaN(current)) {
+      const converted = current * (9 / 5) + 32;
+      tempInput.value = Number(converted.toFixed(2));
+    }
+  }
+  updateAdvanced();
+}
+
+function handleChallengeStart() {
+  challengeState.active = true;
+  challengeStartBtn.hidden = true;
+  challengeForm.hidden = false;
+  challengeResult.hidden = true;
+  challengeStatus.textContent = '';
+  challengeActions.innerHTML = '';
+  challengeAmmonia.focus();
+}
+
+function handleChallengeCheck() {
+  if (!challengeState.active) {
+    return;
+  }
+  const ammonia = parseInput(challengeAmmonia);
+  const nitrite = parseInput(challengeNitrite);
+  if (Number.isNaN(ammonia) || Number.isNaN(nitrite)) {
+    challengeStatus.textContent = 'Please enter both readings to continue.';
+    challengeResult.hidden = false;
+    challengeActions.innerHTML = '';
+    return;
+  }
+  const passed = isZero(ammonia) && isZero(nitrite);
+  challengeState.result = passed ? 'pass' : 'fail';
+  const mainInputs = getInputs();
+  setChallengeResult(passed, mainInputs.planted);
+}
+
+assessBtn.addEventListener('click', handleAssess);
+clearBtn.addEventListener('click', handleClear);
+plantedCheckbox.addEventListener('change', handlePlantedToggle);
+advancedToggle.addEventListener('click', handleAdvancedToggle);
+tempUnitBtn.addEventListener('click', handleTempUnitToggle);
+[ammoniaInput, phInput, tempInput].forEach((input) => {
+  input?.addEventListener('input', updateAdvanced);
+});
+if (challengeStartBtn) {
+  challengeStartBtn.addEventListener('click', handleChallengeStart);
+}
+if (challengeCheckBtn) {
+  challengeCheckBtn.addEventListener('click', handleChallengeCheck);
+}
+
+handlePlantedToggle();
+updateAdvanced();
+updateStatusBadge(STATUS.INCOMPLETE);

--- a/params.html
+++ b/params.html
@@ -2,98 +2,155 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>The Tank Guide — Cycling Coach</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="Master the nitrogen cycle for your aquarium with detailed schedules and alerts." />
+  <title>The Tank Guide — Cycling Coach</title>
+  <meta name="description" content="Check today’s aquarium readings, see your cycling status, and get guidance tailored to fishless or fish-in methods." />
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
-  <link rel="stylesheet" href="css/params.css?v=1.0.4" />
+  <link rel="stylesheet" href="css/params.css?v=1.1.0" />
   <script defer src="js/nav.js?v=1.0.8"></script>
 </head>
-<body class="page-background bg--dark">
+<body class="theme-dark cycling-coach">
+  <div id="site-nav"></div>
+  <div class="planted-overlay" aria-hidden="true"></div>
 
-  <header class="site-header">
-    <div class="site-header__inner">
-      <a class="site-brand" href="index.html" aria-label="The Tank Guide — Home">
-        <span class="site-brand__title">The Tank Guide</span>
-        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
-      </a>
-      <button class="hamburger" data-nav="hamburger" aria-expanded="false" aria-controls="site-drawer" aria-label="Open menu">
-        <span class="hamburger__bars" aria-hidden="true"></span>
-        <span class="visually-hidden">Menu</span>
-      </button>
-    </div>
-  </header>
-  <div class="nav-overlay" data-nav="overlay"></div>
-  <nav id="site-drawer" class="nav-drawer" data-nav="drawer" aria-label="Site">
-    <a href="index.html" class="nav__link">Home</a>
-    <a href="stocking.html" class="nav__link">Stocking Advisor</a>
-    <a href="gear.html" class="nav__link">Gear</a>
-    <a href="params.html" class="nav__link" aria-current="page">Cycling Coach</a>
-    <a href="media.html" class="nav__link">Media</a>
-    <a href="about.html" class="nav__link">About</a>
-  </nav>
-
-  <main class="app">
-    <header class="hero">
-      <div class="hero__content">
-        <p class="hero__eyebrow">Cycling Coach</p>
-        <h1 class="hero__title">Master the Nitrogen Cycle</h1>
-        <p class="hero__lede">Track parameters, get alerts, and keep your aquarium safe for your fish — from day zero to fully cycled.</p>
-      </div>
-      <div class="hero__cta">
-        <button class="btn btn--primary" id="start-over">Start Over</button>
-        <button class="btn" id="load-session">Resume Session</button>
-      </div>
+  <main class="coach" id="main-content">
+    <header class="coach__header">
+      <p class="coach__eyebrow">Cycling Coach</p>
+      <h1 class="coach__title" id="coach-title">Cycling Coach <span class="coach__leaf" id="coach-leaf" aria-hidden="true">🍃</span></h1>
+      <p class="coach__lede">Enter today’s parameters to understand your cycle progress and next steps.</p>
     </header>
 
-    <section class="stepper" aria-label="Cycling timeline">
-      <ol class="stepper__list">
-        <li class="stepper__item is-active">
-          <button class="stepper__button" data-step="1">1. Prep Tank</button>
-        </li>
-        <li class="stepper__item">
-          <button class="stepper__button" data-step="2">2. Seed &amp; Dose</button>
-        </li>
-        <li class="stepper__item">
-          <button class="stepper__button" data-step="3">3. Monitor</button>
-        </li>
-        <li class="stepper__item">
-          <button class="stepper__button" data-step="4">4. Stocking Day</button>
-        </li>
-      </ol>
+    <section class="panel panel--inputs" aria-labelledby="inputs-heading">
+      <div class="panel__header">
+        <h2 class="panel__title" id="inputs-heading">Today’s readings</h2>
+      </div>
+      <form id="coach-form" class="panel__body" novalidate>
+        <div class="field-grid">
+          <div class="field">
+            <label for="ammonia">Ammonia (NH₃/NH₄⁺)</label>
+            <div class="field__controls">
+              <input type="number" id="ammonia" name="ammonia" step="0.01" min="0" inputmode="decimal" />
+              <button type="button" class="tooltip" data-tooltip="Waste from fish/food. Even tiny amounts are toxic." aria-label="Waste from fish and food. Even tiny amounts are toxic.">?</button>
+            </div>
+          </div>
+          <div class="field">
+            <label for="nitrite">Nitrite (NO₂⁻)</label>
+            <div class="field__controls">
+              <input type="number" id="nitrite" name="nitrite" step="0.01" min="0" inputmode="decimal" />
+              <button type="button" class="tooltip" data-tooltip="Mid-stage of the cycle; also toxic." aria-label="Mid-stage of the cycle; also toxic.">?</button>
+            </div>
+          </div>
+          <div class="field">
+            <label for="nitrate">Nitrate (NO₃⁻)</label>
+            <div class="field__controls">
+              <input type="number" id="nitrate" name="nitrate" step="0.1" min="0" inputmode="decimal" />
+              <button type="button" class="tooltip" data-tooltip="End product; safer but must be controlled with water changes." aria-label="End product; safer but must be controlled with water changes.">?</button>
+            </div>
+          </div>
+          <div class="field">
+            <label for="cycle-method">Cycle Method</label>
+            <div class="field__controls">
+              <select id="cycle-method" name="cycle-method">
+                <option value="fishless" selected>Fishless</option>
+                <option value="fish-in">Fish-in</option>
+              </select>
+              <button type="button" class="tooltip" data-tooltip="Fishless = add ammonia without fish. Fish-in = cycle with fish; requires extra care." aria-label="Fishless means add ammonia without fish. Fish-in means cycling with fish and requires extra care.">?</button>
+            </div>
+          </div>
+          <div class="field field--checkbox">
+            <label class="checkbox">
+              <input type="checkbox" id="planted" name="planted" />
+              <span>This is a planted tank.</span>
+            </label>
+          </div>
+        </div>
+        <div class="form-actions">
+          <button type="button" class="btn btn--primary" id="assess">Assess</button>
+          <button type="button" class="btn" id="clear">Clear</button>
+        </div>
+      </form>
     </section>
 
-    <section class="card" id="step-content" tabindex="-1">
-      <div class="card__content">
-        <h2>Welcome to your Cycling Coach</h2>
-        <p>This guided experience walks you through preparing your aquarium, seeding beneficial bacteria, dosing ammonia, and testing water parameters until your tank is fully cycled.</p>
-        <p>Select a step above to get started, or hit “Start Over” to reset your session.</p>
+    <section class="panel panel--advanced" aria-labelledby="advanced-heading">
+      <div class="panel__header panel__header--toggle">
+        <h2 class="panel__title" id="advanced-heading">Advanced (optional)</h2>
+        <button type="button" class="panel__toggle" id="advanced-toggle" aria-expanded="false" aria-controls="advanced-content">Open</button>
       </div>
-      <aside class="card__aside">
-        <h3>Need to print?</h3>
-        <p>Use the “Export Schedule” option to get a printable PDF when you’re done.</p>
-      </aside>
+      <div class="panel__body panel__body--advanced" id="advanced-content" hidden>
+        <div class="advanced-grid">
+          <div class="field">
+            <label for="ph">pH</label>
+            <input type="number" id="ph" name="ph" step="0.1" inputmode="decimal" />
+          </div>
+          <div class="field">
+            <label for="temperature">Temperature</label>
+            <div class="field__controls field__controls--temp">
+              <input type="number" id="temperature" name="temperature" step="0.1" inputmode="decimal" />
+              <button type="button" class="unit-toggle" id="temp-unit" aria-label="Switch temperature unit">°F</button>
+            </div>
+          </div>
+        </div>
+        <div class="advanced__result" id="advanced-result" aria-live="polite">
+          <span class="advanced__label">Estimated toxic NH₃:</span>
+          <span class="advanced__value" id="nh3-value">—</span>
+          <span class="advanced__badge" id="nh3-badge"></span>
+          <button type="button" class="tooltip tooltip--inline" data-tooltip="Test kits read TAN (NH₃ + NH₄⁺). Only NH₃ is toxic and increases with pH and temperature." aria-label="Test kits read TAN, which is NH3 plus NH4. Only NH3 is toxic and it increases with pH and temperature.">?</button>
+        </div>
+        <p class="advanced__note">References: <a href="https://floridadep.gov/sites/default/files/SOP-001-1_0.pdf" target="_blank" rel="noopener noreferrer">Florida Department of Environmental Protection — Calculation on Un-ionized Ammonia in Fresh Water</a>; <a href="https://edis.ifas.ufl.edu/publication/FA16" target="_blank" rel="noopener noreferrer">University of Florida IFAS — How to calculate un-ionized ammonia levels</a></p>
+      </div>
     </section>
 
-    <section class="card">
-      <header class="card__header">
-        <h2>Parameter Log</h2>
-        <button class="btn btn--ghost" id="export-log">Export Schedule</button>
-      </header>
-      <div class="card__content">
-        <table class="log" aria-label="Parameter log">
-          <thead>
-            <tr>
-              <th scope="col">Day</th>
-              <th scope="col">Ammonia</th>
-              <th scope="col">Nitrite</th>
-              <th scope="col">Nitrate</th>
-              <th scope="col">Notes</th>
-            </tr>
-          </thead>
-          <tbody id="log-body"></tbody>
-        </table>
+    <section class="panel panel--results" aria-labelledby="results-heading">
+      <div class="panel__header">
+        <h2 class="panel__title" id="results-heading">Results</h2>
+        <button type="button" class="tooltip tooltip--inline" data-tooltip="High-level snapshot of where your tank stands." aria-label="High-level snapshot of where your tank stands.">?</button>
       </div>
+      <div class="panel__body" id="results" aria-live="polite">
+        <div class="status-row">
+          <span class="status-badge" id="status-badge">Incomplete</span>
+        </div>
+        <p class="results__summary" id="summary">TAN: — ppm • NO₂⁻: — ppm • NO₃⁻: — ppm • Method: Fishless • Planted: No</p>
+        <div class="results__actions" id="actions-container" hidden>
+          <p class="actions__intro">Action steps <button type="button" class="tooltip tooltip--inline" data-tooltip="Quick, practical steps based on your readings." aria-label="Quick, practical steps based on your readings.">?</button></p>
+          <ul class="actions__list" id="action-list"></ul>
+          <p class="actions__note">Water conditioner <button type="button" class="tooltip tooltip--inline" data-tooltip="Temporarily detoxifies ammonia/nitrite. Not a substitute for water changes." aria-label="A water conditioner temporarily detoxifies ammonia and nitrite but is not a substitute for water changes.">?</button></p>
+        </div>
+        <div class="challenge" id="challenge" hidden>
+          <div class="challenge__header">
+            <h3>Start 24-hour challenge</h3>
+            <button type="button" class="btn btn--ghost" id="challenge-start">Start 24-hour challenge</button>
+            <button type="button" class="tooltip tooltip--inline" data-tooltip="Shows your filter can process 2 ppm ammonia to 0 ammonia and 0 nitrite in 24 hours." aria-label="The challenge shows your filter can process two ppm ammonia to zero ammonia and zero nitrite in twenty-four hours.">?</button>
+          </div>
+          <p class="challenge__subtext">Dose to ~2 ppm, wait 24 hours, then enter the readings below.</p>
+          <div class="challenge__timer" aria-hidden="true">
+            <span class="timer__label">24-hour window</span>
+            <div class="timer__track"><span class="timer__fill"></span></div>
+          </div>
+          <div class="challenge__form" id="challenge-form" hidden>
+            <div class="field-grid field-grid--compact">
+              <div class="field">
+                <label for="challenge-ammonia">Ammonia after 24h</label>
+                <input type="number" id="challenge-ammonia" step="0.01" min="0" inputmode="decimal" />
+              </div>
+              <div class="field">
+                <label for="challenge-nitrite">Nitrite after 24h</label>
+                <input type="number" id="challenge-nitrite" step="0.01" min="0" inputmode="decimal" />
+              </div>
+            </div>
+            <button type="button" class="btn btn--primary" id="challenge-check">Check results</button>
+          </div>
+          <div class="challenge__result" id="challenge-result" hidden>
+            <p class="challenge__status" id="challenge-status"></p>
+            <ul class="challenge__actions" id="challenge-actions"></ul>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <div class="disclaimer" role="note">Cycling Coach is an educational tool. Always confirm with your own testing and judgment before making aquarium decisions.</div>
+    <section class="about" aria-labelledby="about-coach">
+      <h2 class="about__title" id="about-coach">About Cycling Coach</h2>
+      <p class="about__text">Cycling Coach combines aquarium science with simple guidance. By breaking down your test results, it shows how your tank is progressing through the cycle and offers guidance along the way.</p>
     </section>
   </main>
 
@@ -106,6 +163,6 @@
       host.innerHTML = await res.text();
     })();
   </script>
-  <script src="js/params.js?v=1.0.4" type="module"></script>
+  <script type="module" src="js/params.js?v=1.1.0"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the Cycling Coach page with a streamlined assessment workflow driven by the shared navigation/footer
- add dedicated styling for the new coach layout, responsive cards, tooltips, planted overlay, and challenge affordances
- implement Cycling Coach logic for status evaluation, actionable guidance, 24-hour challenge flow, and NH₃ estimator with plant-aware nitrate tips

## Testing
- Manual scenario verification

------
https://chatgpt.com/codex/tasks/task_e_68d4cfb418d48332837c812cf9180ece