### PR TITLE
Adjust environmental recommendations card layout

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -31,6 +31,17 @@
 .env-xl-value { font-size:1.06rem; font-weight:650; line-height:1.2; }
 .env-xl-nowrap { white-space:nowrap; }
 
+/* Environmental recommendations card refinements */
+#env-card .card__hd { margin-bottom:12px; }
+#env-card .card__hd--split { align-items:flex-start; }
+#env-card .card__title-stack { display:flex; flex-direction:column; gap:4px; min-width:0; }
+#env-card .card__title-stack h2 { margin:0; }
+#env-card .card__subtitle { margin:0; }
+#env-card .env-grid-xl { margin-top:12px; overflow-x:auto; -webkit-overflow-scrolling:touch; }
+#env-card .env-grid-xl .env-xl-table { min-width:520px; }
+#env-card .env-grid-xl::-webkit-scrollbar { height:6px; }
+#env-card .env-grid-xl::-webkit-scrollbar-thumb { background:rgba(255,255,255,.24); border-radius:999px; }
+
 /* Chips row inside "Notes" value cell */
 .env-notes { display:flex; gap:6px; overflow-x:auto; padding:2px 0; }
 .env-chip { flex:0 0 auto; font-size:.8rem; padding:4px 8px; border-radius:999px; background:rgba(255,255,255,.08); border:1px solid rgba(255,255,255,.12); }
@@ -69,9 +80,10 @@
   /* Subtle zebra only on value rows for readability */
   .env-xl-rowB .env-xl-cell { background:rgba(255,255,255,.035); }
 
-  /* Compact header/subtitle spacing */
-  #env-card .card__hd--split { align-items:baseline; }
-  #env-card .subtle { margin:2px 0 8px; }
+  /* Mobile typography and spacing */
+  #env-card .env-grid-xl { padding-bottom:4px; }
+  #env-card .env-grid-xl .env-xl-cell { padding:8px 12px; font-size:0.9rem; line-height:1.35; }
+  #env-card .env-grid-xl .env-xl-value { font-size:0.95rem; }
 
   /* Bars block uses the compact style */
   #env-bars.env-bars--xl { margin-top:10px; }

--- a/stocking.html
+++ b/stocking.html
@@ -710,13 +710,13 @@
 
       <section class="card tank-env-card" id="env-card" aria-live="polite">
         <div class="card__hd card__hd--split">
-          <h2>Environmental Recommendations</h2>
+          <div class="card__title-stack">
+            <h2>Environmental Recommendations</h2>
+            <p class="subtle card__subtitle">Derived from your selected stock.</p>
+          </div>
           <button type="button" id="env-tips-toggle" class="linklike" aria-pressed="false">Show More Tips</button>
         </div>
 
-        <p class="subtle">Derived from your selected stock.</p>
-
-        <h3 class="h-subtle">Recommended Environmental Conditions</h3>
         <div id="env-warnings" class="env-warnings" hidden></div>
         <div id="env-reco" class="env-list" role="list"></div>
         <div id="env-reco-xl" class="env-grid-xl" hidden></div>


### PR DESCRIPTION
## Summary
- align the Environmental Recommendations card header and subtitle with the card padding while removing the duplicate heading
- refine the mobile environmental table for consistent spacing, readable typography, and horizontal scrolling when needed
- keep the bioload and aggression bars positioned beneath the table with unchanged behaviour and full-width tracks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d94d89c2988332a8aafe8b8386fcef