### PR TITLE
Add legal links row to footer

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -1,3 +1,35 @@
+<style>
+  #site-footer .legal-divider {
+    border: 0;
+    border-top: 1px solid rgba(192, 192, 192, 0.3);
+    margin: 20px 0 12px;
+  }
+
+  #site-footer .legal-links {
+    font-size: 0.85em;
+    color: #b5b5b5;
+    text-align: center;
+    line-height: 1.6;
+  }
+
+  #site-footer .legal-links a {
+    color: #b5b5b5;
+    text-decoration: none;
+    margin: 0 4px;
+  }
+
+  #site-footer .legal-links a:hover,
+  #site-footer .legal-links a:focus {
+    color: #e6e6e6;
+    text-decoration: underline;
+  }
+
+  @media (min-width: 768px) {
+    #site-footer .legal-links {
+      font-size: 0.9em;
+    }
+  }
+</style>
 <footer id="site-footer">
   <div class="container">
     <!-- Social strip above footer -->
@@ -39,6 +71,10 @@
 
     <div class="foot-inner">
       <p class="small">© 2025 FishkeepingLifeCo • <a href="https://thetankguide.com" target="_blank" rel="noopener">thetankguide.com</a></p>
+      <hr class="legal-divider">
+      <div class="legal-links">
+        &copy; 2025 FishKeepingLifeCo • <a href="/privacy-legal.html">Privacy &amp; Legal</a> • <a href="/privacy-legal.html#accessibility">Accessibility</a> • <a href="/contact-feedback.html">Contact</a>
+      </div>
       <p class="small">As an Amazon Associate, I earn from qualifying purchases.</p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add inline footer styling for a new legal notice row
- insert the legal links row above the Amazon disclaimer while keeping existing content intact

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d613878e248332a912d59dd26653ca