### PR TITLE
Add inline success feedback to feature submission form

### DIFF
--- a/feature-your-tank.html
+++ b/feature-your-tank.html
@@ -304,6 +304,12 @@
         </div>
       </form>
 
+      <div id="feature-form-success"
+           style="display:none;margin-top:16px;color:#39b385;font-weight:600;"
+           role="status" aria-live="polite">
+        ✅ Thanks! Your submission has been sent. We’ll review and contact you if selected.
+      </div>
+
       <p class="tiny" style="margin-top:12px;opacity:.75;">
         📌 Features are <strong>only</strong> accepted through this website. We don’t take submissions via YouTube comments or social DMs.
       </p>

--- a/js/feature-tank.js
+++ b/js/feature-tank.js
@@ -1,12 +1,28 @@
 (() => {
   const init = () => {
+    const form = document.getElementById('tank-feature-form');
     const consent = document.getElementById('consent_feature');
     const submit = document.getElementById('submit_feature');
     const helper = document.getElementById('consent_feature_help');
+    const successMessage = document.getElementById('feature-form-success');
 
-    if (!consent || !submit) {
+    if (!form || !consent || !submit) {
       return;
     }
+
+    const defaultSubmitText = submit.textContent || '';
+
+    const hideSuccess = () => {
+      if (successMessage) {
+        successMessage.style.display = 'none';
+      }
+    };
+
+    const showSuccess = () => {
+      if (successMessage) {
+        successMessage.style.display = 'block';
+      }
+    };
 
     const syncState = () => {
       const enabled = consent.checked;
@@ -17,7 +33,47 @@
       }
     };
 
-    consent.addEventListener('change', syncState);
+    consent.addEventListener('change', () => {
+      hideSuccess();
+      syncState();
+    });
+
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      hideSuccess();
+
+      const formData = new FormData(form);
+
+      submit.disabled = true;
+      submit.setAttribute('aria-disabled', 'true');
+      submit.textContent = 'Submitting…';
+
+      try {
+        const response = await fetch(form.action, {
+          method: 'POST',
+          body: formData,
+          headers: {
+            Accept: 'application/json',
+          },
+        });
+
+        if (response.ok) {
+          form.reset();
+          if (typeof window.grecaptcha !== 'undefined') {
+            window.grecaptcha.reset();
+          }
+          showSuccess();
+        } else {
+          alert('❌ There was a problem sending your submission. Please try again.');
+        }
+      } catch (error) {
+        alert('❌ Network error. Please try again.');
+      } finally {
+        submit.textContent = defaultSubmitText;
+        syncState();
+      }
+    });
+
     syncState();
   };
 


### PR DESCRIPTION
## Summary
- add an inline thank-you message beneath the feature submission form
- intercept the feature form submission to post via fetch, reset the form, and show inline success feedback while alerting on errors
- keep reCAPTCHA + consent logic intact while disabling the submit button until consent is granted

## Testing
- not run (reCAPTCHA-protected form submission)


------
https://chatgpt.com/codex/tasks/task_e_68d87914776c8332bd474f257455d52c