### PR TITLE
Update gear page SEO description and blurb

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -929,3 +929,7 @@ html {
   .hero-title{ margin-bottom: 8px; }
   .hero-header + *{ margin-top: 20px !important; }
 }
+
+/* Gear page blurb */
+.gear-blurb{ max-width:60ch; margin:0 auto 16px; line-height:1.5; opacity:.95; text-align:center; }
+@media (min-width:768px){ .gear-blurb{ margin-bottom:20px; } }

--- a/gear.html
+++ b/gear.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <title>The Tank Guide — Aquarium Gear, Tanks, Filters & Lighting</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="Explore aquarium gear guides by FishKeepingLifeCo — tanks, filters, heaters, lights, and accessories to set up and maintain a thriving fish tank." />
+  <meta name="description" content="The Tank Guide Gear Guide: aquarium gear recommendations for filters, heaters, lighting, substrate, test kits, and planted aquarium setups." />
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <link rel="icon" href="/favicon.ico" />
 
@@ -252,6 +252,7 @@
         <div id="accessory-options" class="grid"></div>
       </div>
     </section>
+    <p class="gear-blurb">Not sure what gear you really need for your aquarium? The Gear Guide by FishKeepingLifeCo helps aquarists choose the right equipment — from filters and heaters to lighting and water care supplies. Beginner-friendly recommendations are matched to your tank size, goals, and fish community, making it easy to build a healthy freshwater aquarium setup. And if your goal is a planted aquarium, our guidance helps you select the right lighting, substrate, and tools to keep your plants thriving alongside your fish.</p>
   </main>
 
   <div id="site-footer"></div>


### PR DESCRIPTION
## Summary
- replace the Gear page meta description with updated SEO-focused copy
- relocate the gear guide blurb to appear just above the footer while retaining its styling
- center the Gear Guide blurb text for improved presentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d83ebfdb248332babda87c61cca491