### PR TITLE
Fix nav brand alignment on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,6 @@
     .visually-hidden{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);border:0}
 
     /* Brand */
-    .site-brand{margin-bottom:48px;}
     .brand-name{font-weight:800;font-size:1.4rem}
     .brand-sub{font-size:1rem;opacity:.9}
     .tagline{margin-top:6px;font-size:1.05rem;opacity:.85}


### PR DESCRIPTION
## Summary
- remove the hero-only margin declaration from `.site-brand` so the global nav brand stays centered beside the hamburger button on mobile

## Testing
- npm test *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8953efb848332b161e741c2d68c07