### PR TITLE
Improve about page SEO metadata

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,8 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>About The Tank Guide — FishKeepingLifeCo Story &amp; Mission</title>
-  <meta name="description" content="Learn how The Tank Guide by FishKeepingLifeCo began — our story, mission, and vision to make fishkeeping simple, inspiring, and educational for every aquarist." />
+  <title>The Tank Guide — FishKeepingLifeCo Story, Mission &amp; Vision</title>
+  <meta name="description" content="Learn about The Tank Guide by FishKeepingLifeCo—our story, mission and vision to make beginner aquarium care simple with stocking, cycling and gear tools." />
+  <link rel="canonical" href="https://thetankguide.com/about.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="The Tank Guide" />
+  <meta property="og:title" content="The Tank Guide — FishKeepingLifeCo Story, Mission &amp; Vision" />
+  <meta property="og:description" content="Learn about The Tank Guide by FishKeepingLifeCo—our story, mission and vision to make beginner aquarium care simple with stocking, cycling and gear tools." />
+  <meta property="og:url" content="https://thetankguide.com/about.html" />
+  <meta property="og:image" content="https://thetankguide.com/logo.png" />
   <link rel="icon" href="/favicon.ico" />
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <script defer src="js/nav.js?v=1.0.8"></script>
@@ -248,6 +255,7 @@
         <h1 id="about-page-title" class="hero-title">About</h1>
       </section>
 
+      <h2>Our Story &amp; Mission</h2>
       <section class="accordion-section" aria-label="About The Tank Guide">
         <div class="accordion" id="about-accordion">
           <div class="accordion-item">


### PR DESCRIPTION
## Summary
- update the About page head metadata with optimized title, description, canonical URL, and Open Graph tags
- add an H2 "Our Story & Mission" heading before the accordion to improve content hierarchy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8944669e08332aa0158bcf8ccc5d5