### PR TITLE
Update homepage metadata and bottom blurb

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>The Tank Guide — Aquarium Stocking Advisor & Fishkeeping Tools</title>
-  <meta name="description" content="Discover the aquarium stocking advisor, cycling coach, and fishkeeping guides to plan, build, and maintain healthy tanks with confidence — by FishKeepingLifeCo." />
+  <title>The Tank Guide — Stocking Advisor, Cycling Coach and Gear Recommendations | FishKeepingLifeCo</title>
+  <meta name="description" content="The Tank Guide by FishKeepingLifeCo: beginner-friendly aquarium tools including a stocking advisor, cycling coach, and gear tips to build healthy freshwater aquariums.">
 
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
 
@@ -209,9 +209,9 @@
   <!-- SEO Intro (blurb, sits above footer) -->
 <section class="seo-intro">
   <div class="wrap">
-    <p>Welcome to <strong>The Tank Guide</strong>, your trusted resource for aquarium care. Whether you’re setting up your first fish tank or fine-tuning a planted community aquarium, we make the process simple and enjoyable. Our fishkeeping guides help you build confidence while you plan every stage.</p>
-    <p>Our free tools include the <strong>Aquarium Stocking Advisor</strong>, <strong>Cycling Coach</strong>, and <strong>Gear Guide</strong> — each designed to give hobbyists clear answers without the confusion.</p>
-    <p>Whether you keep bettas, tetras, shrimp, or snails, The Tank Guide helps you plan, stock, and maintain a thriving aquarium with confidence.</p>
+    <p>Welcome to The Tank Guide by FishKeepingLifeCo — your trusted resource for healthy freshwater aquariums.</p>
+    <p>Our free tools include the Stocking Advisor, Cycling Coach, and Gear Guide, giving hobbyists clear answers without confusion.</p>
+    <p>Whether you keep bettas, tetras, shrimp, or snails, The Tank Guide helps you plan, stock, and maintain thriving aquariums with confidence.</p>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- update the homepage title and meta description with the latest FishKeepingLifeCo messaging
- refresh the bottom blurb copy to highlight the Stocking Advisor, Cycling Coach, and Gear Guide

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d82b706f2483329a9dd9fda2830a0d