### PR TITLE
Prevent Enter submission on species select

### DIFF
--- a/js/stocking.js
+++ b/js/stocking.js
@@ -25,6 +25,12 @@ sel?.addEventListener('change', (e) => {
   target.value = '';
 });
 
+sel?.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') {
+    e.preventDefault();
+  }
+});
+
 document.addEventListener('DOMContentLoaded', populateSpeciesDropdown);
 
 const state = createDefaultState();


### PR DESCRIPTION
## Summary
- prevent the species selector from submitting a parent form when Enter is pressed

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d800b744f08332a695b06c18772db8