### PR TITLE
Restore static asset versioning for stocking page

### DIFF
--- a/js/stocking.js
+++ b/js/stocking.js
@@ -1,70 +1,18 @@
-import { APP_VERSION } from './utils/version.js';
 import { createDefaultState, buildComputedState, runSanitySuite, runStressSuite, SPECIES, getDefaultSpeciesId } from './logic/compute.js';
 import { computeEnv, renderEnvInto, renderWarningsInto } from './logic/envRecommend.js';
 import { getTankVariants, describeVariant } from './logic/sizeMap.js';
 import { debounce, getQueryFlag, roundCapacity, nowTimestamp, byCommonName } from './logic/utils.js';
 import { renderConditions, renderBioloadBar, renderAggressionBar, renderStatus, renderChips, bindPopoverHandlers } from './logic/ui.js';
-
-const versionSuffix = `?v=${APP_VERSION}`;
-
-const ensureVersionedAssets = () => {
-  const cssEl = document.querySelector('#css-main');
-  if (cssEl) {
-    const href = cssEl.getAttribute('href');
-    if (href && !href.includes('?v=')) {
-      cssEl.href = href + versionSuffix;
-    }
+window.addEventListener('keydown', (e) => {
+  const platform = typeof navigator !== 'undefined' ? navigator.platform : '';
+  const isMac = platform.toUpperCase().includes('MAC');
+  if ((isMac ? e.metaKey : e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'l') {
+    e.preventDefault();
+    const u = new URL(location.href);
+    u.searchParams.set('v', Date.now().toString(36));
+    location.replace(u.toString());
   }
-
-  const scriptEl = document.querySelector('#js-stocking');
-  if (scriptEl) {
-    const src = scriptEl.getAttribute('src');
-    if (src && !src.includes('?v=')) {
-      scriptEl.src = src + versionSuffix;
-      return false;
-    }
-  }
-
-  return true;
-};
-
-const readyForBootstrap = ensureVersionedAssets();
-
-if (readyForBootstrap) {
-  console.log(`[TheTankGuide] APP_VERSION = ${APP_VERSION}`);
-} else {
-  console.log(`[TheTankGuide] Bootstrapping APP_VERSION = ${APP_VERSION}`);
-}
-
-if (readyForBootstrap) {
-  document.addEventListener('DOMContentLoaded', () => {
-    const bump = (el) => {
-      if (!el) return;
-      const href = el.getAttribute('href') || el.getAttribute('src');
-      if (!href || href.includes('?v=')) return;
-      const withV = href + versionSuffix;
-      if (el.tagName === 'LINK') {
-        el.href = withV;
-      } else if (el.tagName === 'SCRIPT') {
-        el.src = withV;
-      }
-    };
-    bump(document.querySelector('#css-main'));
-    bump(document.querySelector('#js-stocking'));
-  });
-
-  window.addEventListener('keydown', (e) => {
-    // Use ⌘/Ctrl + Shift + L to force cache-bust reload.
-    const platform = typeof navigator !== 'undefined' ? navigator.platform : '';
-    const isMac = platform.toUpperCase().includes('MAC');
-    if ((isMac ? e.metaKey : e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'l') {
-      e.preventDefault();
-      const u = new URL(location.href);
-      u.searchParams.set('v', `${APP_VERSION}-${Date.now()}`);
-      location.replace(u.toString());
-    }
-  });
-}
+});
 
 function bootstrapStocking() {
   const state = createDefaultState();
@@ -745,6 +693,4 @@ function buildGearPayload() {
   init();
 }
 
-if (readyForBootstrap) {
-  bootstrapStocking();
-}
+bootstrapStocking();

--- a/js/utils/version.js
+++ b/js/utils/version.js
@@ -1,6 +1,0 @@
-export const APP_VERSION = (() => {
-  const t = (typeof window !== 'undefined' && window.__APP_BUILD__) || new Date();
-  const pad = (n) => String(n).padStart(2, '0');
-  const v = `${t.getFullYear()}${pad(t.getMonth() + 1)}${pad(t.getDate())}${pad(t.getHours())}${pad(t.getMinutes())}`;
-  return v;
-})();

--- a/stocking.html
+++ b/stocking.html
@@ -4,10 +4,7 @@
   <meta charset="UTF-8" />
   <title>The Tank Guide — Stocking Advisor</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script>
-    window.__APP_BUILD__ = new Date();
-  </script>
-  <link rel="stylesheet" id="css-main" href="css/style.css" />
+  <link rel="stylesheet" id="css-main" href="css/style.css?v=2024-06-05a" />
   <link rel="icon" href="/favicon.ico" />
   <script defer src="js/nav.js?v=1.0.8"></script>
   <style>
@@ -741,7 +738,7 @@
   <script type="module" src="js/fish-data.js"></script>
   <script type="module" src="js/logic/compute.js"></script>
   <script type="module" src="js/logic/conflicts.js"></script>
-  <script type="module" src="js/stocking.js" id="js-stocking"></script>
+  <script type="module" src="js/stocking.js?v=2024-06-05a" id="js-stocking"></script>
 
   <div id="beginner-info" class="popover" data-hidden="true" role="dialog" aria-modal="false">
     <strong>Beginner safeguards</strong>


### PR DESCRIPTION
## Summary
- remove the runtime asset rewriting logic from the stocking module and keep the hot reload shortcut limited to reloading the page URL
- hardcode matching cache-bust query parameters for the stocking stylesheet and module script, eliminating the need for the version helper

## Testing
- npm test *(fails: playwright: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8adff5e8483329fafe96d2e095c32