### PR TITLE
Restore homepage feature card styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@
 
     .wrap{max-width:1080px;margin:0 auto}
 
+    .visually-hidden{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}
+
     /* Brand */
     .site-brand{margin-bottom:48px;}
     .brand-name{font-weight:800;font-size:1.4rem}
@@ -47,12 +49,23 @@
     .headline{max-width:900px;font-weight:800;font-size:clamp(2rem,4vw,3.2rem);line-height:1.1;margin:40px 0 26px}
 
     /* Launch grid */
-    .grid{display:grid;gap:14px;grid-template-columns:repeat(auto-fit,minmax(250px,1fr))}
+    .features-grid{
+      display:grid;
+      grid-template-columns: repeat(3, minmax(0,1fr));
+      gap: 24px;
+    }
+    @media (max-width: 1024px){
+      .features-grid{ grid-template-columns: repeat(2, minmax(0,1fr)); }
+    }
+    @media (max-width: 640px){
+      .features-grid{ grid-template-columns: 1fr; }
+    }
+
     .card{background:var(--card-bg);border:1px solid var(--card-line);border-radius:14px;padding:16px;backdrop-filter: blur(6px);display:grid;gap:10px}
     .card h3{margin:2px 0 4px;font-size:1.1rem}
     .card p{margin:0;color:var(--muted);min-height:3.2em}
     .actions{margin-top:8px}
-    .btn{display:inline-block;padding:10px 14px;border-radius:10px;border:1px solid var(--link-line);background:var(--btn-bg);color:var(--btn-fg);font-weight:700}
+    .btn{display:inline-block;padding:10px 14px;border-radius:10px;border:1px solid var(--link-line);background:var(--btn-bg);color:var(--btn-fg);font-weight:700;text-decoration:none}
     .btn:hover{background:var(--btn-bg-hover)}
 
     /* Follow strip (if included inside footer.html, you can keep these styles here) */
@@ -139,36 +152,52 @@
       </div>
 
       <!-- Launchpad -->
-      <section aria-label="Launchpad">
-        <div class="grid">
-          <article class="card">
-            <h3>Stocking Advisor</h3>
+      <section id="features" aria-labelledby="features-title">
+        <h2 id="features-title" class="visually-hidden">Tools &amp; Sections</h2>
+        <div class="features-grid">
+          <article class="card" aria-labelledby="card-stocking-title">
+            <h3 id="card-stocking-title">Stocking Advisor</h3>
             <p>Smart stocking made simple — plan a thriving community with confidence.</p>
-            <div class="actions"><a class="btn" href="/stocking.html">Launch</a></div>
+            <div class="actions"><a class="btn" href="/stocking.html" aria-label="Open Stocking Advisor tool">Launch</a></div>
           </article>
 
-          <article class="card">
-            <h3>Gear</h3>
+          <article class="card" aria-labelledby="card-gear-title">
+            <h3 id="card-gear-title">Gear</h3>
             <p>The gear you need, matched to your tank and goals.</p>
-            <div class="actions"><a class="btn" href="/gear.html">Launch</a></div>
+            <div class="actions"><a class="btn" href="/gear.html" aria-label="Open Gear recommendations">Launch</a></div>
           </article>
 
-          <article class="card">
-            <h3>Cycling Coach</h3>
+          <article class="card" aria-labelledby="card-cycling-title">
+            <h3 id="card-cycling-title">Cycling Coach</h3>
             <p>Master the nitrogen cycle with step-by-step guidance.</p>
-            <div class="actions"><a class="btn" href="/params.html">Launch</a></div>
+            <div class="actions"><a class="btn" href="/params.html" aria-label="Open Cycling Coach tool">Launch</a></div>
           </article>
 
-          <article class="card">
-            <h3>Media</h3>
+          <article class="card" aria-labelledby="card-media-title">
+            <h3 id="card-media-title">Media</h3>
             <p>Watch • Read • Explore — videos and blogs for every aquarist.</p>
-            <div class="actions"><a class="btn" href="/media.html">Discover</a></div>
+            <div class="actions"><a class="btn" href="/media.html" aria-label="Discover Media resources">Discover</a></div>
           </article>
 
-          <article class="card">
-            <h3>About</h3>
-            <p>Discover the story behind The Tank Guide and how FishKeepingLifeCo helps aquarists thrive. We pair research-driven tools with community-backed guidance to make every tank feel achievable. Join us to see where the mission is heading.</p>
-            <div class="actions"><a class="btn" href="/about.html">Learn more</a></div>
+          <article class="card" aria-labelledby="card-about-title">
+            <h3 id="card-about-title">About</h3>
+            <p>
+              Learn who we are, our approach to guides and tools, and what’s next for The Tank Guide.
+            </p>
+            <div class="actions">
+              <a class="btn" href="/about.html" aria-label="Open About page">Learn more</a>
+            </div>
+          </article>
+
+          <article class="card" aria-labelledby="card-contact-title">
+            <h3 id="card-contact-title">Contact &amp; Feedback</h3>
+            <p>
+              Questions, ideas, or spot a logic issue? Recommend a fish, suggest a product to review, or share your insights.
+              We appreciate all feedback and information as we continue improving The Tank Guide.
+            </p>
+            <div class="actions">
+              <a class="btn" href="/contact-feedback.html" aria-label="Open Contact &amp; Feedback form">Contact Us</a>
+            </div>
           </article>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- refactor the homepage launchpad into a single accessible grid covering all six key cards
- add scoped styles so the cards share a consistent look with responsive breakpoints for desktop, tablet, and mobile
- restore the homepage card and button styling to use the site's original palette and hover states

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d611fcf5f483328c3776c6362dfd73