### PR TITLE
Merge environmental recommendation cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -813,6 +813,40 @@ html {
   padding:10px 12px; border-radius:10px;
   background: rgba(255,255,255,.04);
 }
+.card__hd--split {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  justify-content: space-between;
+}
+.linklike {
+  background: none;
+  border: 0;
+  padding: 0;
+  color: var(--link, #87b4ff);
+  font: inherit;
+  cursor: pointer;
+}
+.linklike:hover {
+  text-decoration: underline;
+}
+.linklike:focus {
+  outline: 2px solid rgba(255, 255, 255, 0.35);
+  outline-offset: 2px;
+  border-radius: 6px;
+}
+.env-tips {
+  margin-top: 18px;
+  padding-top: 14px;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+  display: grid;
+  gap: 14px;
+}
+.env-tips__title {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.01em;
+}
 .env-row__label { font-weight:600; letter-spacing:.02em; opacity:.9; }
 .env-row__value { font-size:1rem; }
 .env-row__sub   { font-size:.9rem; opacity:.7; }

--- a/js/stocking.js
+++ b/js/stocking.js
@@ -15,7 +15,7 @@ const refs = {
   gallons: document.getElementById('input-gallons'),
   planted: document.getElementById('toggle-planted'),
   tips: document.getElementById('toggle-tips'),
-  tipsInline: document.getElementById('toggle-tips-inline'),
+  tipsInline: document.getElementById('env-tips-toggle'),
   beginner: document.getElementById('toggle-beginner'),
   blackwater: document.getElementById('toggle-blackwater'),
   turnover: document.getElementById('input-turnover'),
@@ -45,6 +45,7 @@ const refs = {
   diagnostics: document.getElementById('diagnostics'),
   diagnosticsContent: document.getElementById('diagnostics-content'),
   envReco: document.getElementById('env-reco'),
+  envTips: document.getElementById('env-tips'),
   warningsCard: document.getElementById('warnings-card'),
 };
 
@@ -435,7 +436,17 @@ function syncToggles() {
   updateToggle(refs.tips, state.showTips);
   updateToggle(refs.beginner, state.beginnerMode);
   updateToggle(refs.blackwater, state.water.blackwater);
-  refs.tipsInline.textContent = state.showTips ? 'Hide Tips' : 'Show More Tips';
+  if (refs.tipsInline) {
+    refs.tipsInline.textContent = state.showTips ? 'Hide Tips' : 'Show More Tips';
+    refs.tipsInline.setAttribute('aria-pressed', state.showTips ? 'true' : 'false');
+  }
+  if (refs.envTips) {
+    if (state.showTips) {
+      refs.envTips.removeAttribute('hidden');
+    } else {
+      refs.envTips.setAttribute('hidden', '');
+    }
+  }
   refs.plantIcon.style.display = state.planted ? 'inline-flex' : 'none';
 }
 
@@ -523,6 +534,27 @@ const scheduleUpdate = debounce(() => {
   renderAll();
 });
 
+const tipsBtn = document.querySelector('#env-tips-toggle');
+const tipsPane = document.querySelector('#env-tips');
+
+if (tipsBtn && tipsPane) {
+  tipsBtn.addEventListener('click', () => {
+    const open = tipsPane.hasAttribute('hidden') ? false : true;
+    if (open) {
+      tipsPane.setAttribute('hidden', '');
+      tipsBtn.setAttribute('aria-pressed', 'false');
+      tipsBtn.textContent = 'Show More Tips';
+    } else {
+      tipsPane.removeAttribute('hidden');
+      tipsBtn.setAttribute('aria-pressed', 'true');
+      tipsBtn.textContent = 'Hide Tips';
+    }
+    state.showTips = !open;
+    syncToggles();
+    scheduleUpdate();
+  });
+}
+
 function bindInputs() {
   refs.gallons.addEventListener('input', scheduleUpdate);
   if (refs.turnover) refs.turnover.addEventListener('input', scheduleUpdate);
@@ -540,11 +572,6 @@ function bindInputs() {
   });
 
   refs.tips.addEventListener('click', () => {
-    state.showTips = !state.showTips;
-    syncToggles();
-    scheduleUpdate();
-  });
-  refs.tipsInline.addEventListener('click', () => {
     state.showTips = !state.showTips;
     syncToggles();
     scheduleUpdate();

--- a/stocking.html
+++ b/stocking.html
@@ -215,19 +215,6 @@
       background: rgba(163, 200, 255, 0.16);
     }
 
-    .conditions-header {
-      display: flex;
-      align-items: baseline;
-      justify-content: space-between;
-      gap: 12px;
-    }
-
-    .conditions-header h2 {
-      margin: 0;
-      font-size: 1.2rem;
-      letter-spacing: 0.02em;
-    }
-
     .conditions-list {
       display: grid;
       gap: 10px;
@@ -692,22 +679,19 @@
     </section>
 
     <section class="card tank-env-card" aria-live="polite" id="env-card">
-      <div class="card__hd">
+      <div class="card__hd card__hd--split">
         <h2>Environmental Recommendations</h2>
-        <p class="subtle">Derived from your selected stock.</p>
+        <button type="button" id="env-tips-toggle" class="linklike" aria-pressed="false">Show More Tips</button>
       </div>
+      <p class="subtle">Derived from your selected stock.</p>
       <div id="env-reco" class="env-list"></div>
+      <div id="env-tips" class="env-tips" hidden>
+        <h3 class="env-tips__title" id="conditions-title">Recommended Environmental Conditions</h3>
+        <ul class="conditions-list" id="conditions-list"></ul>
+      </div>
     </section>
 
     <section class="card warn-card" id="warnings-card" hidden></section>
-
-    <section class="panel" aria-labelledby="conditions-title">
-      <div class="conditions-header">
-        <h2 id="conditions-title">Recommended Environmental Conditions</h2>
-        <button class="link-like" type="button" id="toggle-tips-inline">Show More Tips</button>
-      </div>
-      <ul class="conditions-list" id="conditions-list"></ul>
-    </section>
 
     <section class="panel" aria-labelledby="capacity-title">
       <div class="bars">


### PR DESCRIPTION
## Summary
- replace the duplicated environmental cards on stocking.html with a single card that contains the recommendations list and collapsible tips content
- update the stocking JavaScript to target the new markup, synchronise the inline tips button with app state, and hook up the toggle behaviour
- extend the shared stylesheet with utilities for split card headers, the link-styled button, and the collapsible tips block spacing

## Testing
- python3 -m http.server 8000 (manual verification via Playwright)

------
https://chatgpt.com/codex/tasks/task_e_68d88fddac7c8332b63d6a14e203d8e7