### PR TITLE
Ensure contact page reCAPTCHA markup highlights active key

### DIFF
--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -405,7 +405,8 @@
 
         <!-- CAPTCHA + hidden fields -->
         <div class="captcha-wrapper">
-          <div class="g-recaptcha" data-sitekey="6LecjNUrAAAAACdwiRIn1KvR21x_gP8_hdOrtXA3"></div>
+          <div class="g-recaptcha"
+               data-sitekey="6LecjNUrAAAAACdwiRIn1KvR21x_gP8_hdOrtXA3"></div>
           <p class="captcha-error" id="captchaError">Please confirm you’re not a robot.</p>
         </div>
 


### PR DESCRIPTION
## Summary
- split the contact page reCAPTCHA container across lines to clearly apply the live site key

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d61e2704388332b6e7ba9344509836