### PR TITLE
Fix Stay-in-touch card spacing regression

### DIFF
--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -96,9 +96,53 @@
     .panel.active{margin-top:6px; max-height:1000px; opacity:1}
     .panel .field-group{margin:0 0 16px}
 
-    /* --- spacing logic around Stay in touch --- */
-    #feedbackForm:not(.has-subject) #stay-in-touch{ margin-top:6px }       /* when empty, hug subject */
-    #feedbackForm.has-subject #stay-in-touch{ margin-top:10px }            /* when panel is open, small gap */
+    :root{
+      --gap-under-subject-when-empty: 6px;
+      --gap-after-panel: 10px;
+    }
+
+    /* Kill extra bottom space on the Subject group itself */
+    #feedbackForm .subject-group{ margin-bottom: 0 !important; }
+    #feedbackForm .subject-group .required-note{ margin-bottom: 0 !important; }
+    /* Subject control: ensure we can apply a small bottom gap reliably */
+    #feedbackForm #subject{
+      margin-bottom: var(--gap-under-subject-when-empty) !important;
+      display: block; /* to make margin-bottom consistent across browsers */
+    }
+
+    /* Collapsed panels: occupy ZERO space */
+    #feedbackForm .panel{
+      padding: 0 !important;
+      border-width: 0 !important;
+      margin: 0 !important;
+      max-height: 0 !important;
+      opacity: 0 !important;
+      overflow: hidden !important;
+    }
+    /* Open panel: restore look and add a tight top margin under Subject */
+    #feedbackForm .panel.active{
+      padding: 20px 20px 24px !important;
+      border-width: 2px !important;
+      margin-top: 6px !important;
+      max-height: 1000px !important;
+      opacity: 1 !important;
+    }
+
+    /* Stay-in-touch baseline: remove any inherent top margin; we control it below */
+    #feedbackForm #stay-in-touch{
+      margin-top: 0 !important;
+    }
+
+    /* STATE-CONTROLLED SPACING
+       The form gets .has-subject when the Subject select has a value.
+       When NO subject -> hug the Subject (6px).
+       When HAS subject -> sit after the open panel with a small gap (10px). */
+    #feedbackForm.js-spacing-state:not(.has-subject) #stay-in-touch{
+      margin-top: var(--gap-under-subject-when-empty) !important;
+    }
+    #feedbackForm.js-spacing-state.has-subject #stay-in-touch{
+      margin-top: var(--gap-after-panel) !important;
+    }
 
     /* --- stay in touch (bulletproof) --- */
     #stay-in-touch{
@@ -401,6 +445,20 @@
       const formStatus = document.getElementById('formStatus');
       const captchaError = document.getElementById('captchaError');
 
+      // Ensure the form carries the spacing state class and toggles based on subject value
+      if (form && !form.classList.contains('js-spacing-state')) {
+        form.classList.add('js-spacing-state');
+      }
+
+      function syncSubjectState(){
+        if (!form || !subjectSelect) return;
+        const has = subjectSelect.value && subjectSelect.value.trim() !== '';
+        form.classList.toggle('has-subject', has);
+      }
+
+      syncSubjectState();
+      subjectSelect?.addEventListener('change', syncSubjectState);
+
       const panels = {
         'Recommend a Fish': document.getElementById('panel-fish'),
         'Logic Issues': document.getElementById('panel-logic'),
@@ -414,7 +472,6 @@
       const productNameInput = document.getElementById('productName');
       const productNameError = document.getElementById('productNameError');
 
-      function setHasSubject(flag){ form.classList.toggle('has-subject', !!flag); }
       function closeAll(){ Object.values(panels).forEach(p=>p.classList.remove('active')); }
       function openPanel(val){ closeAll(); if(panels[val]) panels[val].classList.add('active'); }
 
@@ -422,7 +479,6 @@
         const v = subjectSelect.value;
         openPanel(v);
         hiddenSubject.value = v ? `[Contact & Feedback] – ${v}` : '';
-        setHasSubject(!!v);
       });
 
       function validateDynamic(){
@@ -497,7 +553,7 @@
           const r = await fetch(form.action, { method:'POST', body:fd, headers:{Accept:'application/json'} });
           if(!r.ok) throw new Error('Network');
           formStatus.textContent='Thank you — message sent. Please check your inbox (and spam folder just in case) for our reply.';
-          form.reset(); closeAll(); setHasSubject(false); syncPills(); hiddenSubject.value=''; timestampField.value='';
+          form.reset(); closeAll(); syncSubjectState(); syncPills(); hiddenSubject.value=''; timestampField.value='';
           grecaptcha.reset?.();
         }catch(err){
           formStatus.textContent='Sorry — your message could not be sent. Please try again later.';


### PR DESCRIPTION
## Summary
- tighten the inline CSS so the Subject control, panels, and Stay-in-touch card use explicit gaps with collapsed panels taking no space
- neutralize extra margins inside the Subject group to prevent stray spacing
- add a JS subject-state sync that adds the required classes for spacing control when the Subject value changes

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5f98c9cd48332997743fccdab5b78