### PR TITLE
Align Cycling Coach blurbs with homepage styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1013,18 +1013,27 @@ nav[role="navigation"] + .hero-header{
 
 /* conditions grid */
 
-/* Scoped fallbacks for Cycling Coach only (used only if homepage styles aren’t global) */
+/* Cycling Coach blurbs — fallback to match homepage sizing exactly */
 #cc-blurbs .home-subtext {
-  font-size: 0.95rem;
-  line-height: 1.5;
-  opacity: 0.8;
-  color: var(--text-muted, rgba(255, 255, 255, 0.8));
-  margin: 0 0 10px;
+  font: inherit;
+  font-size: var(--home-subtext-size, 0.95rem);
+  line-height: var(--home-subtext-leading, 1.5);
+  color: var(--text-muted, rgba(255,255,255,0.8));
+  margin: 12px 0 10px;
 }
-
 #cc-blurbs .home-blurb {
-  font-size: 1.05rem;
-  line-height: 1.7;
+  font: inherit;
+  font-size: var(--home-blurb-size, 1.05rem);
+  line-height: var(--home-blurb-leading, 1.7);
   color: var(--text-primary, #fff);
-  margin: 0;
+  margin: 0 0 18px;
+}
+/* Neutralize any accidental oversized styles coming from cards/containers */
+#cc-blurbs .home-subtext,
+#cc-blurbs .home-blurb {
+  font-weight: var(--home-blurb-weight, 400);
+}
+@media (min-width: 768px) {
+  #cc-blurbs .home-subtext { font-size: var(--home-subtext-size-md, 1rem); }
+  #cc-blurbs .home-blurb { font-size: var(--home-blurb-size-md, 1.1rem); }
 }

--- a/params.html
+++ b/params.html
@@ -455,19 +455,6 @@
       color: inherit;
     }
 
-    .disclaimer,
-    .coach-blurb {
-      background: rgba(8, 12, 20, 0.5);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-      border-radius: 16px;
-      padding: 20px 24px;
-      line-height: 1.5;
-    }
-
-    .disclaimer {
-      font-weight: 600;
-    }
-
     footer {
       margin-top: 40px;
     }
@@ -690,12 +677,8 @@
       </details>
 
       <section id="cc-blurbs" class="cc-blurbs" aria-label="About Cycling Coach">
-        <p class="home-subtext cc-disclaimer">
-          Cycling Coach is an educational tool. Always confirm with your own testing and judgment before making aquarium decisions.
-        </p>
-        <p class="home-blurb cc-seo">
-          Cycling Coach is your aquarium cycling assistant. Enter your test results for ammonia (NH₃/NH₄⁺), nitrite (NO₂⁻), and nitrate (NO₃⁻) to see how your tank is progressing through the nitrogen cycle. Whether you’re doing a fishless cycle or cycling with fish, the tool helps you track water parameters, understand the next steps, and maintain a safe environment for your fish.
-        </p>
+        <p class="home-subtext cc-disclaimer">Cycling Coach is an educational tool. Always confirm with your own testing and judgment before making aquarium decisions.</p>
+        <p class="home-blurb cc-seo">Cycling Coach is your aquarium cycling assistant. Enter your test results for ammonia (NH₃/NH₄⁺), nitrite (NO₂⁻), and nitrate (NO₃⁻) to see how your tank is progressing through the nitrogen cycle. Whether you’re doing a fishless cycle or cycling with fish, the tool helps you track water parameters, understand the next steps, and maintain a safe environment for your fish.</p>
       </section>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- replace Cycling Coach disclaimer and SEO blurb with homepage-style tagline/blurb section
- remove local overrides inflating Cycling Coach blurb typography
- add scoped fallback styles to ensure homepage sizing applies when global classes are unavailable

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8c27f9ef48332b5072f6c5d0eeba6