### PR TITLE
Remove decorative divider bubble on stocking page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -762,6 +762,32 @@ html {
   }
 }
 
+#stocking-app > section[aria-labelledby="controls-title"] {
+  margin-bottom: 16px;
+}
+
+#stocking-app #tank-summary {
+  margin-top: 16px;
+}
+
+#stocking-app > section[aria-labelledby="water-title"] {
+  margin-top: 16px;
+}
+
+@media (min-width: 720px) {
+  #stocking-app > section[aria-labelledby="controls-title"] {
+    margin-bottom: 20px;
+  }
+
+  #stocking-app #tank-summary {
+    margin-top: 20px;
+  }
+
+  #stocking-app > section[aria-labelledby="water-title"] {
+    margin-top: 20px;
+  }
+}
+
 .control-field {
   display: flex;
   flex-direction: column;

--- a/stocking.html
+++ b/stocking.html
@@ -633,9 +633,8 @@
           </select>
         </div>
       </div>
+      <div id="tank-summary" aria-live="polite"></div>
     </section>
-
-    <section class="panel" id="tank-summary" aria-live="polite"></section>
 
     <section class="panel" aria-labelledby="water-title">
       <div class="conditions-header">


### PR DESCRIPTION
## Summary
- remove the empty tank summary wrapper that created the decorative divider between the species selector and tank profile card
- keep the tank summary container within the controls panel so scripted content still renders while reducing the gap between sections
- add responsive spacing tweaks so the controls block and tank profile card sit 16–20px apart across breakpoints

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7f8d443cc83328315cdd5988ff8d3