### PR TITLE
Add nav and tighten contact form spacing

### DIFF
--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -5,6 +5,8 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Contact &amp; Feedback | The Tank Guide</title>
+    <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+    <script defer src="js/nav.js?v=1.0.8"></script>
     <style>
         :root {
             --background-dark: #0f1c2c;
@@ -27,6 +29,9 @@
             --gap-tight: 12px;
             --gap-subject: 14px;
             --gap-between: 16px;
+            --gap-xxs: 6px;
+            --gap-xs: 8px;
+            --gap-s: 10px;
         }
 
         * {
@@ -216,35 +221,39 @@
         }
 
         .js-spacing-state .stay-in-touch {
-            margin-top: var(--gap-subject);
+            margin-top: var(--gap-xs) !important;
         }
 
-        .accordion-panel {
-            margin-top: var(--gap-tight);
-        }
-
-        .accordion-panel:not(.active) {
-            margin-top: 0;
-        }
-
-        .js-spacing-state.has-subject .stay-in-touch {
-            margin-top: var(--gap-between);
-        }
-
+        .accordion-panel,
         #panel-fish,
         #panel-logic,
         #panel-questions,
         #panel-reviews,
         #panel-general {
-            margin-top: var(--gap-tight);
+            margin-top: var(--gap-xs) !important;
         }
 
+        .accordion-panel:not(.active),
         #panel-fish:not(.active),
         #panel-logic:not(.active),
         #panel-questions:not(.active),
         #panel-reviews:not(.active),
         #panel-general:not(.active) {
+            margin-top: 0 !important;
+        }
+
+        .js-spacing-state.has-subject .stay-in-touch {
+            margin-top: var(--gap-s) !important;
+        }
+
+        .form-card .field,
+        .form-card .group,
+        .stay-in-touch {
             margin-top: 0;
+        }
+
+        .stay-in-touch {
+            padding-top: 12px;
         }
 
         .subject-panel .field-group {
@@ -374,7 +383,53 @@
     </style>
 </head>
 <body>
-    <!-- // Include site nav here (non-sticky, as on other pages) -->
+    <header id="global-nav">
+        <div class="inner">
+            <button
+                id="ttg-nav-open"
+                class="hamburger"
+                type="button"
+                aria-controls="ttg-drawer"
+                aria-expanded="false"
+                aria-label="Open menu"
+                data-nav="hamburger"
+            >
+                <span class="hamburger__bars" aria-hidden="true"></span>
+                <span class="visually-hidden">Open menu</span>
+            </button>
+            <a class="site-brand brand" href="index.html" aria-label="The Tank Guide — Home">
+                <span class="site-brand__title">The Tank Guide</span>
+                <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
+            </a>
+            <nav class="site-links links" aria-label="Primary">
+                <a href="index.html" class="nav__link">Home</a>
+                <a href="stocking.html" class="nav__link">Stocking Advisor</a>
+                <a href="gear.html" class="nav__link">Gear</a>
+                <a href="params.html" class="nav__link">Cycling Coach</a>
+                <a href="media.html" class="nav__link">Media</a>
+                <a href="contact-feedback.html" class="nav__link">Contact &amp; Feedback</a>
+                <a href="about.html" class="nav__link">About</a>
+            </nav>
+        </div>
+        <aside id="ttg-drawer" aria-label="Site" data-nav="drawer" aria-hidden="true">
+            <div class="drawer-head">
+                <span class="drawer-title">The Tank Guide</span>
+                <button id="ttg-nav-close" class="drawer-close" type="button" aria-label="Close menu">
+                    <span aria-hidden="true">×</span>
+                </button>
+            </div>
+            <nav class="drawer-links" aria-label="Mobile">
+                <a href="index.html" class="nav__link">Home</a>
+                <a href="stocking.html" class="nav__link">Stocking Advisor</a>
+                <a href="gear.html" class="nav__link">Gear</a>
+                <a href="params.html" class="nav__link">Cycling Coach</a>
+                <a href="media.html" class="nav__link">Media</a>
+                <a href="contact-feedback.html" class="nav__link" target="_blank" rel="noopener">Feedback</a>
+                <a href="about.html" class="nav__link">About</a>
+            </nav>
+        </aside>
+        <div id="ttg-overlay" data-nav="overlay" aria-hidden="true"></div>
+    </header>
     <main class="page-wrapper">
         <section class="contact-card">
             <h1>Contact &amp; Feedback</h1>
@@ -704,6 +759,11 @@
                 }
             });
         })();
+    </script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            window.ttgInitNav?.();
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed the global navigation on the contact feedback page and initialize it with the shared nav script
- tighten subject panel and stay-in-touch spacing with new spacing variables and rules to keep elements closely grouped

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5c4c5a81483328789c54445ce34a9