### PR TITLE
Align homepage nav with shared site header

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,52 +144,56 @@
 <body class="page-background">
 
   <!-- NAV -->
-  <header id="global-nav">
-    <div class="inner">
+  <header id="global-nav" class="site-header">
+    <div class="site-header__inner inner">
+      <a class="site-brand brand" href="/" aria-label="The Tank Guide — Home">
+        <span class="site-brand__title">The Tank Guide</span>
+        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
+      </a>
       <button
         id="ttg-nav-open"
-        class="hamburger"
+        class="nav-toggle hamburger"
         type="button"
-        aria-controls="ttg-drawer"
+        aria-controls="primary-nav"
         aria-expanded="false"
         aria-label="Open menu"
         data-nav="hamburger"
       >
-        <span class="hamburger__bars" aria-hidden="true"></span>
+        <span class="hamburger__bars nav-toggle__bars" aria-hidden="true"></span>
         <span class="visually-hidden">Open menu</span>
       </button>
-      <a class="site-brand brand" href="index.html" aria-label="The Tank Guide — Home">
-        <span class="site-brand__title">The Tank Guide</span>
-        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
-      </a>
-      <nav class="site-links links" aria-label="Primary" role="navigation">
-        <a href="index.html" class="nav__link">Home</a>
-        <a href="stocking.html" class="nav__link">Stocking Advisor</a>
-        <a href="gear.html" class="nav__link">Gear</a>
-        <a href="params.html" class="nav__link">Cycling Coach</a>
-        <a href="media.html" class="nav__link">Media</a>
-        <a href="contact-feedback.html" class="nav__link">Contact &amp; Feedback</a>
-        <a href="about.html" class="nav__link">About</a>
+      <nav id="primary-nav" class="nav site-links links" aria-label="Primary navigation">
+        <ul class="nav__list">
+          <li class="nav__item"><a href="/" class="nav__link">Home</a></li>
+          <li class="nav__item"><a href="/stocking.html" class="nav__link">Stocking Advisor</a></li>
+          <li class="nav__item"><a href="/gear.html" class="nav__link">Gear</a></li>
+          <li class="nav__item"><a href="/params.html" class="nav__link">Cycling Coach</a></li>
+          <li class="nav__item"><a href="/media.html" class="nav__link">Media</a></li>
+          <li class="nav__item"><a href="/contact-feedback.html" class="nav__link">Contact &amp; Feedback</a></li>
+          <li class="nav__item"><a href="/about.html" class="nav__link">About</a></li>
+        </ul>
       </nav>
     </div>
-    <aside id="ttg-drawer" aria-label="Site" data-nav="drawer" aria-hidden="true">
-      <div class="drawer-head">
-        <span class="drawer-title">The Tank Guide</span>
-        <button id="ttg-nav-close" class="drawer-close" type="button" aria-label="Close menu">
+    <aside id="ttg-drawer" class="nav-panel" aria-label="Site" data-nav="drawer" aria-hidden="true">
+      <div class="drawer-head nav-panel__header">
+        <span class="drawer-title nav-panel__title">The Tank Guide</span>
+        <button id="ttg-nav-close" class="drawer-close nav-close" type="button" aria-label="Close menu">
           <span aria-hidden="true">×</span>
         </button>
       </div>
-      <nav class="drawer-links" aria-label="Mobile" role="navigation">
-        <a href="index.html" class="nav__link">Home</a>
-        <a href="stocking.html" class="nav__link">Stocking Advisor</a>
-        <a href="gear.html" class="nav__link">Gear</a>
-        <a href="params.html" class="nav__link">Cycling Coach</a>
-        <a href="media.html" class="nav__link">Media</a>
-        <a href="contact-feedback.html" class="nav__link">Feedback</a>
-        <a href="about.html" class="nav__link">About</a>
+      <nav class="drawer-links nav-panel__nav" aria-label="Mobile">
+        <ul class="nav__list">
+          <li class="nav__item"><a href="/" class="nav__link">Home</a></li>
+          <li class="nav__item"><a href="/stocking.html" class="nav__link">Stocking Advisor</a></li>
+          <li class="nav__item"><a href="/gear.html" class="nav__link">Gear</a></li>
+          <li class="nav__item"><a href="/params.html" class="nav__link">Cycling Coach</a></li>
+          <li class="nav__item"><a href="/media.html" class="nav__link">Media</a></li>
+          <li class="nav__item"><a href="/contact-feedback.html" class="nav__link">Contact &amp; Feedback</a></li>
+          <li class="nav__item"><a href="/about.html" class="nav__link">About</a></li>
+        </ul>
       </nav>
     </aside>
-    <div id="ttg-overlay" data-nav="overlay" aria-hidden="true"></div>
+    <div id="ttg-overlay" class="nav-backdrop" data-nav="overlay" aria-hidden="true"></div>
   </header>
 
   <main>


### PR DESCRIPTION
## Summary
- replace the homepage navigation markup with the shared site header structure used across the rest of the site
- ensure the primary and drawer menus use the common link set and class names for consistent styling and behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d88b84881483329d1758ccf22d5f14