### PR TITLE
Update sitemap with current site structure

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,39 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-
-  <!-- Homepage -->
   <url>
     <loc>https://thetankguide.com/</loc>
+    <lastmod>2025-09-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
-
-  <!-- Stocking Advisor -->
-  <url>
-    <loc>https://thetankguide.com/index.html</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-
-  <!-- Gear -->
   <url>
     <loc>https://thetankguide.com/gear.html</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <lastmod>2025-09-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
-
-  <!-- Cycling Coach -->
   <url>
-    <loc>https://thetankguide.com/cycling.html</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
+    <loc>https://thetankguide.com/params.html</loc>
+    <lastmod>2025-09-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
   </url>
-
-  <!-- Media -->
   <url>
-    <loc>https://thetankguide.com/media.html</loc>
+    <loc>https://thetankguide.com/stocking.html</loc>
+    <lastmod>2025-09-26</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://thetankguide.com/about.html</loc>
+    <lastmod>2025-09-26</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
-
+  <url>
+    <loc>https://thetankguide.com/contact-feedback.html</loc>
+    <lastmod>2025-09-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://thetankguide.com/media.html</loc>
+    <lastmod>2025-09-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://thetankguide.com/privacy-legal.html</loc>
+    <lastmod>2025-09-26</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- audit the site to confirm the list of public pages that should be indexed
- refresh sitemap.xml with canonical URLs, last modified dates, change frequencies, and priorities for each public page
- remove outdated entries and correct the homepage URL

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d75906463083328d73f1e0bb0bbe6e