### PR TITLE
Fix planted checkbox UI

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -658,3 +658,33 @@ td.empty-cell {
   cursor: pointer;
   appearance: none;
 }
+#cycling-coach .planted-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 8px 0 16px;
+}
+#cycling-coach input[type="checkbox"]#planted {
+  appearance: checkbox;
+  -webkit-appearance: checkbox;
+  width: 18px;
+  height: 18px;
+  margin: 0;
+  vertical-align: middle;
+  accent-color: currentColor; /* use theme text color; preserves native tick */
+}
+#cycling-coach label[for="planted"] {
+  line-height: 1.2;
+  cursor: pointer;     /* make label a large tap target */
+  user-select: none;
+}
+#cycling-coach input[type="checkbox"]#planted::before,
+#cycling-coach input[type="checkbox"]#planted::after {
+  content: none !important;  /* defeat any global faux-checkbox art */
+}
+/* Guard against global resets forcing custom pills */
+#cycling-coach input[type="checkbox"]#planted,
+#cycling-coach .planted-row input[type="checkbox"] {
+  border: initial;
+  background: initial;
+}

--- a/js/params.js
+++ b/js/params.js
@@ -358,6 +358,8 @@ document.addEventListener('DOMContentLoaded', () => {
     updateNH3Estimate();
   }
 
+  updatePlantedVisual();
+
   checkButton.addEventListener('click', () => {
     hasAssessed = true;
     handleAssessment();

--- a/params.html
+++ b/params.html
@@ -590,8 +590,8 @@
               </select>
               <span id="tip-method" class="visually-hidden">Fishless equals adding ammonia without fish. Fish-in means cycling with fish and requires extra care.</span>
             </div>
-            <div class="field field--checkbox">
-              <input type="checkbox" id="planted" name="planted" />
+            <div id="planted-row" class="planted-row">
+              <input type="checkbox" id="planted">
               <label for="planted">This is a planted tank.</label>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- replace the planted tank control with a native checkbox row in the Cycling Coach inputs
- initialize planted visual state based on the checkbox and keep overlay/leaf tied to changes
- append scoped Cycling Coach checkbox styles to ensure a compact native appearance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d52d83df188332be02ee2b779bee82