### PR TITLE
Default Beginner Mode to off on load

### DIFF
--- a/js/logic/compute.js
+++ b/js/logic/compute.js
@@ -705,7 +705,7 @@ export function createDefaultState() {
     gallons: 20,
     planted: false,
     showTips: false,
-    beginnerMode: true,
+    beginnerMode: false,
     turnover: 5,
     sumpGallons: 0,
     tankAgeWeeks: 12,

--- a/stocking.html
+++ b/stocking.html
@@ -680,11 +680,11 @@
                 type="button"
                 id="toggle-beginner"
                 role="switch"
-                aria-checked="true"
+                aria-checked="false"
                 aria-label="Toggle beginner safeguards"
               >
                 <span class="slider" aria-hidden="true"></span>
-                <span>On</span>
+                <span>Off</span>
               </button>
               <button
                 class="micro-info"


### PR DESCRIPTION
## Summary
- initialize Beginner Mode as off so safeguards are opt-in on first load
- update the Beginner Mode toggle markup to reflect the default off state

## Testing
- Manual verification via local HTTP server (Beginner Mode loads off and toggles correctly)


------
https://chatgpt.com/codex/tasks/task_e_68d978e480148332bf7ce82e3d0237d1