### PR TITLE
Add Contact & Feedback page

### DIFF
--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -1,0 +1,652 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Contact &amp; Feedback | The Tank Guide</title>
+    <style>
+        :root {
+            --background-dark: #0f1c2c;
+            --background-light: #f4f7fb;
+            --card-bg: #f9f9f6;
+            --border-color: #c8ced6;
+            --accordion-bg: #eef1f5;
+            --checkbox-bg: #e5e9ef;
+            --text-color: #1c2733;
+            --accent: #2f8f83;
+            --accent-focus: #38a3a0;
+            --error: #c0392b;
+            --button-gradient-start: #39b385;
+            --button-gradient-end: #2e8a68;
+            --button-gradient-hover-start: #2f9c74;
+            --button-gradient-hover-end: #267256;
+            --shadow-top: 0 -18px 36px rgba(15, 28, 44, 0.35), 0 22px 40px rgba(15, 28, 44, 0.08);
+            --shadow-mobile: 0 12px 24px rgba(15, 28, 44, 0.18);
+            --transition-duration: 450ms;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+            color: var(--text-color);
+            background: linear-gradient(to bottom, var(--background-dark) 0%, var(--background-dark) 50%, var(--background-light) 100%);
+            min-height: 100vh;
+        }
+
+        a {
+            color: inherit;
+        }
+
+        .page-wrapper {
+            min-height: calc(100vh - 80px);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            padding: 40px 20px 80px;
+        }
+
+        @media (min-width: 1280px) {
+            .page-wrapper {
+                justify-content: center;
+                padding-top: 60px;
+                padding-bottom: 120px;
+            }
+        }
+
+        @media (max-width: 1024px) {
+            .page-wrapper {
+                padding-top: 32px;
+            }
+        }
+
+        .contact-card {
+            width: 100%;
+            max-width: 1000px;
+            background: var(--card-bg);
+            border-radius: 18px;
+            padding: 48px 56px 56px;
+            box-shadow: var(--shadow-top);
+        }
+
+        @media (max-width: 768px) {
+            .contact-card {
+                padding: 32px 24px 40px;
+                box-shadow: var(--shadow-mobile);
+            }
+        }
+
+        h1 {
+            margin: 0 0 28px;
+            font-size: clamp(2.3rem, 2.5vw + 1rem, 3rem);
+            font-weight: 700;
+            color: var(--text-color);
+            text-align: left;
+        }
+
+        form {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+
+        .field-group {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        label {
+            font-weight: 600;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .required-asterisk {
+            color: var(--error);
+            font-weight: 600;
+        }
+
+        .required-note {
+            font-size: 0.85rem;
+            color: var(--error);
+            margin: 0;
+        }
+
+        input[type="text"],
+        input[type="email"],
+        input[type="url"],
+        select,
+        textarea {
+            width: 100%;
+            padding: 12px 14px;
+            border-radius: 10px;
+            border: 1px solid var(--border-color);
+            background: #ffffff;
+            font-size: 1rem;
+            transition: border-color 180ms ease, box-shadow 180ms ease;
+            color: var(--text-color);
+        }
+
+        input[type="text"]:focus,
+        input[type="email"]:focus,
+        input[type="url"]:focus,
+        textarea:focus {
+            border-color: var(--accent-focus);
+            box-shadow: 0 0 0 3px rgba(56, 163, 160, 0.15);
+            outline: none;
+        }
+
+        select:focus {
+            outline: none;
+        }
+
+        textarea {
+            min-height: 140px;
+            resize: none;
+        }
+
+        textarea::placeholder {
+            color: rgba(28, 39, 51, 0.55);
+        }
+
+        .subject-wrapper {
+            position: relative;
+            display: flex;
+            align-items: center;
+        }
+
+        .subject-wrapper select {
+            appearance: none;
+            -moz-appearance: none;
+            -webkit-appearance: none;
+            padding-right: 44px;
+        }
+
+        .chevron {
+            position: absolute;
+            right: 16px;
+            pointer-events: none;
+            font-size: 1.1rem;
+            color: #9099a4;
+            transition: transform 0ms;
+        }
+
+        .chevron.up {
+            transform: rotate(180deg);
+        }
+
+        .subject-panel {
+            border: 2px solid #d3d9e1;
+            border-radius: 14px;
+            background: var(--accordion-bg);
+            padding: 20px 20px 24px;
+            overflow: hidden;
+            max-height: 0;
+            opacity: 0;
+            margin: 0;
+            transition: max-height var(--transition-duration) ease, opacity 120ms ease;
+        }
+
+        .subject-panel.active {
+            margin-top: 8px;
+            margin-bottom: 4px;
+            max-height: 800px;
+            opacity: 1;
+        }
+
+        .subject-panel .field-group {
+            margin-bottom: 16px;
+        }
+
+        .inline-error {
+            color: var(--error);
+            font-size: 0.9rem;
+            margin: 4px 0 0;
+            display: none;
+        }
+
+        .inline-error.visible {
+            display: block;
+        }
+
+        .checkbox-block {
+            background: var(--checkbox-bg);
+            border-radius: 14px;
+            padding: 18px 20px;
+            display: flex;
+            flex-direction: column;
+            gap: 14px;
+        }
+
+        .checkbox-item {
+            display: flex;
+            align-items: flex-start;
+            gap: 10px;
+            font-size: 1rem;
+        }
+
+        .checkbox-item input[type="checkbox"] {
+            margin-top: 4px;
+        }
+
+        .privacy-note {
+            font-size: 0.88rem;
+            line-height: 1.5;
+            color: var(--text-color);
+        }
+
+        .privacy-note a {
+            text-decoration: underline;
+        }
+
+        .actions {
+            display: flex;
+            justify-content: flex-end;
+        }
+
+        .actions button {
+            padding: 12px 32px;
+            font-size: 1rem;
+            border-radius: 12px;
+            border: none;
+            cursor: pointer;
+            background-image: linear-gradient(135deg, var(--button-gradient-start), var(--button-gradient-end));
+            color: #ffffff;
+            font-weight: 600;
+            transition: transform 160ms ease, box-shadow 160ms ease, background-image 160ms ease;
+        }
+
+        .actions button:hover,
+        .actions button:focus {
+            background-image: linear-gradient(135deg, var(--button-gradient-hover-start), var(--button-gradient-hover-end));
+        }
+
+        .actions button:focus {
+            outline: 3px solid rgba(47, 156, 116, 0.35);
+        }
+
+        @media (max-width: 600px) {
+            .actions button {
+                width: 100%;
+            }
+            .actions {
+                justify-content: center;
+            }
+        }
+
+        .divider {
+            margin: 24px 0 16px;
+            border: 0;
+            border-top: 1px solid #d7dce3;
+        }
+
+        .form-status {
+            text-align: center;
+            font-size: 1.02rem;
+            font-weight: 600;
+            min-height: 1.2em;
+            color: var(--accent);
+        }
+
+        .form-status.error {
+            color: var(--error);
+        }
+
+        .captcha-wrapper {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+
+        .captcha-error {
+            color: var(--error);
+            font-size: 0.9rem;
+            display: none;
+        }
+
+        .captcha-error.visible {
+            display: block;
+        }
+
+        .hidden {
+            display: none !important;
+        }
+
+        @media (min-width: 1440px) {
+            .contact-card {
+                padding: 56px 64px 64px;
+            }
+        }
+    </style>
+</head>
+<body>
+    <!-- // Include site nav here (non-sticky, as on other pages) -->
+    <main class="page-wrapper">
+        <section class="contact-card">
+            <h1>Contact &amp; Feedback</h1>
+            <!-- TODO: Insert your Formspree endpoint in the form action attribute below -->
+            <form id="contactForm" method="POST" action="https://formspree.io/f/XXXXXXXX">
+                <div class="field-group">
+                    <label for="name">Name <span class="required-asterisk">*</span></label>
+                    <p class="required-note">*Required</p>
+                    <input type="text" id="name" name="name" autocomplete="name" required />
+                </div>
+
+                <div class="field-group">
+                    <label for="email">Email <span class="required-asterisk">*</span></label>
+                    <p class="required-note">*Required</p>
+                    <input type="email" id="email" name="email" autocomplete="email" required />
+                </div>
+
+                <div class="field-group">
+                    <label for="subject">Subject <span class="required-asterisk">*</span></label>
+                    <p class="required-note">*Required</p>
+                    <div class="subject-wrapper">
+                        <select id="subject" name="subject" required>
+                            <option value="">Select one…</option>
+                            <option value="Recommend a Fish">Recommend a Fish</option>
+                            <option value="Logic Issues">Logic Issues</option>
+                            <option value="Questions?">Questions?</option>
+                            <option value="Product Reviews">Product Reviews</option>
+                            <option value="General (YouTube, article ideas, events, forums, anything related to aquariums)">General (YouTube, article ideas, events, forums, anything related to aquariums)</option>
+                        </select>
+                        <span class="chevron" aria-hidden="true">⌄</span>
+                    </div>
+                </div>
+
+                <div class="subject-panel" id="panel-recommend">
+                    <div class="field-group">
+                        <label for="fishName">Fish Name <span class="required-asterisk">*</span></label>
+                        <p class="required-note">*Required</p>
+                        <input type="text" id="fishName" name="fishName" />
+                        <p class="inline-error" id="fishNameError">Please provide a fish name.</p>
+                    </div>
+                    <div class="field-group">
+                        <label for="scientificName">Scientific Name</label>
+                        <input type="text" id="scientificName" name="scientificName" />
+                    </div>
+                    <div class="field-group">
+                        <label for="phTempRange">pH / Temp Range</label>
+                        <input type="text" id="phTempRange" name="phTempRange" />
+                    </div>
+                    <div class="field-group">
+                        <label for="fishNotes">Other Notes</label>
+                        <textarea id="fishNotes" name="fishNotes"></textarea>
+                    </div>
+                </div>
+
+                <div class="subject-panel" id="panel-logic">
+                    <div class="field-group">
+                        <label for="logicPage">Page Selector</label>
+                        <select id="logicPage" name="logicPage">
+                            <option value="Stocking Advisor">Stocking Advisor</option>
+                            <option value="Cycling Coach">Cycling Coach</option>
+                            <option value="Parameters">Parameters</option>
+                            <option value="Media">Media</option>
+                            <option value="Contact &amp; Feedback">Contact &amp; Feedback</option>
+                        </select>
+                    </div>
+                    <div class="field-group">
+                        <label for="logicIssue">Describe the Issue</label>
+                        <textarea id="logicIssue" name="logicIssue"></textarea>
+                    </div>
+                </div>
+
+                <div class="subject-panel" id="panel-questions">
+                    <div class="field-group">
+                        <label for="generalQuestion">Your Question</label>
+                        <textarea id="generalQuestion" name="generalQuestion" placeholder="Ask us anything — we’ll get back to you."></textarea>
+                    </div>
+                </div>
+
+                <div class="subject-panel" id="panel-reviews">
+                    <div class="field-group">
+                        <label for="productName">Product Name <span class="required-asterisk">*</span></label>
+                        <p class="required-note">*Required</p>
+                        <input type="text" id="productName" name="productName" />
+                        <p class="inline-error" id="productNameError">Please provide the product name.</p>
+                    </div>
+                    <div class="field-group">
+                        <label for="productLink">Product Link</label>
+                        <input type="url" id="productLink" name="productLink" />
+                    </div>
+                    <div class="field-group">
+                        <label for="productCoverage">What would you like us to cover?</label>
+                        <textarea id="productCoverage" name="productCoverage" placeholder="Features, pros/cons, ease of use, etc."></textarea>
+                    </div>
+                </div>
+
+                <div class="subject-panel" id="panel-general">
+                    <div class="field-group">
+                        <label for="generalIdeas">Share Your Ideas</label>
+                        <textarea id="generalIdeas" name="generalIdeas" placeholder="Share your idea — YouTube, article, event, forum, or anything aquarium related."></textarea>
+                    </div>
+                </div>
+
+                <div class="checkbox-block" role="group" aria-labelledby="consentHeading">
+                    <div class="field-group">
+                        <label id="consentHeading">Stay in touch</label>
+                    </div>
+                    <label class="checkbox-item" for="consent">
+                        <input type="checkbox" id="consent" name="consent" required />
+                        <span>I agree that The Tank Guide may contact me about my submission.</span>
+                    </label>
+                    <label class="checkbox-item" for="newsletter">
+                        <input type="checkbox" id="newsletter" name="newsletter" />
+                        <span>Yes, I’d like to receive The Tank Guide newsletter/updates.</span>
+                    </label>
+                    <p class="privacy-note">
+                        We value your privacy. Your information will never be sold to third parties. We’ll use it only to reply to your message and—if you opt in—to send occasional newsletters. You can unsubscribe anytime. See our <a href="https://thetankguide.com/privacy.html">Privacy Policy</a>.
+                    </p>
+                </div>
+
+                <div class="captcha-wrapper">
+                    <!-- TODO: Insert your reCAPTCHA v2 SITE KEY in the data-sitekey attribute below -->
+                    <div class="g-recaptcha" data-sitekey="YOUR_RECAPTCHA_SITE_KEY"></div>
+                    <p class="captcha-error" id="captchaError">Please confirm you’re not a robot.</p>
+                </div>
+
+                <input type="text" id="honeypot" name="honeypot" class="hidden" autocomplete="off" tabindex="-1" aria-hidden="true" />
+                <input type="hidden" name="_subject" id="hiddenSubject" />
+                <input type="hidden" name="timestamp" id="timestamp" />
+
+                <div class="actions">
+                    <button type="submit" id="submitButton">Send</button>
+                </div>
+                <hr class="divider" />
+                <p class="form-status" id="formStatus" aria-live="polite"></p>
+            </form>
+        </section>
+    </main>
+    <!-- // Include footer.html here when integrating with the site build -->
+
+    <script src="https://www.google.com/recaptcha/api.js" async defer></script>
+    <script>
+        (function () {
+            const subjectSelect = document.getElementById('subject');
+            const panels = {
+                'Recommend a Fish': document.getElementById('panel-recommend'),
+                'Logic Issues': document.getElementById('panel-logic'),
+                'Questions?': document.getElementById('panel-questions'),
+                'Product Reviews': document.getElementById('panel-reviews'),
+                'General (YouTube, article ideas, events, forums, anything related to aquariums)': document.getElementById('panel-general')
+            };
+            const chevron = document.querySelector('.chevron');
+            const form = document.getElementById('contactForm');
+            const formStatus = document.getElementById('formStatus');
+            const fishNameInput = document.getElementById('fishName');
+            const fishNameError = document.getElementById('fishNameError');
+            const productNameInput = document.getElementById('productName');
+            const productNameError = document.getElementById('productNameError');
+            const hiddenSubject = document.getElementById('hiddenSubject');
+            const timestampField = document.getElementById('timestamp');
+            const captchaError = document.getElementById('captchaError');
+            const textareas = Array.from(document.querySelectorAll('textarea'));
+
+            function closeAllPanels() {
+                Object.values(panels).forEach(panel => {
+                    panel.classList.remove('active');
+                });
+            }
+
+            function openPanel(value) {
+                closeAllPanels();
+                const panel = panels[value];
+                if (panel) {
+                    panel.classList.add('active');
+                    chevron.classList.add('up');
+                } else {
+                    chevron.classList.remove('up');
+                }
+            }
+
+            subjectSelect.addEventListener('change', () => {
+                const value = subjectSelect.value;
+                openPanel(value);
+                hiddenSubject.value = value ? `[Contact & Feedback] – ${value}` : '';
+            });
+
+            function autoResizeTextarea(el) {
+                el.style.height = 'auto';
+                el.style.height = `${el.scrollHeight + 2}px`;
+            }
+
+            textareas.forEach(textarea => {
+                autoResizeTextarea(textarea);
+                textarea.addEventListener('input', () => autoResizeTextarea(textarea));
+            });
+
+            function validateDynamicFields() {
+                let valid = true;
+                if (subjectSelect.value === 'Recommend a Fish') {
+                    if (!fishNameInput.value.trim()) {
+                        fishNameError.classList.add('visible');
+                        fishNameInput.setAttribute('aria-invalid', 'true');
+                        valid = false;
+                    } else {
+                        fishNameError.classList.remove('visible');
+                        fishNameInput.removeAttribute('aria-invalid');
+                    }
+                } else {
+                    fishNameError.classList.remove('visible');
+                    fishNameInput.removeAttribute('aria-invalid');
+                }
+
+                if (subjectSelect.value === 'Product Reviews') {
+                    if (!productNameInput.value.trim()) {
+                        productNameError.classList.add('visible');
+                        productNameInput.setAttribute('aria-invalid', 'true');
+                        valid = false;
+                    } else {
+                        productNameError.classList.remove('visible');
+                        productNameInput.removeAttribute('aria-invalid');
+                    }
+                } else {
+                    productNameError.classList.remove('visible');
+                    productNameInput.removeAttribute('aria-invalid');
+                }
+
+                return valid;
+            }
+
+            function resetDynamicErrors() {
+                fishNameError.classList.remove('visible');
+                fishNameInput.removeAttribute('aria-invalid');
+                productNameError.classList.remove('visible');
+                productNameInput.removeAttribute('aria-invalid');
+                captchaError.classList.remove('visible');
+            }
+
+            function clearForm() {
+                form.reset();
+                closeAllPanels();
+                chevron.classList.remove('up');
+                hiddenSubject.value = '';
+                timestampField.value = '';
+                textareas.forEach(textarea => {
+                    textarea.style.height = '';
+                    autoResizeTextarea(textarea);
+                });
+                if (window.grecaptcha) {
+                    grecaptcha.reset();
+                }
+            }
+
+            form.addEventListener('submit', async (event) => {
+                event.preventDefault();
+                resetDynamicErrors();
+
+                if (!validateDynamicFields()) {
+                    return;
+                }
+
+                if (!subjectSelect.value) {
+                    subjectSelect.focus();
+                    return;
+                }
+
+                const honeypot = document.getElementById('honeypot');
+                if (honeypot.value) {
+                    return;
+                }
+
+                const captchaResponse = grecaptcha.getResponse();
+                if (!captchaResponse) {
+                    captchaError.classList.add('visible');
+                    return;
+                }
+
+                captchaError.classList.remove('visible');
+
+                const subjectValue = subjectSelect.value;
+                hiddenSubject.value = subjectValue ? `[Contact & Feedback] – ${subjectValue}` : '';
+                timestampField.value = new Date().toLocaleString();
+
+                const formData = new FormData(form);
+
+                try {
+                    const response = await fetch(form.action, {
+                        method: 'POST',
+                        body: formData,
+                        headers: {
+                            'Accept': 'application/json'
+                        }
+                    });
+
+                    if (response.ok) {
+                        formStatus.textContent = 'Thank you — message sent. Please check your inbox (and spam folder just in case) for our reply.';
+                        formStatus.classList.remove('error');
+                        clearForm();
+                    } else {
+                        throw new Error('Network response was not ok');
+                    }
+                } catch (error) {
+                    formStatus.textContent = 'Sorry — your message could not be sent. Please try again later.';
+                    formStatus.classList.add('error');
+                }
+            });
+
+            form.addEventListener('input', (event) => {
+                if (event.target === fishNameInput && fishNameError.classList.contains('visible')) {
+                    if (fishNameInput.value.trim()) {
+                        fishNameError.classList.remove('visible');
+                        fishNameInput.removeAttribute('aria-invalid');
+                    }
+                }
+                if (event.target === productNameInput && productNameError.classList.contains('visible')) {
+                    if (productNameInput.value.trim()) {
+                        productNameError.classList.remove('visible');
+                        productNameInput.removeAttribute('aria-invalid');
+                    }
+                }
+            });
+        })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create dedicated Contact & Feedback page with gradient backdrop and responsive card layout
- implement dynamic subject-driven accordion fields with validation and auto-resizing textareas
- add Formspree-ready submission flow including reCAPTCHA integration, hidden metadata, and inline success/error handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5b3a5877c8332aeacba34781d13f9