### PR TITLE
Tighten hero header layout spacing on homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -866,3 +866,66 @@ html {
 .warn-reason { opacity:.9; margin-bottom:4px; }
 .warn-detail { opacity:.8; font-size:.95rem; margin-bottom:4px; }
 .warn-reco { font-size:.95rem; }
+
+/* --- Hero grouping & spacing --- */
+.hero-header{
+  max-width: 30rem;
+  padding: 16px 0 14px;
+  margin: 0;            /* keep left-aligned; parent handles overall layout */
+}
+.hero-title{
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;             /* gap between title text and the info button */
+  margin: 0 0 6px 0;    /* compact space under H1 */
+}
+.hero-subline{
+  font-size: 12px;
+  opacity: 0.85;
+  margin: 0 0 4px 0;
+}
+.hero-tagline{
+  line-height: 1.35;
+  margin: 0 0 8px 0;
+}
+.hero-how{
+  display: inline-block;
+  margin-top: 2px;      /* tuck the link right under the tagline */
+}
+
+/* Info button aligned to title baseline */
+.info-btn{
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  line-height: 1;
+  /* Use existing icon or letter “i”; this styles the container */
+  background: rgba(0,0,0,0.35);
+  color: #fff;
+  border: 0;
+  padding: 0;
+  transform: translateY(1px);  /* subtle vertical nudge to align with text baseline */
+  cursor: pointer;
+}
+.info-btn:hover{ background: rgba(0,0,0,0.5); }
+
+/* Remove default paragraph spacing INSIDE hero to keep tight control */
+.hero-header p{ margin-top: 0; }
+
+/* Ensure the cards stack doesn’t float too far below the hero */
+.hero-header + *{
+  margin-top: 16px !important;   /* tighten the gap below hero on mobile */
+}
+
+/* --- Tablet and up --- */
+@media (min-width: 768px){
+  .hero-header{
+    max-width: 40rem;
+    padding: 24px 0 18px;
+  }
+  .hero-title{ margin-bottom: 8px; }
+  .hero-header + *{ margin-top: 20px !important; }
+}

--- a/index.html
+++ b/index.html
@@ -147,10 +147,10 @@
   <header class="hero">
     <div class="wrap">
       <!-- Brand -->
-      <div class="site-brand">
-        <h1 class="brand-name">The Tank Guide</h1>
-        <div class="brand-sub">a product of <strong>FishKeepingLifeCo</strong></div>
-        <p class="tagline" id="hero-blurb">Smart tools and guides to plan, stock, and set up your aquarium — all in one place.</p>
+      <div class="hero-header">
+        <h1 class="brand-name hero-title">The Tank Guide</h1>
+        <p class="brand-sub hero-subline">a product of <strong>FishKeepingLifeCo</strong></p>
+        <p class="tagline hero-tagline" id="hero-blurb">Smart tools and guides to plan, stock, and set up your aquarium — all in one place.</p>
       </div>
 
       <!-- Launchpad -->
@@ -360,10 +360,10 @@
     const h1 = document.querySelector('h1');
     if(!h1) return;
     // Create once if not present
-    if(!h1.querySelector('.ttg-info-btn--inline')){
+    if(!h1.querySelector('.info-btn')){
       const btn = document.createElement('button');
       btn.type='button';
-      btn.className='ttg-info-btn--inline';
+      btn.className='info-btn';
       btn.setAttribute('aria-label','Open How it works');
       btn.title='How it works';
       btn.textContent='i';
@@ -390,7 +390,7 @@
 
     const link = document.createElement('a');
     link.href = '#how-it-works';
-    link.className = 'ttg-howitworks-link';
+    link.className = 'ttg-howitworks-link hero-how';
     link.id = 'ttg-howitworks-opener';
     link.setAttribute('role','button');
     link.setAttribute('aria-haspopup','dialog');
@@ -399,6 +399,7 @@
     // Wrap for controlled spacing (prevents full-width pill look)
     const wrap = document.createElement('div');
     wrap.className = 'ttg-howitworks-link-wrap';
+    wrap.style.marginTop = '0';
     wrap.appendChild(link);
 
     // Preferred anchor: <p id="hero-blurb">


### PR DESCRIPTION
## Summary
- group the homepage hero title, subline, tagline, and How it works link inside a new `.hero-header` block with updated utility classes
- adjust the inline How it works helper script so the generated button/link use the new classes and spacing without altering behavior
- append dedicated hero spacing styles to keep the stack compact on mobile and relaxed on tablet

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d82dc5058883329c6890b8ae65172f