### PR TITLE
Wrap homepage hero and SEO intro in main

### DIFF
--- a/index.html
+++ b/index.html
@@ -192,6 +192,7 @@
     <div id="ttg-overlay" data-nav="overlay" aria-hidden="true"></div>
   </header>
 
+  <main>
   <!-- HERO -->
   <header class="hero">
     <div class="wrap">
@@ -263,6 +264,8 @@
     <p>Whether you keep bettas, tetras, shrimp, or snails, The Tank Guide helps you plan, stock, and maintain thriving aquariums with confidence.</p>
   </div>
 </section>
+
+  </main>
 
 <div id="site-footer"></div>
 <script>


### PR DESCRIPTION
## Summary
- wrap the homepage hero and SEO intro content in a semantic `<main>` wrapper without altering layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d87d414244833294c23135a4760f3d