### PR TITLE
Restore homepage navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -160,11 +160,14 @@ body.theme-light {
   gap: 2px;
   min-width: 0;
   text-shadow: 0 1px 8px rgba(0, 0, 0, 0.35);
+  justify-content: center;
+  min-height: 48px;
 }
 
 .site-brand__title {
   font-weight: 800;
   font-size: 1.12rem;
+  line-height: 1;
 }
 
 .site-brand__subtitle {
@@ -928,4 +931,49 @@ html {
   }
   .hero-title{ margin-bottom: 8px; }
   .hero-header + *{ margin-top: 20px !important; }
+}
+
+/* --- Nav restoration / normalization --- */
+.site-nav,
+header.site-header,
+nav[role="navigation"]{
+  position: static !important;   /* ensure non-sticky, non-fixed */
+  top: auto !important;
+  z-index: auto !important;
+  display: block !important;     /* visible at all breakpoints */
+  opacity: 1 !important;
+  visibility: visible !important;
+}
+
+/* Remove accidental hidden states on small screens */
+@media (max-width: 767.98px){
+  .site-nav,
+  header.site-header,
+  nav[role="navigation"]{
+    display: block !important;
+  }
+}
+
+/* Ensure the hero does not overlap nav; keep normal flow */
+.site-nav + .hero-header,
+header.site-header + .hero-header,
+nav[role="navigation"] + .hero-header{
+  margin-top: 0; /* hero already has internal padding; do not add extra gap */
+}
+
+/* If the nav previously had a sticky class, neutralize it */
+.is-sticky,
+.sticky,
+.nav-sticky{
+  position: static !important;
+}
+
+/* Guard against negative margins pushing content under the nav */
+.site-nav, header.site-header, nav[role="navigation"]{
+  margin-bottom: 0 !important;
+}
+
+/* Optional: ensure tap target comfort on mobile without changing layout */
+.site-nav a, header.site-header a, nav[role="navigation"] a{
+  -webkit-tap-highlight-color: rgba(0,0,0,0.1);
 }

--- a/index.html
+++ b/index.html
@@ -143,6 +143,55 @@
 </head>
 <body class="page-background">
 
+  <!-- NAV -->
+  <header id="global-nav">
+    <div class="inner">
+      <button
+        id="ttg-nav-open"
+        class="hamburger"
+        type="button"
+        aria-controls="ttg-drawer"
+        aria-expanded="false"
+        aria-label="Open menu"
+        data-nav="hamburger"
+      >
+        <span class="hamburger__bars" aria-hidden="true"></span>
+        <span class="visually-hidden">Open menu</span>
+      </button>
+      <a class="site-brand brand" href="index.html" aria-label="The Tank Guide — Home">
+        <span class="site-brand__title">The Tank Guide</span>
+        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
+      </a>
+      <nav class="site-links links" aria-label="Primary" role="navigation">
+        <a href="index.html" class="nav__link">Home</a>
+        <a href="stocking.html" class="nav__link">Stocking Advisor</a>
+        <a href="gear.html" class="nav__link">Gear</a>
+        <a href="params.html" class="nav__link">Cycling Coach</a>
+        <a href="media.html" class="nav__link">Media</a>
+        <a href="contact-feedback.html" class="nav__link">Contact &amp; Feedback</a>
+        <a href="about.html" class="nav__link">About</a>
+      </nav>
+    </div>
+    <aside id="ttg-drawer" aria-label="Site" data-nav="drawer" aria-hidden="true">
+      <div class="drawer-head">
+        <span class="drawer-title">The Tank Guide</span>
+        <button id="ttg-nav-close" class="drawer-close" type="button" aria-label="Close menu">
+          <span aria-hidden="true">×</span>
+        </button>
+      </div>
+      <nav class="drawer-links" aria-label="Mobile" role="navigation">
+        <a href="index.html" class="nav__link">Home</a>
+        <a href="stocking.html" class="nav__link">Stocking Advisor</a>
+        <a href="gear.html" class="nav__link">Gear</a>
+        <a href="params.html" class="nav__link">Cycling Coach</a>
+        <a href="media.html" class="nav__link">Media</a>
+        <a href="contact-feedback.html" class="nav__link">Feedback</a>
+        <a href="about.html" class="nav__link">About</a>
+      </nav>
+    </aside>
+    <div id="ttg-overlay" data-nav="overlay" aria-hidden="true"></div>
+  </header>
+
   <!-- HERO -->
   <header class="hero">
     <div class="wrap">


### PR DESCRIPTION
## Summary
- reintroduce the global navigation markup at the top of the homepage to appear above the hero section
- append normalization styles to ensure the navigation remains non-sticky and visible across viewports
- center the nav brand block so the site title aligns with the hamburger trigger

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d837180d68833280d2b0b77b417869