### PR TITLE
Add outside click support to close nav drawer

### DIFF
--- a/js/nav.js
+++ b/js/nav.js
@@ -105,6 +105,20 @@
       });
     };
 
+    const handleOutsidePointer = (event) => {
+      if (root.getAttribute('data-open') !== 'true') {
+        return;
+      }
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      if (!target) {
+        return;
+      }
+      if (drawer.contains(target) || (openBtn instanceof HTMLElement && openBtn.contains(target))) {
+        return;
+      }
+      closeDrawer();
+    };
+
     const handleKeydown = (event) => {
       if (event.key === 'Escape') {
         closeDrawer();
@@ -135,6 +149,12 @@
     if (!root.__ttgEscHandler) {
       document.addEventListener('keydown', handleKeydown);
       root.__ttgEscHandler = handleKeydown;
+    }
+
+    if (!root.__ttgOutsideHandler) {
+      document.addEventListener('pointerdown', handleOutsidePointer, true);
+      document.addEventListener('click', handleOutsidePointer, true);
+      root.__ttgOutsideHandler = handleOutsidePointer;
     }
 
     markActiveLinks(root);


### PR DESCRIPTION
## Summary
- add a document-level outside pointer handler so the drawer closes when clicking outside the nav or toggle
- ensure the handler and existing Escape handler are registered idempotently on the document

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8b1951a888332ae9404f58ac9407b