### PR TITLE
Refine privacy and legal accordion layout

### DIFF
--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -1,0 +1,563 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy &amp; Legal | The Tank Guide • FishKeepingLifeCo</title>
+  <meta name="description" content="Read The Tank Guide’s Privacy & Legal Policy, including privacy practices, cookies &amp; tracking, affiliate disclosures, DMCA, and terms of use. Updated September 2025." />
+  <meta name="robots" content="index,follow" />
+  <link rel="canonical" href="https://thetankguide.com/privacy-legal.html" />
+  <meta property="og:title" content="Privacy &amp; Legal | The Tank Guide • FishKeepingLifeCo" />
+  <meta property="og:description" content="Read The Tank Guide’s Privacy & Legal Policy, including privacy practices, cookies &amp; tracking, affiliate disclosures, DMCA, and terms of use. Updated September 2025." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://thetankguide.com/privacy-legal.html" />
+  <meta property="og:image" content="https://thetankguide.com/logo.png" />
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Privacy &amp; Legal | The Tank Guide • FishKeepingLifeCo" />
+  <meta name="twitter:description" content="Read The Tank Guide’s Privacy & Legal Policy, including privacy practices, cookies &amp; tracking, affiliate disclosures, DMCA, and terms of use. Updated September 2025." />
+  <meta name="twitter:image" content="https://thetankguide.com/logo.png" />
+  <link rel="icon" href="/favicon.ico" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.9" />
+  <script defer src="js/nav.js?v=1.0.9"></script>
+  <style>
+    :root {
+      color-scheme: dark;
+    }
+
+    *, *::before, *::after {
+      box-sizing: border-box;
+    }
+
+    html, body {
+      margin: 0;
+      min-height: 100%;
+      font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+      background:
+        radial-gradient(circle at 18% 22%, rgba(72, 122, 200, 0.22), rgba(10, 15, 30, 0.95) 62%),
+        linear-gradient(180deg, #03050b 0%, #101423 38%, #181b28 100%);
+      background-attachment: fixed;
+      color: rgba(255, 255, 255, 0.9);
+      line-height: 1.65;
+      font-size: 16px;
+    }
+
+    @media (min-width: 768px) {
+      html, body {
+        font-size: 18px;
+      }
+    }
+
+    a {
+      color: #bcd2ff;
+      text-decoration: none;
+      transition: color 0.2s ease, text-decoration-color 0.2s ease;
+    }
+
+    a:hover,
+    a:focus {
+      text-decoration: underline;
+      text-decoration-color: rgba(188, 210, 255, 0.85);
+    }
+
+    a:focus-visible {
+      outline: 2px solid rgba(188, 210, 255, 0.85);
+      outline-offset: 3px;
+    }
+
+    body > .skip-link {
+      position: absolute;
+      top: -40px;
+      left: 16px;
+      padding: 8px 14px;
+      background: rgba(25, 32, 48, 0.95);
+      color: #ffffff;
+      border-radius: 6px;
+      z-index: 1000;
+      transition: top 0.2s ease;
+    }
+
+    body > .skip-link:focus {
+      top: 12px;
+    }
+
+    main {
+      padding: 32px 16px 96px;
+      display: flex;
+      justify-content: center;
+    }
+
+    .page-wrapper {
+      width: 100%;
+      max-width: 900px;
+      margin: 48px auto;
+      padding: 32px 24px;
+      background: rgba(20, 20, 20, 0.7);
+      border: 1px solid rgba(192, 192, 192, 0.9);
+      border-radius: 12px;
+      backdrop-filter: blur(6px);
+      box-shadow: 0 30px 60px rgba(2, 4, 12, 0.35);
+    }
+
+    @media (min-width: 768px) {
+      .page-wrapper {
+        padding: 40px 32px 48px;
+      }
+    }
+
+    h1, h2, h3 {
+      color: #ffffff;
+      margin-top: 0;
+    }
+
+    h1 {
+      font-size: clamp(2.1rem, 2vw + 1.5rem, 3rem);
+      margin-bottom: 0.75em;
+      text-align: left;
+    }
+
+    h2 {
+      font-size: clamp(1.45rem, 1.4vw + 1rem, 2.05rem);
+      margin-bottom: 0.75em;
+    }
+
+    h3 {
+      font-size: clamp(1.15rem, 1vw + 0.85rem, 1.55rem);
+      margin-top: 1.8em;
+      margin-bottom: 0.6em;
+    }
+
+    p {
+      margin-top: 0;
+      margin-bottom: 1.1em;
+    }
+
+    ul {
+      padding-left: 1.25em;
+      margin: 0 0 1.2em;
+    }
+
+    li {
+      margin-bottom: 0.6em;
+    }
+
+    strong {
+      color: rgba(255, 255, 255, 0.96);
+    }
+
+    hr {
+      border: none;
+      border-top: 1px solid rgba(192, 192, 192, 0.4);
+      margin: 2em 0;
+    }
+
+    .intro-text {
+      margin-bottom: 1.8em;
+    }
+
+    .accordion-heading {
+      font-size: 1.1rem;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.75);
+      margin-bottom: 1rem;
+    }
+
+    .accordion {
+      border: 1px solid rgba(192, 192, 192, 0.35);
+      border-radius: 10px;
+      background: rgba(15, 17, 24, 0.7);
+      overflow: hidden;
+    }
+
+    .accordion details + details {
+      border-top: 1px solid rgba(192, 192, 192, 0.28);
+    }
+
+    details {
+      padding: 0;
+    }
+
+    summary {
+      list-style: none;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      width: 100%;
+      padding: 20px 24px;
+      font-size: 1.1rem;
+      font-weight: 600;
+      color: #ffffff;
+      transition: background-color 0.2s ease;
+    }
+
+    summary::-webkit-details-marker {
+      display: none;
+    }
+
+    summary::after {
+      content: "";
+      flex-shrink: 0;
+      width: 12px;
+      height: 12px;
+      border: 2px solid rgba(188, 210, 255, 0.9);
+      border-top: 0;
+      border-left: 0;
+      transform: rotate(45deg);
+      transition: transform 0.2s ease;
+    }
+
+    details[open] summary::after {
+      transform: rotate(-135deg);
+    }
+
+    summary:focus-visible {
+      outline: 2px solid rgba(188, 210, 255, 0.85);
+      outline-offset: -4px;
+    }
+
+    summary:hover {
+      background: rgba(188, 210, 255, 0.08);
+    }
+
+    details[open] summary {
+      background: rgba(188, 210, 255, 0.08);
+    }
+
+    .details-body {
+      padding: 0 24px 24px;
+    }
+
+    .details-body h2 {
+      margin-top: 1.4em;
+    }
+
+    .details-body h2:first-of-type {
+      margin-top: 0;
+    }
+
+    .last-updated {
+      margin-top: 2.8em;
+      font-size: 0.95rem;
+      color: rgba(255, 255, 255, 0.65);
+    }
+
+    @media (max-width: 599px) {
+      summary {
+        padding: 18px 20px;
+        font-size: 1.05rem;
+      }
+
+      .details-body {
+        padding: 0 20px 22px;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      summary,
+      summary::after,
+      a {
+        transition: none;
+      }
+    }
+
+    @media print {
+      body {
+        background: #ffffff !important;
+        color: #000000 !important;
+      }
+
+      .page-wrapper {
+        background: transparent;
+        border: none;
+        box-shadow: none;
+        margin: 0;
+        padding: 0;
+      }
+
+      .accordion {
+        border: none;
+        background: transparent;
+      }
+
+      summary {
+        display: none;
+      }
+
+      details {
+        border: none !important;
+      }
+
+      details .details-body {
+        padding: 0 0 16px;
+      }
+    }
+  </style>
+
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  "name": "FishKeepingLifeCo",
+  "url": "https://thetankguide.com",
+  "logo": "https://thetankguide.com/logo.png",
+  "image": "https://thetankguide.com/logo.png",
+  "foundingLocation": "United States, New York",
+  "sameAs": [
+    "https://www.instagram.com/fishkeepinglifeco/",
+    "https://youtube.com/@fishkeepinglifeco"
+  ]
+}
+  </script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to content</a>
+  <div id="site-nav"></div>
+
+  <main id="main-content">
+    <article class="page-wrapper">
+      <h1>Privacy &amp; Legal</h1>
+      <p class="intro-text">This page explains how <strong>FishKeepingLifeCo</strong> (“we,” “our,” or “us”) handles your information, our affiliate relationships, and the terms of using <strong>TheTankGuide.com</strong>. By using this site, you agree to the policies and terms described here.</p>
+
+      <hr />
+
+      <h2 class="accordion-heading">On this page</h2>
+      <div class="accordion" aria-label="Privacy and legal sections">
+        <details id="privacy-policy">
+          <summary><span>Privacy Policy</span></summary>
+          <div class="details-body">
+            <h2>Privacy Policy</h2>
+            <h3>Information We Collect</h3>
+            <ul>
+              <li><strong>Contact Forms:</strong> If you contact us through a form, we collect the details you provide (name, email, and your message).</li>
+              <li><strong>Basic Logs:</strong> Our hosting service may automatically record basic technical data (like IP address, browser type, and pages visited) for performance and security.</li>
+              <li><strong>Future Features:</strong> If we add a newsletter or analytics, we may collect your email and engagement information with your consent.</li>
+            </ul>
+            <h3>How We Use Information</h3>
+            <ul>
+              <li>To respond to inquiries and provide support.</li>
+              <li>To operate and improve our website.</li>
+              <li>To detect, prevent, and address technical issues or misuse.</li>
+              <li>To comply with legal requirements.</li>
+            </ul>
+            <h3>Retention</h3>
+            <p>We keep personal data only as long as necessary to fulfill the purposes described above, unless a longer retention period is required by law. Contact form submissions are deleted upon request.</p>
+            <h3>Sharing &amp; Disclosure</h3>
+            <p>We do <strong>not sell</strong> your personal information. We only share limited information with service providers (such as hosting or email providers) who help us operate this site.</p>
+            <h3>Security</h3>
+            <p>We use reasonable safeguards to protect information, but no method of storage or transmission is 100% secure.</p>
+            <h3>Your Rights</h3>
+            <p>You may request access to or deletion of your personal data collected through this site by emailing us at <strong>info@thetankguide.com</strong>.</p>
+            <h3>Children’s Privacy</h3>
+            <p>Our site is not directed to children under 13. If we learn that we’ve collected information from a child under 13, we will delete it.</p>
+            <h3>International Access</h3>
+            <p>Our website is operated in the United States. If you access it from outside the U.S., you consent to the transfer and processing of your information here.<br />
+            Users in the <strong>EEA/UK</strong> may have additional rights (access, correction, deletion, portability). Contact us to exercise these rights.</p>
+            <h3>State Privacy Rights</h3>
+            <p>We do not “sell” or “share” personal information as defined by California law. California residents may request more details or deletion by emailing <strong>info@thetankguide.com</strong>.</p>
+          </div>
+        </details>
+
+        <details id="cookies-tracking">
+          <summary><span>Cookies &amp; Tracking</span></summary>
+          <div class="details-body">
+            <h2>Cookies &amp; Tracking</h2>
+            <p>We may use cookies and similar technologies to:</p>
+            <ul>
+              <li>Provide essential site functions.</li>
+              <li>Understand usage through analytics (if enabled in the future).</li>
+              <li>Track affiliate referrals (e.g., when you click product links).</li>
+            </ul>
+            <p><strong>Do Not Track:</strong> Some browsers send “Do Not Track” signals. Because standards vary, we rely on cookie preference settings instead.</p>
+          </div>
+        </details>
+
+        <details id="affiliate-disclosure">
+          <summary><span>Affiliate Disclosure</span></summary>
+          <div class="details-body">
+            <h2>Affiliate Disclosure</h2>
+            <p>TheTankGuide.com participates in affiliate programs. This means we may earn a commission if you click links and make purchases.</p>
+            <ul>
+              <li><strong>Amazon Associates:</strong> As an Amazon Associate, we earn from qualifying purchases.</li>
+              <li><strong>Other Programs:</strong> We may also join other affiliate programs (such as Chewy or specialty aquarium retailers) in the future.</li>
+              <li><strong>Transparency:</strong> All product recommendations are hand-selected for quality and usefulness. Affiliate partnerships do not affect the price you pay.</li>
+            </ul>
+          </div>
+        </details>
+
+        <details id="terms-of-use">
+          <summary><span>Terms of Use</span></summary>
+          <div class="details-body">
+            <h2>Terms of Use</h2>
+            <ul>
+              <li><strong>Informational Only:</strong> Content on TheTankGuide.com is for educational and informational purposes. It is not professional advice.</li>
+              <li><strong>No Warranties:</strong> The site is provided “as is.” We make no guarantees regarding accuracy, completeness, or availability.</li>
+              <li><strong>Limitation of Liability:</strong> To the fullest extent permitted by law, FishKeepingLifeCo is not liable for damages arising from use of this site.</li>
+              <li><strong>Indemnification:</strong> By using this site, you agree to indemnify and hold us harmless from claims related to your misuse of the content.</li>
+              <li><strong>Intellectual Property:</strong> All content is owned by FishKeepingLifeCo or our licensors. You may not copy or redistribute without permission.</li>
+              <li><strong>External Links:</strong> We may link to third-party sites. We are not responsible for their content, policies, or practices.</li>
+              <li><strong>Governing Law:</strong> This Agreement is governed by the laws of New York, USA.</li>
+              <li><strong>Termination:</strong> We may suspend or terminate access to this site at any time.</li>
+              <li><strong>Severability:</strong> If any provision is held invalid, the rest remain in effect.</li>
+            </ul>
+          </div>
+        </details>
+
+        <details id="copyright-dmca">
+          <summary><span>Copyright &amp; DMCA</span></summary>
+          <div class="details-body">
+            <h2>Copyright &amp; DMCA</h2>
+            <p>All original content on this site is © FishKeepingLifeCo.</p>
+            <p>If you believe your copyrighted work appears on our site without authorization, send a DMCA notice to <strong>info@thetankguide.com</strong> including:</p>
+            <ul>
+              <li>Identification of the copyrighted work.</li>
+              <li>The URL of the material in question.</li>
+              <li>Your contact information.</li>
+              <li>A good-faith statement that use is not authorized.</li>
+              <li>A statement under penalty of perjury that your notice is accurate.</li>
+              <li>Your physical or electronic signature.</li>
+            </ul>
+          </div>
+        </details>
+
+        <details id="accessibility">
+          <summary><span>Accessibility Statement</span></summary>
+          <div class="details-body">
+            <h2>Accessibility Statement</h2>
+            <p>We are committed to making TheTankGuide.com accessible and usable for everyone. If you encounter any issues with accessibility, please contact us at <strong>info@thetankguide.com</strong> so we can improve.</p>
+          </div>
+        </details>
+
+        <details id="contact">
+          <summary><span>Contact</span></summary>
+          <div class="details-body">
+            <h2>Contact</h2>
+            <p>FishKeepingLifeCo<br />
+            info@thetankguide.com</p>
+          </div>
+        </details>
+
+        <details id="effective-date">
+          <summary><span>Effective Date</span></summary>
+          <div class="details-body">
+            <h2>Effective Date</h2>
+            <p>This Privacy &amp; Legal Policy is effective as of <strong>September 2025</strong>.<br />
+            Last updated: September 2025.</p>
+          </div>
+        </details>
+      </div>
+
+      <p class="last-updated">Last updated: September 2025</p>
+    </article>
+  </main>
+
+  <div id="site-footer"></div>
+
+  <script>
+    (async () => {
+      const host = document.getElementById('site-footer');
+      if (!host) return;
+      try {
+        const res = await fetch('footer.html?v=1.0.9', { cache: 'no-cache' });
+        if (!res.ok) throw new Error('Footer failed to load');
+        host.outerHTML = await res.text();
+      } catch (error) {
+        console.error(error);
+      }
+    })();
+  </script>
+
+  <script>
+    (() => {
+      const SECTION_IDS = [
+        'privacy-policy',
+        'cookies-tracking',
+        'affiliate-disclosure',
+        'terms-of-use',
+        'copyright-dmca',
+        'accessibility',
+        'contact',
+        'effective-date'
+      ];
+
+      const detailsElements = SECTION_IDS
+        .map((id) => document.getElementById(id))
+        .filter((el) => el instanceof HTMLDetailsElement);
+
+      const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+      const scrollToDetails = (details) => {
+        if (!(details instanceof HTMLElement)) return;
+        const behavior = prefersReducedMotion.matches ? 'auto' : 'smooth';
+        try {
+          details.scrollIntoView({ behavior, block: 'start' });
+        } catch (error) {
+          details.scrollIntoView({ block: 'start' });
+        }
+      };
+
+      const openFromHash = (hash, { scroll = true } = {}) => {
+        if (!hash) return;
+        const id = hash.replace(/^#/u, '');
+        if (!SECTION_IDS.includes(id)) return;
+        const target = document.getElementById(id);
+        if (!(target instanceof HTMLDetailsElement)) return;
+        target.open = true;
+        if (scroll) {
+          scrollToDetails(target);
+        }
+      };
+
+      const updateHash = (id) => {
+        if (typeof history.replaceState === 'function') {
+          history.replaceState(null, '', id ? `#${id}` : `${window.location.pathname}${window.location.search}`);
+        } else if (id) {
+          window.location.hash = id;
+        } else {
+          window.location.hash = '';
+        }
+      };
+
+      detailsElements.forEach((detail) => {
+        detail.addEventListener('toggle', () => {
+          if (detail.open) {
+            updateHash(detail.id);
+          } else {
+            updateHash('');
+          }
+        });
+      });
+
+      window.addEventListener('hashchange', () => {
+        openFromHash(window.location.hash, { scroll: true });
+      });
+
+      if (window.location.hash) {
+        window.requestAnimationFrame(() => {
+          openFromHash(window.location.hash, { scroll: true });
+        });
+      }
+
+      const beforePrint = () => {
+        detailsElements.forEach((detail) => {
+          detail.dataset.wasOpen = detail.open ? 'true' : 'false';
+          detail.open = true;
+        });
+      };
+
+      const afterPrint = () => {
+        detailsElements.forEach((detail) => {
+          if (detail.dataset.wasOpen !== 'true') {
+            detail.open = false;
+          }
+          delete detail.dataset.wasOpen;
+        });
+      };
+
+      window.addEventListener('beforeprint', beforePrint);
+      window.addEventListener('afterprint', afterPrint);
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- rebuild the privacy & legal page with a details-based accordion that supports hash deep links for each policy section
- maintain the dark gradient aesthetic with a frosted content card, skip link, and updated accordion styling for readability
- retain full SEO metadata, canonical link, and organization JSON-LD while loading the existing nav and footer includes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d609551a4883329626e452eded51dd