### PR TITLE
Add release notes for September 2025 updates

### DIFF
--- a/docs/releases/2025-09-20-amazon-associate-disclaimer.md
+++ b/docs/releases/2025-09-20-amazon-associate-disclaimer.md
@@ -1,0 +1,15 @@
+# Amazon Associate Disclaimer (Sitewide)
+
+## Summary
+- Compliance message added to footer across site.
+- Text: “As an Amazon Associate, I earn from qualifying purchases.”
+- Style: small, subtle text in footer area
+
+## Owner
+FishKeepingLifeCo (CXLXC LLC)
+
+## Date
+2025-09-20
+
+## Acceptance
+- Disclaimer present on all pages using the shared footer

--- a/docs/releases/2025-09-21-media-page-v1.md
+++ b/docs/releases/2025-09-21-media-page-v1.md
@@ -1,0 +1,16 @@
+# Media Page: Amazon Book Link + CTA + Blurb
+
+## Summary
+- Commerce link + copy polish.
+- Updated book link to: https://amzn.to/3Kh34I1
+- Button label changed from “Get the eBook” to “Buy Book On Amazon”
+- Restored/updated short blurb under the book image
+
+## Owner
+FishKeepingLifeCo (CXLXC LLC)
+
+## Date
+2025-09-21
+
+## Acceptance
+- Button label correct; link resolves; blurb visible

--- a/docs/releases/2025-09-23-homepage-v1.md
+++ b/docs/releases/2025-09-23-homepage-v1.md
@@ -1,0 +1,19 @@
+# Homepage v1 Released
+
+## Summary
+- Brand block finalized (The Tank Guide • FishKeepingLifeCo) + tagline
+- 4-card launch grid: Stocking Advisor, Gear, Cycling Coach, Media
+- Social strip (Instagram, TikTok, YouTube)
+- Footer with Amazon Associate disclaimer integrated
+- Duplicate headline removed; CSS scoped for socials
+- Status: v1 stable checkpoint for expansion (v1.1+)
+
+## Owner
+FishKeepingLifeCo (CXLXC LLC)
+
+## Date
+2025-09-23
+
+## Acceptance
+- Live at: https://thetankguide.com/
+- Visual hierarchy clean; grid + social strip present; disclaimer visible

--- a/docs/releases/2025-09-24-about-page-v1.md
+++ b/docs/releases/2025-09-24-about-page-v1.md
@@ -1,0 +1,15 @@
+# About Page Finalized
+
+## Summary
+- Visuals and link routing complete.
+- Background matches Home/Media; silver border treatment
+- “Send feedback” link points to Contact/Feedback page
+
+## Owner
+FishKeepingLifeCo (CXLXC LLC)
+
+## Date
+2025-09-24
+
+## Acceptance
+- About page renders correctly; feedback link opens `/contact-feedback.html`

--- a/docs/releases/2025-09-25-footer-links.md
+++ b/docs/releases/2025-09-25-footer-links.md
@@ -1,0 +1,15 @@
+# Footer Links: Privacy & Legal, Accessibility, Contact
+
+## Summary
+- Footer updated to include legal and contact links across the site.
+- Footer text: `© 2025 FishKeepingLifeCo • Privacy & Legal • Accessibility • Contact`
+- Links wired to their respective pages/anchors (where applicable)
+
+## Owner
+FishKeepingLifeCo (CXLXC LLC)
+
+## Date
+2025-09-25
+
+## Acceptance
+- Visible footer links on all pages; links resolve without errors

--- a/docs/releases/2025-09-25-privacy-legal-v1.md
+++ b/docs/releases/2025-09-25-privacy-legal-v1.md
@@ -1,0 +1,16 @@
+# Privacy & Legal Page: Structure + Link Integration
+
+## Summary
+- Established page scaffolding and style; linked in footer.
+- Style: gradient black background, high-readability layout, silver outline container
+- Plan for collapsible sections (dropdowns) for long content
+- Footer now links to this page
+
+## Owner
+FishKeepingLifeCo (CXLXC LLC)
+
+## Date
+2025-09-25
+
+## Acceptance
+- Page loads, matches brand style; link available via footer

--- a/docs/releases/2025-09-25-seo-schema-refresh.md
+++ b/docs/releases/2025-09-25-seo-schema-refresh.md
@@ -1,0 +1,22 @@
+# SEO Schema Refresh (Sitewide) + Media Page Book Data
+
+## Summary
+- Sitewide JSON-LD Organization schema added/updated; Media page book metadata refreshed.
+- JSON-LD `Organization` applied across pages:
+  - `name`: FishKeepingLifeCo
+  - `url`: https://thetankguide.com
+  - `logo`/`image`: https://thetankguide.com/logo.png
+  - `addressLocality`: New York
+  - `addressCountry`: United States
+- Media page updated with book details:
+  - ISBN: 979-8263446215
+  - Ensured book info reflects current softcover
+
+## Owner
+FishKeepingLifeCo (CXLXC LLC)
+
+## Date
+2025-09-25
+
+## Acceptance
+- Schema present in `<script type="application/ld+json">` on all core pages; Media page shows updated book info.

--- a/docs/releases/2025-09-26-contact-feedback-v1.0.md
+++ b/docs/releases/2025-09-26-contact-feedback-v1.0.md
@@ -1,0 +1,20 @@
+# Contact & Feedback v1.0 — Baseline Live
+
+## Summary
+- Contact & Feedback form live (`/contact-feedback.html`)
+- Formspree endpoint active: `/f/xnngnwld`
+- reCAPTCHA v2 site key installed on page (front-end)
+- Consent + Newsletter toggles included in payload
+- Test submissions delivered to inbox
+
+## Owner
+FishKeepingLifeCo (CXLXC LLC)
+
+## Date
+2025-09-26
+
+## Follow-ups
+- Add reCAPTCHA secret key in Formspree (done in v1.1 entry)
+- Live test validation + green badge
+- Create GitHub release: `release/contact-form-v1.1`
+- Minor UI tidy (spacing, label copy)

--- a/docs/releases/2025-09-26-contact-feedback-v1.1.md
+++ b/docs/releases/2025-09-26-contact-feedback-v1.1.md
@@ -1,0 +1,18 @@
+# Contact & Feedback v1.1 (reCAPTCHA secret key added)
+
+## Summary
+- reCAPTCHA fully configured on Formspree side.
+- Secret key added in Formspree: CAPTCHA → Custom reCAPTCHA → Secret key configured
+- Front-end already had site key (v1 baseline)
+- Next: run live challenge test and ship `release/contact-form-v1.1`
+- No UI changes in this step
+
+## Owner
+FishKeepingLifeCo (CXLXC LLC)
+
+## Date
+2025-09-26
+
+## Evidence / Links
+- Formspree dashboard: https://formspree.io
+- Page: https://thetankguide.com/contact-feedback.html


### PR DESCRIPTION
## Summary
- add markdown release records for September 20-26, 2025 updates
- capture summaries, owners, dates, and acceptance details for each channel log entry
- align documentation with annotated git release tags for nine releases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d69e0dbc9883329a2c924c9a3e5e75