### PR TITLE
Fix planted checkbox display and 24-hour challenge gating

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -520,6 +520,30 @@ button.danger {
   gap: 8px;
 }
 
+body.cycling-coach input[type='checkbox'] {
+  appearance: checkbox;
+  -webkit-appearance: checkbox;
+  width: auto;
+  height: auto;
+  margin: 0;
+}
+
+body.cycling-coach .field--checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+}
+
+body.cycling-coach .field--checkbox label {
+  margin: 0;
+}
+
+body.cycling-coach .field-error {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #ffb5b5;
+}
+
 .env-recs {
   opacity: 0.85;
   font-size: 0.9rem;

--- a/params.html
+++ b/params.html
@@ -590,11 +590,9 @@
               </select>
               <span id="tip-method" class="visually-hidden">Fishless equals adding ammonia without fish. Fish-in means cycling with fish and requires extra care.</span>
             </div>
-            <div class="field">
-              <label class="checkbox" for="planted">
-                <input type="checkbox" id="planted" name="planted" />
-                <span>This is a planted tank.</span>
-              </label>
+            <div class="field field--checkbox">
+              <input type="checkbox" id="planted" name="planted" />
+              <label for="planted">This is a planted tank.</label>
             </div>
           </div>
           <div class="form-actions">
@@ -626,23 +624,25 @@
         </div>
       </section>
 
-      <section class="card" id="challenge-section" aria-labelledby="challenge-heading" hidden>
+      <section class="card" id="challengeCard" aria-labelledby="challenge-heading" hidden>
         <div class="card__header">
           <h2 class="card__title" id="challenge-heading">24-hour challenge</h2>
           <button type="button" class="info-btn" data-tooltip="Shows your filter can process 2 ppm ammonia to 0 ammonia and 0 nitrite in 24 hours." aria-label="Challenge info" aria-describedby="tip-challenge">ⓘ</button>
           <span id="tip-challenge" class="visually-hidden">Shows your filter can process two ppm ammonia to zero ammonia and zero nitrite in twenty-four hours.</span>
         </div>
         <div class="challenge-card">
+          <p class="challenge-instructions" id="challenge-instructions">Dose to ~2 ppm, wait 24 hours, then enter the readings below.</p>
           <button type="button" class="btn" id="challenge-start">Start 24-hour challenge</button>
-          <p class="chip-note">Dose to ~2 ppm, wait 24 hours, then enter the readings below.</p>
           <div class="challenge-grid" id="challenge-form" hidden>
             <div class="field">
               <label for="challenge-ammonia">Ammonia after 24h</label>
               <input type="number" id="challenge-ammonia" step="0.01" min="0" inputmode="decimal" />
+              <p class="field-error" id="challenge-ammonia-error" hidden></p>
             </div>
             <div class="field">
               <label for="challenge-nitrite">Nitrite after 24h</label>
               <input type="number" id="challenge-nitrite" step="0.01" min="0" inputmode="decimal" />
+              <p class="field-error" id="challenge-nitrite-error" hidden></p>
             </div>
           </div>
           <button type="button" class="btn" id="challenge-check" hidden>Check results</button>


### PR DESCRIPTION
## Summary
- restore the planted tank checkbox to a native control and keep the leaf overlay logic intact
- gate the 24-hour challenge card to only fishless cycled results and add inline validation for the challenge inputs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5299513c88332b20dc8999194d3d9