### PR TITLE
Remove add species dropdown from stocking controls

### DIFF
--- a/js/stocking.js
+++ b/js/stocking.js
@@ -3,36 +3,6 @@ import { getTankVariants, describeVariant } from './logic/sizeMap.js';
 import { debounce, getQueryFlag, roundCapacity, nowTimestamp, byCommonName } from './logic/utils.js';
 import { renderConditions, renderBioloadBar, renderAggressionBar, renderStatus, renderChips, renderStockList, bindPopoverHandlers } from './logic/ui.js';
 
-const sel = document.querySelector('#species-select');
-
-function populateSpeciesDropdown() {
-  if (!sel) return;
-  const items = Array.isArray(SPECIES) ? SPECIES.slice() : [];
-  items.sort((a, b) => a.common_name.localeCompare(b.common_name));
-  sel.innerHTML = `<option value="">Add species…</option>` +
-    items.map((s) => `<option value="${s.id}">${s.common_name} — ${s.scientific_name}</option>`).join('');
-}
-
-sel?.addEventListener('change', (e) => {
-  const target = e.target;
-  if (!(target instanceof HTMLSelectElement)) return;
-  const id = target.value;
-  if (!id) return;
-  const list = Array.isArray(SPECIES) ? SPECIES : [];
-  const s = list.find((x) => x.id === id);
-  if (!s) return;
-  document.dispatchEvent(new CustomEvent('advisor:addCandidate', { detail: { species: s, qty: 1 } }));
-  target.value = '';
-});
-
-sel?.addEventListener('keydown', (e) => {
-  if (e.key === 'Enter') {
-    e.preventDefault();
-  }
-});
-
-document.addEventListener('DOMContentLoaded', populateSpeciesDropdown);
-
 const state = createDefaultState();
 let computed = null;
 let variantSelectorOpen = false;

--- a/stocking.html
+++ b/stocking.html
@@ -626,12 +626,6 @@
           </div>
         </div>
 
-        <div class="control-field">
-          <label class="sr-only" for="species-select">Add species</label>
-          <select id="species-select" class="control" aria-label="Add species to tank">
-            <option value="">Add species…</option>
-          </select>
-        </div>
       </div>
       <div id="tank-summary" aria-live="polite"></div>
     </section>


### PR DESCRIPTION
## Summary
- remove the "Add species" dropdown from the stocking advisor controls
- delete unused JavaScript that populated and listened to the dropdown

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d808e6ff24833289688c232a2cc0f7