### PR TITLE
Fix mobile overflow for environmental recommendations grid

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -25,10 +25,14 @@
 .env-bar__chips { margin-top:8px; display:flex; flex-wrap:wrap; gap:6px; }
 
 /* Shared small utilities */
+.env-card .env-table { width:100%; }
+.env-card .env-table table { width:100%; table-layout:fixed; border-collapse:separate; border-spacing:0; }
+.env-card .env-table td { padding:0.5rem 0.625rem; line-height:1.25; vertical-align:middle; overflow-wrap:anywhere; }
 .env-xl-table { width:100%; border-collapse:separate; border-spacing:0; }
-.env-xl-cell { padding:6px 10px; border:1px solid rgba(255,255,255,.09); }
-.env-xl-label { font-size:.88rem; opacity:.8; line-height:1.1; }
-.env-xl-value { font-size:1.06rem; font-weight:650; line-height:1.2; }
+.env-xl-cell { padding:0.5rem 0.625rem; border:1px solid rgba(255,255,255,.09); line-height:1.25; }
+.env-xl-label { font-size:.75rem; letter-spacing:.02em; opacity:.8; text-transform:none; }
+.env-xl-rowB .env-xl-cell { font-size:.875rem; font-weight:600; }
+.env-xl-value { font-size:.875rem; font-weight:600; line-height:1.25; }
 .env-xl-nowrap { white-space:nowrap; }
 
 /* Environmental recommendations card refinements */
@@ -38,7 +42,7 @@
 #env-card .card__title-stack h2 { margin:0; }
 #env-card .card__subtitle { margin:0; }
 #env-card .env-grid-xl { margin-top:12px; overflow-x:auto; -webkit-overflow-scrolling:touch; }
-#env-card .env-grid-xl .env-xl-table { min-width:520px; }
+#env-card .env-grid-xl .env-xl-table { min-width:100%; }
 #env-card .env-grid-xl::-webkit-scrollbar { height:6px; }
 #env-card .env-grid-xl::-webkit-scrollbar-thumb { background:rgba(255,255,255,.24); border-radius:999px; }
 
@@ -82,11 +86,23 @@
 
   /* Mobile typography and spacing */
   #env-card .env-grid-xl { padding-bottom:4px; }
-  #env-card .env-grid-xl .env-xl-cell { padding:8px 12px; font-size:0.9rem; line-height:1.35; }
-  #env-card .env-grid-xl .env-xl-value { font-size:0.95rem; }
-
   /* Bars block uses the compact style */
   #env-bars.env-bars--xl { margin-top:10px; }
+}
+
+@media (max-width: 420px){
+  .env-card { padding-left:14px; padding-right:14px; }
+  .env-card .env-table td { padding:0.5rem; }
+  .env-card .env-table colgroup col:nth-child(1),
+  .env-card .env-table colgroup col:nth-child(2),
+  .env-card .env-table colgroup col:nth-child(3) { width:33.333%; }
+  .env-card .env-table .env-xl-nowrap { white-space:normal; }
+}
+
+@media (max-width: 340px){
+  .env-card { padding-left:12px; padding-right:12px; }
+  .env-card .env-table .env-xl-rowA .env-xl-cell { font-size:0.72rem; }
+  .env-card .env-table .env-xl-rowB .env-xl-cell { font-size:0.84rem; }
 }
 
 @media (min-width: 768px){

--- a/js/logic/envRecommend.js
+++ b/js/logic/envRecommend.js
@@ -245,6 +245,7 @@ function renderConditions(root, conditions, { isEmpty = false } = {}) {
 function renderConditionsExcel(env, { isEmpty = false } = {}) {
   const root = document.getElementById('env-reco-xl');
   if (!root) return;
+  root.classList.add('env-table');
 
   const chipsHtml = !isEmpty && env.chips?.length
     ? `<div class="env-notes">${env.chips.map((c) => `<span class="env-chip">${esc(c)}</span>`).join('')}</div>`
@@ -265,7 +266,11 @@ function renderConditionsExcel(env, { isEmpty = false } = {}) {
 
   const html = `
     <table class="env-xl-table" role="table" aria-label="Recommended Environmental Conditions (mobile)">
-      <col><col><col>
+      <colgroup>
+        <col />
+        <col />
+        <col />
+      </colgroup>
       <tbody>
         <tr class="env-xl-rowA">
           <td class="env-xl-cell env-xl-label">Temp °F</td>

--- a/stocking.html
+++ b/stocking.html
@@ -708,7 +708,7 @@
         <div id="stock-list" class="stock-list"></div>
       </section>
 
-      <section class="card tank-env-card" id="env-card" aria-live="polite">
+      <section class="card tank-env-card env-card" id="env-card" aria-live="polite">
         <div class="card__hd card__hd--split">
           <div class="card__title-stack">
             <h2>Environmental Recommendations</h2>
@@ -719,7 +719,7 @@
 
         <div id="env-warnings" class="env-warnings" hidden></div>
         <div id="env-reco" class="env-list" role="list"></div>
-        <div id="env-reco-xl" class="env-grid-xl" hidden></div>
+        <div id="env-reco-xl" class="env-grid-xl env-table" hidden></div>
 
         <hr class="env-divider" aria-hidden="true" />
 


### PR DESCRIPTION
## Summary
- add dedicated env-card/table classes so the environmental recommendations table can be targeted for responsive styling
- tighten typography, spacing, and breakpoint-specific padding to remove horizontal scrolling on small screens
- ensure the renderer emits a colgroup and class hook so columns stay balanced in the 3×3 grid

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d952ea68fc8332be80b9b4e5b3a3a8