### PR TITLE
Replace contact reCAPTCHA placeholder with live widget

### DIFF
--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -184,7 +184,7 @@
     .form-status.error{color:var(--error)}
 
     /* --- captcha --- */
-    .captcha-wrapper{display:flex; flex-direction:column; gap:6px}
+    .captcha-wrapper{display:flex; flex-direction:column; gap:6px; margin:0 0 var(--gap-m)}
     .captcha-error{display:none; color:var(--error); font-size:.9rem}
     .captcha-error.visible{display:block}
     .hidden{display:none !important}
@@ -405,7 +405,7 @@
 
         <!-- CAPTCHA + hidden fields -->
         <div class="captcha-wrapper">
-          <div class="g-recaptcha" data-sitekey="YOUR_RECAPTCHA_SITE_KEY"></div>
+          <div class="g-recaptcha" data-sitekey="6LecjNUrAAAAACdwiRIn1KvR21x_gP8_hdOrtXA3"></div>
           <p class="captcha-error" id="captchaError">Please confirm you’re not a robot.</p>
         </div>
 


### PR DESCRIPTION
## Summary
- swap the contact form reCAPTCHA placeholder for the live widget with the production site key
- add spacing beneath the captcha block so it doesn’t crowd the send button

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d61c607d1883328a39c1ba3b2b365b