### PR TITLE
Unify environmental recommendations card with integrated logic

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1057,3 +1057,36 @@ nav[role="navigation"] + .hero-header{
   .stock-list .stock-row { grid-template-columns: 1fr auto; }
   .stock-list .stock-row__remove { grid-column: 1 / -1; justify-self: end; }
 }
+
+/* unified header with right-aligned toggle */
+.card__hd--split { display:flex; align-items:center; justify-content:space-between; gap:12px; }
+.linklike { background:none; border:0; padding:0; color:var(--link, #87b4ff); font:inherit; cursor:pointer; }
+.linklike:focus { outline:2px solid rgba(255,255,255,.35); outline-offset:2px; border-radius:6px; }
+
+/* conditions grid */
+.env-list { display:grid; grid-template-columns: 1fr 1fr; gap:10px 16px; margin-top:6px; }
+.env-item { background:rgba(255,255,255,.04); border-radius:10px; padding:10px 12px; }
+.env-item__label { opacity:.9; font-size:.9rem; }
+.env-item__value { font-weight:600; margin-top:2px; }
+.env-item__badge { display:inline-block; font-size:.75rem; padding:2px 6px; border-radius:999px; background:rgba(255,255,255,.10); margin-left:6px; }
+@media (max-width: 680px){ .env-list { grid-template-columns: 1fr; } }
+
+/* divider */
+.env-divider { border:0; height:1px; background:rgba(255,255,255,.08); margin:14px 0; }
+
+/* bars inside this card */
+.env-bars { display:grid; gap:14px; }
+.env-bar { background:rgba(255,255,255,.04); padding:12px; border-radius:12px; }
+.env-bar__hd { display:flex; align-items:center; justify-content:space-between; margin-bottom:8px; }
+.env-bar__track { height:14px; border-radius:999px; background:rgba(255,255,255,.08); overflow:hidden; }
+.env-bar__fill { height:100%; width:0%; background:linear-gradient(90deg, #6aa9ff, #6effb1); }
+.env-bar__chips { margin-top:8px; display:flex; flex-wrap:wrap; gap:6px; }
+
+/* warnings block */
+.env-warnings { background:rgba(255,0,0,.08); border:1px solid rgba(255,0,0,.25); border-radius:12px; padding:12px; }
+.env-warn-title { font-weight:700; margin-bottom:6px; }
+.env-warn-list { margin:0; padding-left:18px; }
+.env-warn-hard { color:#ff8a8a; font-weight:700; }
+
+/* tips */
+.env-tips { margin-top:10px; padding:10px 12px; border-radius:10px; background:rgba(255,255,255,.04); }

--- a/js/logic/envRecommend.js
+++ b/js/logic/envRecommend.js
@@ -1,238 +1,601 @@
-export function computeEnv({ speciesList = [], planted = false }) {
-  const num = v => typeof v === "number" && isFinite(v);
-  const rng = r => r && num(r.min) && num(r.max) && r.min < r.max;
-  const tRng = r => r && num(r.min_f) && num(r.max_f) && r.min_f < r.max_f;
+import { clamp, getBandColor } from './utils.js';
 
-  // Defaults if empty stock
-  if (!speciesList.length) {
+const FLOW_LABEL = { low: 'Low', moderate: 'Moderate', high: 'High' };
+const BLACK_LABEL = { off: 'Off', neutral: 'Off', prefers: 'Recommended', recommended: 'Recommended', required: 'Required' };
+const SALINITY_LABEL = {
+  fresh: 'Freshwater',
+  'brackish-low': 'Brackish-low',
+  'brackish-high': 'Brackish-high',
+  dual: 'Dual',
+};
+
+const RANGE_KEYS = {
+  temperature: ['temperature', 'min_f', 'max_f'],
+  pH: ['pH', 'min', 'max'],
+  gH: ['gH', 'min_dGH', 'max_dGH'],
+  kH: ['kH', 'min_dKH', 'max_dKH'],
+};
+
+export function renderEnvCard({ stock = [], beginner = false, computed = null } = {}) {
+  const env = deriveEnv(stock, { beginner, computed });
+  const listEl = document.getElementById('env-reco');
+  const barsEl = document.getElementById('env-bars');
+  const warnEl = document.getElementById('env-warnings');
+  const tipsEl = document.getElementById('env-tips');
+
+  if (listEl) {
+    renderConditions(listEl, env.conditions);
+  }
+  if (barsEl) {
+    renderBars(barsEl, env);
+  }
+  if (warnEl) {
+    renderWarnings(warnEl, env.warnings);
+  }
+  if (tipsEl) {
+    ensureTips(tipsEl);
+  }
+}
+
+export function deriveEnv(stock = [], options = {}) {
+  const { beginner = false, computed = null } = options ?? {};
+  const entries = normalizeStock(stock);
+  if (!entries.length) {
+    return buildDefaultEnv({ beginner, computed });
+  }
+
+  const conditions = [];
+  const warnings = [];
+  const chips = [];
+  const notes = { bioload: [], aggression: [] };
+
+  const tempRanges = collectRanges(entries, 'temperature');
+  const tempCondition = buildRangeCondition({
+    label: 'Temperature (°F)',
+    ranges: tempRanges,
+    digits: 0,
+    conflictPrefix: 'Temperature clash',
+    warningBuilder: (cool, warm) =>
+      `Not compatible: ${formatRangeGroup(cool, '°F')} vs ${formatRangeGroup(warm, '°F')}.`,
+  });
+  appendConditionResult(conditions, warnings, tempCondition);
+
+  const phRanges = collectRanges(entries, 'pH');
+  const sensitiveSpecies = entries.filter((entry) => entry.species.pH_sensitive || entry.species.ph_sensitive);
+  const phCondition = buildPhCondition(phRanges, sensitiveSpecies);
+  appendConditionResult(conditions, warnings, phCondition);
+
+  const gRanges = collectRanges(entries, 'gH');
+  const gCondition = buildRangeCondition({
+    label: 'gH (dGH)',
+    ranges: gRanges,
+    digits: 0,
+    conflictPrefix: 'gH mismatch',
+    warningBuilder: (low, high) =>
+      `Hardness mismatch: ${formatRangeGroup(low, ' dGH')} vs ${formatRangeGroup(high, ' dGH')}.`,
+  });
+  appendConditionResult(conditions, warnings, gCondition);
+
+  const kRanges = collectRanges(entries, 'kH');
+  const kCondition = buildRangeCondition({
+    label: 'kH (dKH)',
+    ranges: kRanges,
+    digits: 0,
+    conflictPrefix: 'kH mismatch',
+    warningBuilder: (low, high) =>
+      `Buffering mismatch: ${formatRangeGroup(low, ' dKH')} vs ${formatRangeGroup(high, ' dKH')}.`,
+  });
+  appendConditionResult(conditions, warnings, kCondition);
+
+  const salinityResult = buildSalinity(entries);
+  conditions.push(salinityResult.condition);
+  warnings.push(...salinityResult.warnings);
+  chips.push(...salinityResult.chips);
+
+  const flowResult = buildFlow(entries);
+  conditions.push(flowResult.condition);
+  chips.push(...flowResult.chips);
+
+  const blackResult = buildBlackwater(entries);
+  conditions.push(blackResult.condition);
+
+  const invertResult = evaluateInvertSafety(entries);
+  warnings.push(...invertResult.warnings);
+  chips.push(...invertResult.chips);
+
+  const groupResult = evaluateGroupNeeds(entries);
+  chips.push(...groupResult.chips);
+
+  const tankResult = evaluateTankFit(entries, computed);
+  chips.push(...tankResult.chips);
+
+  const bioloadPct = computeBioloadPct(computed);
+  const bioloadLabel = computeBioloadLabel(computed, entries.length);
+  const bioloadSeverity = computed?.bioload?.severity ?? 'ok';
+  if (computed?.bioload?.message) {
+    notes.bioload.push(computed.bioload.message);
+  }
+
+  const aggressionPct = computeAggressionScore(computed);
+  const aggressionLabel = computed?.aggression?.label ?? 'No conflicts detected.';
+  const aggressionSeverity = computed?.aggression?.severity ?? 'ok';
+  if (Array.isArray(computed?.aggression?.reasons)) {
+    notes.aggression.push(...computed.aggression.reasons);
+  }
+
+  return {
+    beginner,
+    conditions,
+    warnings: dedupeWarnings(warnings),
+    chips: dedupeStrings(chips),
+    barNotes: {
+      bioload: dedupeStrings(notes.bioload),
+      aggression: dedupeStrings(notes.aggression),
+    },
+    bioloadPct,
+    bioloadLabel,
+    bioloadSeverity,
+    aggressionPct,
+    aggressionLabel,
+    aggressionSeverity,
+  };
+}
+
+function renderConditions(root, conditions) {
+  const html = conditions
+    .map((condition) => {
+      const badges = (condition.badges ?? [])
+        .map((badge) => `<span class="env-item__badge">${escapeHtml(badge)}</span>`)
+        .join('');
+      return `<div class="env-item" role="listitem">
+        <div class="env-item__label">${escapeHtml(condition.label)}</div>
+        <div class="env-item__value">${escapeHtml(condition.value)}${badges}</div>
+      </div>`;
+    })
+    .join('');
+  root.innerHTML = html;
+}
+
+function renderBars(root, env) {
+  const bioloadColor = getBandColor((env.bioloadPct || 0) / 100);
+  const aggressionColor = colorForSeverity(env.aggressionSeverity);
+  const bioloadNotes = renderChips(env.barNotes?.bioload ?? []);
+  const aggressionNotes = renderChips(env.barNotes?.aggression ?? []);
+  const generalChips = renderChips(env.chips ?? []);
+
+  root.innerHTML = `
+    <div class="env-bar">
+      <div class="env-bar__hd">
+        <span>Bioload Capacity</span>
+        <span>${escapeHtml(env.bioloadLabel)}</span>
+      </div>
+      <div class="env-bar__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.min(100, Math.max(0, Math.round(env.bioloadPct)))}">
+        <div class="env-bar__fill" style="width:${Math.min(100, Math.max(0, env.bioloadPct))}%; background:${bioloadColor};"></div>
+      </div>
+      ${bioloadNotes}
+    </div>
+    <div class="env-bar">
+      <div class="env-bar__hd">
+        <span>Aggression &amp; Compatibility</span>
+        <span>${escapeHtml(env.aggressionLabel)}</span>
+      </div>
+      <div class="env-bar__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.min(100, Math.max(0, Math.round(env.aggressionPct)))}">
+        <div class="env-bar__fill" style="width:${Math.min(100, Math.max(0, env.aggressionPct))}%; background:${aggressionColor};"></div>
+      </div>
+      ${aggressionNotes}
+    </div>
+    ${generalChips}`;
+}
+
+function renderWarnings(root, warnings) {
+  if (!warnings.length) {
+    root.hidden = true;
+    root.innerHTML = '';
+    return;
+  }
+  root.hidden = false;
+  const list = warnings
+    .map((warning) => {
+      const cls = warning.type === 'hard' ? ' class="env-warn-hard"' : '';
+      return `<li${cls}>${escapeHtml(warning.text)}</li>`;
+    })
+    .join('');
+  root.innerHTML = `<div class="env-warn-title">Warnings</div><ul class="env-warn-list">${list}</ul>`;
+}
+
+function ensureTips(el) {
+  if (el.dataset.bound === 'true') return;
+  el.innerHTML = `
+    <ul>
+      <li>Match general hardness (gH) and carbonate hardness (kH) to the tightest species range— remineralize slowly when using RO.</li>
+      <li>Lock in one salinity profile; avoid mixing freshwater and brackish species unless they are noted as dual-tolerant.</li>
+      <li>Blackwater lovers appreciate botanicals and tinted water; only mark it required when tannin-dependent species are present.</li>
+      <li>Blend flow zones when low- and high-flow species are mixed—use spray bars or directional pumps to create calm refuges.</li>
+      <li>Beginner Mode keeps a conservative buffer on capacity and compatibility. Switch to Advanced only when you can monitor closely.</li>
+    </ul>`;
+  el.dataset.bound = 'true';
+}
+
+function buildDefaultEnv({ beginner, computed }) {
+  const conditions = [
+    { label: 'Temperature (°F)', value: '74–78' },
+    { label: 'pH', value: '6.5–7.5' },
+    { label: 'gH (dGH)', value: '4–12' },
+    { label: 'kH (dKH)', value: '2–8' },
+    { label: 'Salinity', value: 'Freshwater' },
+    { label: 'Flow', value: 'Moderate' },
+    { label: 'Blackwater / Tannins', value: 'Off' },
+  ];
+  return {
+    beginner,
+    conditions,
+    warnings: [],
+    chips: [],
+    barNotes: { bioload: [], aggression: [] },
+    bioloadPct: computeBioloadPct(computed),
+    bioloadLabel: computeBioloadLabel(computed, 0),
+    bioloadSeverity: computed?.bioload?.severity ?? 'ok',
+    aggressionPct: computeAggressionScore(computed),
+    aggressionLabel: computed?.aggression?.label ?? 'No conflicts detected.',
+    aggressionSeverity: computed?.aggression?.severity ?? 'ok',
+  };
+}
+
+function normalizeStock(stock) {
+  const result = [];
+  for (const entry of stock) {
+    if (!entry || !entry.species) continue;
+    const qty = Number(entry.qty) || 0;
+    if (qty <= 0) continue;
+    result.push({ species: entry.species, qty });
+  }
+  return result;
+}
+
+function collectRanges(entries, key) {
+  const results = [];
+  const [prop, minKey, maxKey] = RANGE_KEYS[key] ?? [];
+  if (!prop) return results;
+  for (const entry of entries) {
+    const species = entry.species;
+    let range = species[prop];
+    if (range == null && typeof prop === 'string') {
+      const lower = prop.toLowerCase();
+      range = species[lower] ?? range;
+    }
+    let min = Number.NaN;
+    let max = Number.NaN;
+    if (Array.isArray(range)) {
+      [min, max] = range;
+    } else if (range && typeof range === 'object') {
+      min = range[minKey];
+      max = range[maxKey];
+    }
+    min = Number(min);
+    max = Number(max);
+    if (Number.isFinite(min) && Number.isFinite(max)) {
+      if (max < min) {
+        const tmp = min;
+        min = max;
+        max = tmp;
+      }
+      results.push({ min, max, species });
+    }
+  }
+  return results;
+}
+
+function buildRangeCondition({ label, ranges, digits, conflictPrefix, warningBuilder }) {
+  if (!ranges.length) {
+    return { condition: { label, value: '—', badges: [] }, warnings: [] };
+  }
+  const intersection = intersectRanges(ranges);
+  if (intersection.ok) {
+    const value = formatRange(intersection.min, intersection.max, digits);
+    const badges = extremaBadges(ranges, intersection.min, intersection.max);
+    return { condition: { label, value, badges }, warnings: [] };
+  }
+  const conflict = analyzeConflict(ranges);
+  const compromise = formatRange(conflict.band.min, conflict.band.max, digits);
+  const conflictText = warningBuilder(conflict.low, conflict.high) || `${conflictPrefix}: adjust stock for compatibility.`;
+  return {
+    condition: { label, value: `${compromise} (compromise)`, badges: [] },
+    warnings: [{ type: 'hard', text: conflictText }],
+  };
+}
+
+function buildPhCondition(ranges, sensitiveSpecies) {
+  const label = 'pH';
+  if (!ranges.length) {
+    return { condition: { label, value: '—', badges: [] }, warnings: [] };
+  }
+  const intersection = intersectRanges(ranges);
+  const badges = [];
+  if (sensitiveSpecies.length) {
+    badges.push('sensitive species');
+  }
+  if (intersection.ok) {
+    const value = formatRange(intersection.min, intersection.max, 1);
+    return { condition: { label, value, badges }, warnings: [] };
+  }
+  if (sensitiveSpecies.length) {
+    const conflict = analyzeConflict(ranges);
+    const warning = {
+      type: 'hard',
+      text: `pH clash for sensitive species: ${formatRangeGroup(conflict.low, '')} vs ${formatRangeGroup(conflict.high, '')}.`,
+    };
     return {
-      rows: {
-        temperature: { label:"Temperature", value:"74–78 °F", setpoint:76, confidence:"low" },
-        ph:          { label:"pH",         value:"6.5–7.5", mode:"soft" },
-        gH:          { label:"gH (dGH)",   value:"4–12" },
-        kH:          { label:"kH (dKH)",   value:"2–8" },
-        salinity:    { label:"Salinity",   value:"Freshwater" },
-        flow:        { label:"Flow",       value:"Moderate" },
-        blackwater:  { label:"Blackwater / Tannins", value:"Off" },
-        turnover:    { label:"Turnover (×/hr)", value: planted ? "6–8×" : "7–9×" }
-      },
-      advisories: ["Defaults shown. Add species to refine."],
-      mismatches: []
+      condition: { label, value: 'No shared band (see warnings)', badges },
+      warnings: [warning],
     };
   }
-
-  // Collect ranges/flags
-  const temps = speciesList.filter(s=>tRng(s.temperature)).map(s=>({id:s.id,name:s.common_name,min:s.temperature.min_f,max:s.temperature.max_f}));
-  const phs   = speciesList.filter(s=>rng(s.ph)).map(s=>({id:s.id,name:s.common_name,min:s.ph.min,max:s.ph.max,sens:!!s.ph_sensitive}));
-  const ghs   = speciesList.filter(s=>rng({min:s?.gH?.min_dGH, max:s?.gH?.max_dGH})).map(s=>({min:s.gH.min_dGH,max:s.gH.max_dGH}));
-  const khs   = speciesList.filter(s=>rng({min:s?.kH?.min_dKH, max:s?.kH?.max_dKH})).map(s=>({min:s.kH.min_dKH,max:s.kH.max_dKH}));
-  const flows = speciesList.map(s=>s.flow).filter(Boolean);
-  const blacks= speciesList.map(s=>s.blackwater).filter(Boolean);
-  const sals  = speciesList.map(s=>s.salinity).filter(Boolean);
-
-  const flowRank = {low:0, moderate:1, high:2}, flowInv = ["Low","Moderate","High"];
-  const SAL_ALLOWED = ["fresh","brackish-low","brackish-high","dual"]; // marine not supported
-  const salOrderIdx = v => Math.max(0, SAL_ALLOWED.indexOf(v));
-
-  const intersection = (pairs) => {
-    if (!pairs.length) return {ok:false,min:NaN,max:NaN};
-    const lo = Math.max(...pairs.map(r=>r.min));
-    const hi = Math.min(...pairs.map(r=>r.max));
-    return {ok: lo < hi, min: lo, max: hi};
+  const unionMin = Math.min(...ranges.map((range) => range.min));
+  const unionMax = Math.max(...ranges.map((range) => range.max));
+  const paddedMin = Math.max(0, unionMin - 0.3);
+  const paddedMax = Math.min(9, unionMax + 0.3);
+  badges.push('flexible');
+  return {
+    condition: { label, value: formatRange(paddedMin, paddedMax, 1), badges },
+    warnings: [],
   };
+}
 
-  // --- Temperature: HARD mismatch if no intersection
-  const tInt = intersection(temps);
-  const hardMismatches = [];
-  let tempRow;
-  if (tInt.ok) {
-    const mid = Math.round(((tInt.min+tInt.max)/2));
-    tempRow = { label:"Temperature", value:`${Math.round(tInt.min)}–${Math.round(tInt.max)} °F`, setpoint: mid, confidence:"high" };
-  } else {
-    // Build groups for message: below vs above
-    const hiMin = Math.max(...temps.map(t=>t.min));
-    const below = temps.filter(t=>t.max <= hiMin).map(t=>`${t.name} (${Math.round(t.min)}–${Math.round(t.max)} °F)`);
-    const above = temps.filter(t=>t.min >= hiMin).map(t=>`${t.name} (${Math.round(t.min)}–${Math.round(t.max)} °F)`);
-    hardMismatches.push({
-      axis:"temperature",
-      title:"Not compatible – Temperature",
-      reason:"No shared temperature range.",
-      details: { below, above }
-    });
-    tempRow = { label:"Temperature", value:"— (See warning)" };
+function buildSalinity(entries) {
+  const salinities = new Set(entries.map((entry) => entry.species.salinity).filter(Boolean));
+  const hasFresh = salinities.has('fresh');
+  const hasLow = salinities.has('brackish-low');
+  const hasHigh = salinities.has('brackish-high');
+  const hasDual = salinities.has('dual');
+  const warnings = [];
+  const chips = [];
+  let value = 'Freshwater';
+  if (hasHigh) value = SALINITY_LABEL['brackish-high'];
+  else if (hasLow) value = SALINITY_LABEL['brackish-low'];
+  else if (hasDual) value = SALINITY_LABEL.dual;
+  else if (hasFresh) value = SALINITY_LABEL.fresh;
+
+  if (!hasDual && hasFresh && (hasLow || hasHigh)) {
+    warnings.push({ type: 'soft', text: 'Salinity mix (fresh + brackish) not advised.' });
+    chips.push('fresh + brackish mix');
   }
 
-  // --- Salinity: marine disallowed, fresh+brackish = advisory
-  const marineIds = speciesList.filter(s=>s.salinity==="marine").map(s=>s.common_name);
-  if (marineIds.length) {
-    hardMismatches.push({
-      axis:"salinity",
-      title:"Not compatible – Salinity (Marine not supported)",
-      reason:"Marine species are not supported in this tool.",
-      details:{ marine: marineIds }
-    });
+  return { condition: { label: 'Salinity', value }, warnings, chips };
+}
+
+function buildFlow(entries) {
+  const flows = entries.map((entry) => entry.species.flow).filter(Boolean);
+  if (!flows.length) {
+    return { condition: { label: 'Flow', value: 'Moderate' }, chips: [] };
   }
-  let salIdx = 0;
-  for (const v of sals) salIdx = Math.max(salIdx, salOrderIdx(v));
-  const salLabel = ["Freshwater","Brackish-low","Brackish-high","Dual"][salIdx] || "Freshwater";
-
-  // advisory for mixed fresh+brackish (ignore 'dual')
-  const hasFresh = sals.includes("fresh");
-  const hasBrack = sals.some(v=>v==="brackish-low"||v==="brackish-high");
-  const advisories = [];
-  if (!marineIds.length && hasFresh && hasBrack) {
-    advisories.push("Mixed freshwater/brackish stock — target brackish-low or use dual-tolerant species.");
+  const flowSet = new Set(flows);
+  const hasLow = flowSet.has('low');
+  const hasHigh = flowSet.has('high');
+  const hasModerate = flowSet.has('moderate');
+  const badges = [];
+  const chips = [];
+  let value = 'Moderate';
+  if (hasLow && hasHigh) {
+    value = 'Moderate';
+    badges.push('create zones');
+  } else if (hasHigh) {
+    value = FLOW_LABEL.high;
+  } else if (hasLow && !hasModerate) {
+    value = FLOW_LABEL.low;
+  } else if (hasModerate) {
+    value = FLOW_LABEL.moderate;
   }
-
-  // --- pH: STRICT only if any ph_sensitive and empty intersection
-  const anySensitive = phs.some(p=>p.sens);
-  const pInt = intersection(phs);
-  let phRow;
-  if (anySensitive && !pInt.ok) {
-    const left = phs.map(p=>`${p.name} (${p.min.toFixed(1)}–${p.max.toFixed(1)})`);
-    hardMismatches.push({
-      axis:"ph",
-      title:"Not compatible – pH (Strict)",
-      reason:"A pH-sensitive species requires overlapping pH; none found.",
-      details:{ ranges:left }
-    });
-    phRow = { label:"pH", value:"— (See warning)" };
-  } else {
-    // soft band (trim tails) or strict intersect if ok
-    const lo = Math.max(...phs.map(p=>p.min));
-    const hi = Math.min(...phs.map(p=>p.max));
-    const unionLo = Math.min(...phs.map(p=>p.min));
-    const unionHi = Math.max(...phs.map(p=>p.max));
-    const softLo = Math.max(unionLo, unionLo + (unionHi-unionLo)*0.25);
-    const softHi = Math.min(unionHi, unionHi - (unionHi-unionLo)*0.25);
-    const min = (pInt.ok ? lo : softLo), max = (pInt.ok ? hi : softHi);
-    phRow = { label:"pH", value:`${min.toFixed(1)}–${max.toFixed(1)}`, mode: anySensitive ? "strict" : "soft" };
+  if (hasLow && hasHigh) {
+    chips.push('flow zones needed');
   }
+  return { condition: { label: 'Flow', value, badges }, chips };
+}
 
-  // --- gH/kH: soft ranges
-  const gInt = intersection(ghs); const kInt = intersection(khs);
-  const gRow = gInt.ok ? {label:"gH (dGH)", value:`${Math.round(gInt.min)}–${Math.round(gInt.max)}`} :
-                         bestOverlapRow("gH (dGH)", ghs);
-  const kRow = kInt.ok ? {label:"kH (dKH)", value:`${Math.round(kInt.min)}–${Math.round(kInt.max)}`} :
-                         bestOverlapRow("kH (dKH)", khs);
-  if (gInt.ok && kInt.ok && gInt.min < 3 && kInt.min < 2) {
-    advisories.push("Very soft water — avoid large, rapid pH changes.");
+function buildBlackwater(entries) {
+  const flags = entries.map((entry) => entry.species.blackwater).filter(Boolean);
+  if (!flags.length) {
+    return { condition: { label: 'Blackwater / Tannins', value: 'Off' } };
   }
-
-  // --- Flow: pick highest
-  const flowValue = flows.length ? flowInv[Math.max(...flows.map(f=>flowRank[f] ?? 1))] : "Moderate";
-  const anyFinSensitive = speciesList.some(s=>Array.isArray(s.tags) && s.tags.includes("fin_sensitive"));
-  if (flowValue === "High" && anyFinSensitive) {
-    advisories.push("High flow recommended — provide calm eddies for long/fragile fins.");
+  let value = 'Off';
+  if (flags.includes('required')) {
+    value = BLACK_LABEL.required;
+  } else if (flags.includes('recommended') || flags.includes('prefers')) {
+    value = BLACK_LABEL.recommended;
   }
+  return { condition: { label: 'Blackwater / Tannins', value } };
+}
 
-  // --- Blackwater
-  let black;
-  const requires = blacks.includes("requires");
-  const prefers  = blacks.includes("prefers");
-  if (requires) black = "Requires"; else if (prefers) black = "Prefers"; else black = "Off";
+function evaluateInvertSafety(entries) {
+  const warnings = [];
+  const chips = [];
+  const shrimp = entries.filter((entry) => entry.species.category === 'shrimp');
+  if (!shrimp.length) {
+    return { warnings, chips };
+  }
+  const predators = entries.filter((entry) => entry.species.category !== 'shrimp' && entry.species.invert_safe === false);
+  if (!predators.length) {
+    return { warnings, chips };
+  }
+  const shrimpNames = shrimp.map((entry) => entry.species.common_name).join(', ');
+  const predatorNames = predators.map((entry) => entry.species.common_name).join(', ');
+  warnings.push({ type: 'soft', text: `Shrimp predation risk: ${predatorNames} vs ${shrimpNames}.` });
+  chips.push('shrimp at risk');
+  return { warnings, chips };
+}
 
-  // --- Turnover (×/hr) by bioload + planted
-  const bioload = speciesList.reduce((t,s)=>t + (num(s.bioload_unit)?s.bioload_unit : Math.max(0.1,(s.adult_size_in||2)*0.1)), 0);
-  let turnover;
-  if (bioload > 7) turnover = planted ? "8–9×" : "9–10×";
-  else if (bioload >= 3) turnover = planted ? "6–7×" : "7–8×";
-  else turnover = planted ? "5–6×" : "6–7×";
+function evaluateGroupNeeds(entries) {
+  const chips = [];
+  for (const entry of entries) {
+    const { species, qty } = entry;
+    const group = species.group;
+    if (!group) continue;
+    if (group.type === 'shoal' && qty < group.min) {
+      chips.push(`shoal min not met: ${species.common_name}`);
+    } else if (group.type === 'harem' && qty < group.min) {
+      chips.push(`harem ratio needed: ${species.common_name}`);
+    }
+  }
+  return { chips };
+}
 
-  const rows = {
-    temperature: tempRow,
-    ph:          phRow,
-    gH:          gRow,
-    kH:          kRow,
-    salinity:    { label:"Salinity", value: salLabel },
-    flow:        { label:"Flow", value: flowValue },
-    blackwater:  { label:"Blackwater / Tannins", value: black },
-    turnover:    { label:"Turnover (×/hr)", value: turnover }
-  };
+function evaluateTankFit(entries, computed) {
+  const chips = [];
+  const tankLength = computed?.tank?.length;
+  if (!Number.isFinite(tankLength)) {
+    return { chips };
+  }
+  for (const entry of entries) {
+    const needed = Number(entry.species.min_tank_length_in);
+    if (Number.isFinite(needed) && needed > tankLength) {
+      chips.push(`tank length short for ${entry.species.common_name}`);
+    }
+  }
+  return { chips };
+}
 
-  return { rows, advisories, mismatches: hardMismatches };
+function computeBioloadPct(computed) {
+  const percent = computed?.bioload?.currentPercent;
+  if (!Number.isFinite(percent)) {
+    return 0;
+  }
+  return clamp(percent * 100, 0, 200);
+}
 
-  function bestOverlapRow(label, pairs){
-    if (!pairs.length) return {label, value:"—"};
-    const mins = pairs.map(r=>r.min).sort((a,b)=>a-b);
-    const maxs = pairs.map(r=>r.max).sort((a,b)=>a-b);
-    const lo = Math.round(mins[Math.floor(mins.length*0.5)]);
-    const hi = Math.round(Math.max(lo+1, maxs[Math.floor(maxs.length*0.5)]));
-    return {label, value:`${lo}–${hi}`};
+function computeBioloadLabel(computed, speciesCount) {
+  if (computed?.bioload?.text) {
+    return computed.bioload.text;
+  }
+  return speciesCount > 0 ? 'Capacity estimate unavailable.' : 'Add species to estimate capacity.';
+}
+
+function computeAggressionScore(computed) {
+  const score = computed?.aggression?.score;
+  if (!Number.isFinite(score)) {
+    return 0;
+  }
+  return clamp(score, 0, 100);
+}
+
+function appendConditionResult(conditions, warnings, result) {
+  if (!result) return;
+  if (result.condition) {
+    conditions.push(result.condition);
+  }
+  if (Array.isArray(result.warnings)) {
+    warnings.push(...result.warnings);
   }
 }
 
-export function renderEnvInto(targetEl, data){
-  if (!targetEl || !data) return;
-  const { rows, advisories } = data;
-  targetEl.innerHTML = [
-    row(rows.temperature),
-    row(rows.ph),
-    row(rows.gH),
-    row(rows.kH),
-    row(rows.salinity),
-    row(rows.flow),
-    row(rows.blackwater),
-    row(rows.turnover),
-    advisories?.length ? `<div class="env-advisories">${advisories.map(a=>`<span class="chip">${escapeHtml(a)}</span>`).join("")}</div>` : ""
-  ].join("");
-
-  function row(r){
-    const sub = r.setpoint ? `Set heater ~${r.setpoint} °F (${r.confidence||"medium"} agreement)` :
-               r.mode==="strict" ? "Strict match (pH-sensitive species present)" :
-               r.mode==="soft"   ? "Soft match (acclimation okay)" : "";
-    return `
-      <div class="env-row">
-        <div class="env-row__label">${r.label}</div>
-        <div class="env-row__value">${escapeHtml(r.value)}</div>
-        ${sub ? `<div class="env-row__sub">${escapeHtml(sub)}</div>` : ``}
-      </div>`;
-  }
-  function escapeHtml(s){ return String(s).replace(/[&<>"]/g, c=>({ "&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;" }[c])); }
+function intersectRanges(ranges) {
+  if (!ranges.length) return { ok: false, min: NaN, max: NaN };
+  const min = Math.max(...ranges.map((range) => range.min));
+  const max = Math.min(...ranges.map((range) => range.max));
+  const epsilon = 0.01;
+  return { ok: max - min > epsilon, min, max };
 }
 
-export function renderWarningsInto(targetEl, data){
-  if (!targetEl) return;
-  const list = data?.mismatches || [];
-  if (!list.length) {
-    targetEl.innerHTML = ""; targetEl.hidden = true; return;
+function analyzeConflict(ranges) {
+  if (!ranges.length) {
+    return {
+      low: [],
+      high: [],
+      band: { min: NaN, max: NaN },
+    };
   }
-  targetEl.hidden = false;
-  targetEl.innerHTML = `
-    <div class="card__hd"><h2>Warnings</h2></div>
-    <div class="warn-list">
-      ${list.map(w=>warn(w)).join("")}
-    </div>`;
-  function warn(w){
-    const details = detailHtml(w);
-    return `<div class="warn-row">
-      <div class="warn-title">⚠️ ${escapeHtml(w.title)}</div>
-      <div class="warn-reason">${escapeHtml(w.reason)}</div>
-      ${details}
-      <div class="warn-reco">Recommendation: ${escapeHtml(recoFor(w.axis))}</div>
-    </div>`;
+  const lowEntry = ranges.reduce((prev, next) => (next.max < prev.max ? next : prev));
+  const highEntry = ranges.reduce((prev, next) => (next.min > prev.min ? next : prev));
+  const threshold = 0.1;
+  const lowGroup = ranges.filter((range) => range.max <= lowEntry.max + threshold);
+  const highGroup = ranges.filter((range) => range.min >= highEntry.min - threshold);
+  const min = Math.min(lowEntry.max, highEntry.min);
+  const max = Math.max(lowEntry.max, highEntry.min);
+  const band = {
+    min,
+    max,
+  };
+  return { low: lowGroup, high: highGroup, band };
+}
+
+function extremaBadges(ranges, min, max) {
+  const badges = [];
+  const tolerance = 0.05;
+  const minSetter = ranges.find((range) => Math.abs(range.min - min) <= tolerance);
+  const maxSetter = ranges.find((range) => Math.abs(range.max - max) <= tolerance);
+  if (minSetter) {
+    badges.push(`${minSetter.species.common_name} sets min`);
   }
-  function detailHtml(w){
-    if (w.axis==="temperature") {
-      const below = (w.details?.below||[]).join(", ");
-      const above = (w.details?.above||[]).join(", ");
-      return `<div class="warn-detail"><strong>Cool side:</strong> ${escapeHtml(below)}<br/><strong>Warm side:</strong> ${escapeHtml(above)}</div>`;
-    }
-    if (w.axis==="ph") {
-      const r = (w.details?.ranges||[]).join(", ");
-      return `<div class="warn-detail"><strong>pH ranges:</strong> ${escapeHtml(r)}</div>`;
-    }
-    if (w.axis==="salinity") {
-      const m = (w.details?.marine||[]).join(", ");
-      return `<div class="warn-detail"><strong>Marine species:</strong> ${escapeHtml(m)}</div>`;
-    }
-    return "";
+  if (maxSetter && maxSetter.species !== minSetter?.species) {
+    badges.push(`${maxSetter.species.common_name} sets max`);
   }
-  function recoFor(axis){
-    if (axis==="temperature") return "Pick species that share a temperature band (swap cool-water or warm-water species).";
-    if (axis==="ph")          return "Choose species with overlapping pH or remove the pH-sensitive species.";
-    if (axis==="salinity")    return "Remove marine species. This tool supports freshwater and brackish only.";
-    return "Adjust stock for environmental compatibility.";
+  return badges;
+}
+
+function formatRange(min, max, digits = 0) {
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    return '—';
   }
-  function escapeHtml(s){ return String(s).replace(/[&<>"]/g, c=>({ "&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;" }[c])); }
+  const lo = Math.min(min, max);
+  const hi = Math.max(min, max);
+  const format = (value) => value.toFixed(digits);
+  if (Math.abs(hi - lo) <= 0.05) {
+    return format(lo);
+  }
+  return `${format(lo)}–${format(hi)}`;
+}
+
+function formatRangeGroup(ranges, unit) {
+  if (!ranges.length) return '—';
+  return ranges
+    .map((range) => {
+      const label = range.species.common_name;
+      const digits = unit.trim() === '°F' ? 0 : 1;
+      const formatted = formatRange(range.min, range.max, digits);
+      return `${label} (${formatted}${unit})`;
+    })
+    .join(', ');
+}
+
+function renderChips(items) {
+  if (!items.length) return '';
+  return `<div class="env-bar__chips">${items
+    .map((item) => `<span class="chip">${escapeHtml(item)}</span>`)
+    .join('')}</div>`;
+}
+
+function colorForSeverity(severity) {
+  if (severity === 'bad') return 'var(--bad)';
+  if (severity === 'warn') return '#f4b400';
+  return 'rgba(255,255,255,0.35)';
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function dedupeWarnings(list) {
+  const seen = new Set();
+  const result = [];
+  for (const warning of list) {
+    const key = `${warning.type}|${warning.text}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(warning);
+  }
+  return result;
+}
+
+function dedupeStrings(list) {
+  const seen = new Set();
+  const result = [];
+  for (const item of list) {
+    if (!item) continue;
+    const key = item.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(item);
+  }
+  return result;
 }

--- a/stocking.html
+++ b/stocking.html
@@ -671,48 +671,28 @@
       <div id="stock-list" class="stock-list"></div>
     </section>
 
-    <section class="card tank-env-card" aria-live="polite" id="env-card">
+    <section class="card tank-env-card" id="env-card" aria-live="polite">
       <div class="card__hd card__hd--split">
         <h2>Environmental Recommendations</h2>
         <button type="button" id="env-tips-toggle" class="linklike" aria-pressed="false">Show More Tips</button>
       </div>
+
       <p class="subtle">Derived from your selected stock.</p>
-      <div id="env-reco" class="env-list"></div>
+
+      <h3 class="h-subtle">Recommended Environmental Conditions</h3>
+      <div id="env-reco" class="env-list" role="list"></div>
+
+      <hr class="env-divider" aria-hidden="true" />
+
+      <div id="env-bars" class="env-bars">
+        <!-- populated by JS: Bioload Capacity + Aggression & Compatibility -->
+      </div>
+
+      <div id="env-warnings" class="env-warnings" hidden></div>
+
       <div id="env-tips" class="env-tips" hidden>
-        <h3 class="env-tips__title" id="conditions-title">Recommended Environmental Conditions</h3>
-        <ul class="conditions-list" id="conditions-list"></ul>
+        <!-- brief bullets about GH/KH, salinity, blackwater, flow zones, and Beginner Mode -->
       </div>
-    </section>
-
-    <section class="card warn-card" id="warnings-card" hidden></section>
-
-    <section class="panel" aria-labelledby="capacity-title">
-      <div class="bars">
-        <div class="bar-card">
-          <div class="bar-header">
-            <h3 id="capacity-title">Bioload Capacity</h3>
-            <button class="micro-info" type="button" data-popover="bioload-why" aria-label="Why does bioload capacity change?">?</button>
-          </div>
-          <div class="bar-wrapper" aria-hidden="true">
-            <div class="bar-ghost" id="bioload-ghost"></div>
-            <div class="bar-fill" id="bioload-fill"></div>
-          </div>
-          <p class="bar-text" id="bioload-text">—</p>
-        </div>
-
-        <div class="bar-card">
-          <div class="bar-header">
-            <h3>Aggression &amp; Compatibility</h3>
-            <button class="micro-info" type="button" data-popover="aggression-why" aria-label="Why do aggression warnings show?">?</button>
-          </div>
-          <div class="bar-wrapper" aria-hidden="true">
-            <div class="bar-fill" id="agg-fill" style="background: var(--ghost);"></div>
-          </div>
-          <p class="bar-text" id="agg-text">—</p>
-        </div>
-      </div>
-      <div class="status-strip" id="status-strip" data-state="ok" role="status" aria-live="polite">Loading…</div>
-      <div class="chips" id="chip-row"></div>
     </section>
 
     <button class="see-gear" id="btn-gear" type="button">See Gear Suggestions</button>


### PR DESCRIPTION
## Summary
- merge the environmental panels into a single Environmental Recommendations card with condition list, capacity bars, warnings, and tips placeholders
- add scoped styles for the unified card layout, progress bars, badges, and warning/tips treatments
- rebuild the environment recommendation module to derive ranges, bars, warnings, and chips, and update stocking.js to call the new renderer with current stock

## Testing
- node --input-type=module <<'NODE'\nimport { SPECIES } from './js/logic/compute.js';\nimport { deriveEnv } from './js/logic/envRecommend.js';\nconst map = new Map(SPECIES.map((s) => [s.id, s]));\nfunction envFor(pairs) {\n  return deriveEnv(pairs.map(([id, qty]) => ({ species: map.get(id), qty })));\n}\nconst bettaCardinal = envFor([\n  ['betta_male', 1],\n  ['cardinal', 6],\n]);\nconst bettaZebra = envFor([\n  ['betta_male', 1],\n  ['zebra', 6],\n]);\nconst bettaAmano = envFor([\n  ['betta_male', 1],\n  ['amano', 6],\n]);\nconsole.log('betta+cardinal warnings', bettaCardinal.warnings);\nconsole.log('betta+zebra warnings', bettaZebra.warnings);\nconsole.log('betta+amano warnings', bettaAmano.warnings);\nNODE

------
https://chatgpt.com/codex/tasks/task_e_68d8b0fcec1c833293f574f41b1bb99f