### PR TITLE
Show placeholders for empty stock recommendations

### DIFF
--- a/js/logic/compute.js
+++ b/js/logic/compute.js
@@ -550,6 +550,7 @@ export function buildComputedState(state) {
     blockReasons,
     diagnostics,
     turnover: turnoverBand(tank),
+    stockCount: entries.length,
   };
 }
 

--- a/js/stocking.js
+++ b/js/stocking.js
@@ -527,6 +527,7 @@ function renderEnvironmentPanels() {
   if (!computed) return;
   renderEnvCard({
     stock: currentStockArray(),
+    stockCount: computed?.stockCount ?? 0,
     beginner: state.beginnerMode,
     computed,
   });


### PR DESCRIPTION
## Summary
- add a neutral default environment model and update the environmental card/table to render placeholders when no stock is selected
- expose the computed stock count and use it to clear the bioload/aggression meters for empty state

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d946a4ea788332a9ee476acc3aa2cd