### PR TITLE
Update Cycling Coach blurb layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1012,3 +1012,19 @@ nav[role="navigation"] + .hero-header{
 .linklike:focus { outline:2px solid rgba(255,255,255,.35); outline-offset:2px; border-radius:6px; }
 
 /* conditions grid */
+
+/* Scoped fallbacks for Cycling Coach only (used only if homepage styles aren’t global) */
+#cc-blurbs .home-subtext {
+  font-size: 0.95rem;
+  line-height: 1.5;
+  opacity: 0.8;
+  color: var(--text-muted, rgba(255, 255, 255, 0.8));
+  margin: 0 0 10px;
+}
+
+#cc-blurbs .home-blurb {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--text-primary, #fff);
+  margin: 0;
+}

--- a/params.html
+++ b/params.html
@@ -689,8 +689,14 @@
         </div>
       </details>
 
-      <div class="disclaimer" role="note">Cycling Coach is an educational tool. Always confirm with your own testing and judgment before making aquarium decisions.</div>
-      <div class="coach-blurb">Cycling Coach combines aquarium science with simple guidance. By breaking down your test results, it shows how your tank is progressing through the cycle and offers guidance along the way.</div>
+      <section id="cc-blurbs" class="cc-blurbs" aria-label="About Cycling Coach">
+        <p class="home-subtext cc-disclaimer">
+          Cycling Coach is an educational tool. Always confirm with your own testing and judgment before making aquarium decisions.
+        </p>
+        <p class="home-blurb cc-seo">
+          Cycling Coach is your aquarium cycling assistant. Enter your test results for ammonia (NH₃/NH₄⁺), nitrite (NO₂⁻), and nitrate (NO₃⁻) to see how your tank is progressing through the nitrogen cycle. Whether you’re doing a fishless cycle or cycling with fish, the tool helps you track water parameters, understand the next steps, and maintain a safe environment for your fish.
+        </p>
+      </section>
     </div>
   </main>
 


### PR DESCRIPTION
## Summary
- replace the Cycling Coach disclaimer and blurb with a single stacked section that matches the homepage styles
- add scoped fallback typography so the disclaimer and SEO copy inherit the intended visual treatment

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8bcc7bb948332adac49782dcd140a