### PR TITLE
Replace tank size accordion with dataset-driven select

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -743,151 +743,33 @@ html {
   width: 100%;
 }
 
-.tank-accordion {
-  width: 100%;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.05);
-  overflow: hidden;
-}
 
-.tank-accordion__item + .tank-accordion__item {
-  border-top: 1px solid rgba(255, 255, 255, 0.12);
-}
-
-.tank-accordion__summary {
-  list-style: none;
+.tank-size-group {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex-wrap: wrap;
   gap: 12px;
-  padding: 14px 18px;
-  font-size: 0.9rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: inherit;
-  cursor: pointer;
+  align-items: center;
+  width: 100%;
 }
 
-.tank-accordion__summary::-webkit-details-marker {
-  display: none;
+#tank-size-select {
+  flex: 1 1 220px;
+  max-width: 320px;
 }
 
-.tank-accordion__icon {
-  width: 18px;
-  height: 18px;
-  border-radius: 999px;
+.tank-footprint {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  position: relative;
-}
-
-.tank-accordion__icon::before {
-  content: '';
-  display: block;
-  width: 10px;
-  height: 10px;
-  border-right: 2px solid currentColor;
-  border-bottom: 2px solid currentColor;
-  transform: rotate(45deg);
-  transition: transform 0.2s ease;
-}
-
-.tank-accordion__item[open] .tank-accordion__icon::before {
-  transform: rotate(-135deg);
-}
-
-.tank-accordion__panel {
-  padding: 0 18px 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.tank-preset-fieldset {
-  border: 0;
-  margin: 0;
-  padding: 0;
-}
-
-.tank-preset-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.tank-preset-option {
-  display: flex;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 12px 14px;
-  border-radius: 12px;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  background: rgba(255, 255, 255, 0.03);
-  cursor: pointer;
-  transition: border-color 0.2s ease, background 0.2s ease;
-  min-height: 48px;
-}
-
-.tank-preset-option:hover,
-.tank-preset-option:focus-within {
-  border-color: rgba(255, 255, 255, 0.24);
-  background: rgba(255, 255, 255, 0.06);
-}
-
-.tank-preset-option__control {
-  margin-top: 4px;
-  flex-shrink: 0;
-  width: 20px;
-  height: 20px;
-  accent-color: var(--accent, #30e1a1);
-}
-
-.tank-preset-option__content {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  flex: 1;
-}
-
-.tank-preset-option__row {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.tank-preset-option__label {
-  font-weight: 600;
-  font-size: 1rem;
-}
-
-.tank-preset-option__footprint {
-  font-size: 0.95rem;
-  color: var(--muted, rgba(235, 239, 251, 0.75));
-}
-
-.tank-preset-option__sub {
-  font-size: 0.92rem;
-  color: var(--muted, rgba(235, 239, 251, 0.75));
-}
-
-.tank-preset-option__control:focus-visible + .tank-preset-option__content {
-  outline: 3px solid color-mix(in oklab, var(--accent, #30e1a1) 50%, transparent);
-  outline-offset: 3px;
-}
-
-.tank-preset-option__control:checked + .tank-preset-option__content {
-  border-radius: 8px;
-  box-shadow: inset 0 0 0 2px var(--accent, #30e1a1);
-}
-
-.tank-custom-input--disabled,
-.tank-custom-input:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
+  gap: 6px;
+  flex: 0 0 auto;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--muted, rgba(235, 239, 251, 0.86));
+  font-size: 0.9rem;
+  line-height: 1.2;
+  min-height: 32px;
 }
 
 .tank-facts {

--- a/js/stocking.js
+++ b/js/stocking.js
@@ -16,7 +16,6 @@ window.addEventListener('keydown', (e) => {
 });
 
 function bootstrapStocking() {
-  const LITERS_PER_GALLON = 3.78541;
   const TANK_STORAGE_KEY = 'ttg.selectedTank';
   const state = createDefaultState();
   let computed = null;
@@ -24,39 +23,37 @@ function bootstrapStocking() {
   const debugMode = getQueryFlag('debug');
 
   const refs = {
-  pageTitle: document.getElementById('page-title'),
-  plantIcon: document.getElementById('plant-icon'),
-  gallons: document.getElementById('input-gallons'),
-  tankPresetFieldset: document.getElementById('tank-preset-fieldset'),
-  tankPresetList: document.getElementById('tank-preset-list'),
-  tankFacts: document.getElementById('tank-facts'),
-  tankCustomDetails: document.getElementById('tank-custom-details'),
-  planted: document.getElementById('toggle-planted'),
-  tips: document.getElementById('toggle-tips'),
-  tipsInline: document.getElementById('env-tips-toggle'),
-  beginner: document.getElementById('toggle-beginner'),
-  blackwater: document.getElementById('toggle-blackwater'),
-  turnover: document.getElementById('input-turnover'),
-  temp: document.getElementById('input-temp'),
-  ph: document.getElementById('input-ph'),
-  gh: document.getElementById('input-gh'),
-  kh: document.getElementById('input-kh'),
-  salinity: document.getElementById('select-salinity'),
-  flow: document.getElementById('select-flow'),
-  tankSummary: document.getElementById('tank-summary'),
-  conditions: document.getElementById('conditions-list'),
-  candidateChips: document.getElementById('candidate-chips'),
-  candidateBanner: document.getElementById('candidate-banner'),
-  speciesSelect: document.getElementById('plan-species'),
-  qty: document.getElementById('plan-qty'),
-  addBtn: document.getElementById('plan-add'),
-  stockList: document.getElementById('stock-list'),
-  seeGear: document.getElementById('btn-gear'),
-  diagnostics: document.getElementById('diagnostics'),
-  diagnosticsContent: document.getElementById('diagnostics-content'),
-  envReco: document.getElementById('env-reco'),
-  envTips: document.getElementById('env-tips'),
-};
+    pageTitle: document.getElementById('page-title'),
+    plantIcon: document.getElementById('plant-icon'),
+    tankSelect: document.getElementById('tank-size-select'),
+    tankFootprint: document.getElementById('tank-footprint'),
+    tankFacts: document.getElementById('tank-facts'),
+    planted: document.getElementById('toggle-planted'),
+    tips: document.getElementById('toggle-tips'),
+    tipsInline: document.getElementById('env-tips-toggle'),
+    beginner: document.getElementById('toggle-beginner'),
+    blackwater: document.getElementById('toggle-blackwater'),
+    turnover: document.getElementById('input-turnover'),
+    temp: document.getElementById('input-temp'),
+    ph: document.getElementById('input-ph'),
+    gh: document.getElementById('input-gh'),
+    kh: document.getElementById('input-kh'),
+    salinity: document.getElementById('select-salinity'),
+    flow: document.getElementById('select-flow'),
+    tankSummary: document.getElementById('tank-summary'),
+    conditions: document.getElementById('conditions-list'),
+    candidateChips: document.getElementById('candidate-chips'),
+    candidateBanner: document.getElementById('candidate-banner'),
+    speciesSelect: document.getElementById('plan-species'),
+    qty: document.getElementById('plan-qty'),
+    addBtn: document.getElementById('plan-add'),
+    stockList: document.getElementById('stock-list'),
+    seeGear: document.getElementById('btn-gear'),
+    diagnostics: document.getElementById('diagnostics'),
+    diagnosticsContent: document.getElementById('diagnostics-content'),
+    envReco: document.getElementById('env-reco'),
+    envTips: document.getElementById('env-tips'),
+  };
 
   const tanksCatalog = listTanks();
 
@@ -84,81 +81,44 @@ function bootstrapStocking() {
     return `${rounded.toFixed(1).replace(/0+$/, '').replace(/\.$/, '')}g`;
   }
 
-  function formatLitersLabel(value) {
-    if (!Number.isFinite(value) || value <= 0) {
-      return '0 L';
-    }
-    return `${formatWithPrecision(value, 1)} L`;
-  }
-
   function formatDimensionList(dimensions, decimals = 0) {
     if (!dimensions) return '';
     const keys = ['l', 'w', 'h'];
     return keys
       .map((key) => formatWithPrecision(dimensions[key], decimals))
-      .join('×');
+      .join(' × ');
   }
 
-  function renderTankPresetOptions() {
-    if (!refs.tankPresetList) return;
-    const fragment = document.createDocumentFragment();
-    for (const tank of tanksCatalog) {
-      const option = document.createElement('label');
-      option.className = 'tank-preset-option';
-      option.dataset.tankId = tank.id;
-
-      const input = document.createElement('input');
-      input.type = 'radio';
-      input.name = 'tankPreset';
-      input.value = tank.id;
-      input.id = `tank-preset-${tank.id}`;
-      input.className = 'tank-preset-option__control';
-
-      const content = document.createElement('span');
-      content.className = 'tank-preset-option__content';
-
-      const row = document.createElement('span');
-      row.className = 'tank-preset-option__row';
-
-      const labelEl = document.createElement('span');
-      labelEl.className = 'tank-preset-option__label';
-      labelEl.textContent = tank.label;
-
-      const footprint = document.createElement('span');
-      footprint.className = 'tank-preset-option__footprint';
-      footprint.textContent = tank.footprint_in;
-
-      row.append(labelEl, footprint);
-
-      const sub = document.createElement('span');
-      sub.className = 'tank-preset-option__sub';
-      sub.textContent = `≈${formatWithPrecision(tank.liters, 1)} L • ${formatDimensionList(tank.dimensions_in, 0)} in`;
-
-      content.append(row, sub);
-      option.append(input, content);
-      fragment.append(option);
+  function renderTankSizeOptions() {
+    if (!refs.tankSelect) return;
+    refs.tankSelect.innerHTML = '';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Select a tank size…';
+    placeholder.disabled = true;
+    if (!state.selectedTankId) {
+      placeholder.selected = true;
     }
-    refs.tankPresetList.innerHTML = '';
-    refs.tankPresetList.append(fragment);
+    refs.tankSelect.appendChild(placeholder);
+    for (const tank of tanksCatalog) {
+      const option = document.createElement('option');
+      option.value = tank.id;
+      option.textContent = tank.label;
+      if (tank.id === state.selectedTankId) {
+        option.selected = true;
+      }
+      refs.tankSelect.appendChild(option);
+    }
   }
 
-  function updatePresetRadios(selectedId) {
-    if (!refs.tankPresetFieldset) return;
-    const radios = refs.tankPresetFieldset.querySelectorAll('input[name="tankPreset"]');
-    radios.forEach((radio) => {
-      radio.checked = radio.value === selectedId;
-    });
-  }
-
-  function setCustomInputDisabled(disabled) {
-    if (!refs.gallons) return;
-    refs.gallons.disabled = disabled;
-    if (disabled) {
-      refs.gallons.classList.add('tank-custom-input--disabled');
-      refs.gallons.setAttribute('aria-disabled', 'true');
+  function updateTankFootprint(tank) {
+    if (!refs.tankFootprint) return;
+    if (tank) {
+      refs.tankFootprint.textContent = `Footprint: ${tank.footprint_in} in`;
+      refs.tankFootprint.removeAttribute('hidden');
     } else {
-      refs.gallons.classList.remove('tank-custom-input--disabled');
-      refs.gallons.removeAttribute('aria-disabled');
+      refs.tankFootprint.textContent = '';
+      refs.tankFootprint.setAttribute('hidden', '');
     }
   }
 
@@ -192,32 +152,22 @@ function bootstrapStocking() {
         const dimsIn = formatDimensionList(tank.dimensions_in, 0);
         const dimsCm = formatDimensionList(tank.dimensions_cm, 1);
         const filled = Math.round(tank.filled_weight_lbs);
-        refs.tankFacts.textContent = `${formatGallonsLabel(tank.gallons)} • ${formatWithPrecision(tank.liters, 1)} L • ${dimsIn} in (${dimsCm} cm) • ~${filled} lbs filled`;
+        const litersRounded = Math.round(tank.liters);
+        refs.tankFacts.textContent = `${formatGallonsLabel(tank.gallons)} • ${litersRounded} L • ${dimsIn} in (${dimsCm} cm) • ~${filled} lbs filled`;
         return;
       }
     }
-    if (state.gallons > 0) {
-      const liters = state.liters > 0 ? state.liters : state.gallons * LITERS_PER_GALLON;
-      refs.tankFacts.textContent = `${formatGallonsLabel(state.gallons)} • ${formatLitersLabel(liters)}`;
-      return;
-    }
-    refs.tankFacts.textContent = 'Select a preset or enter custom gallons to get started.';
+    refs.tankFacts.textContent = 'Select a tank size to begin.';
   }
 
-  function applyPresetSelection(id, { shouldPersist = true, skipRecompute = false } = {}) {
+  function applyTankSelection(id, { shouldPersist = true, skipRecompute = false } = {}) {
     const tank = getTankById(id);
     if (!tank) return;
     state.selectedTankId = tank.id;
     state.gallons = tank.gallons;
     state.liters = tank.liters;
-    if (refs.gallons) {
-      refs.gallons.value = '';
-    }
-    setCustomInputDisabled(true);
-    updatePresetRadios(tank.id);
-    if (refs.tankCustomDetails) {
-      refs.tankCustomDetails.open = false;
-    }
+    renderTankSizeOptions();
+    updateTankFootprint(tank);
     if (shouldPersist) {
       persistSelectedTank(tank.id);
     }
@@ -228,77 +178,22 @@ function bootstrapStocking() {
     }
   }
 
-  function enterCustomMode({ resetValue = false, fromToggle = false } = {}) {
-    setCustomInputDisabled(false);
-    const hadPreset = Boolean(state.selectedTankId);
-    if (hadPreset) {
-      state.selectedTankId = null;
-      persistSelectedTank(null);
-    }
-    updatePresetRadios(null);
-    if (resetValue && refs.gallons) {
-      refs.gallons.value = '';
-      state.gallons = 0;
-      state.liters = 0;
-    }
-    if (hadPreset || resetValue) {
-      renderTankFacts();
-    }
-    if (hadPreset && fromToggle) {
-      runRecompute({ skipInputSync: true });
-    }
-  }
-
   function hydrateTankSelection() {
     const storedId = loadPersistedTankId();
     if (storedId) {
       const tank = getTankById(storedId);
       if (tank) {
-        applyPresetSelection(tank.id, { shouldPersist: false, skipRecompute: true });
+        applyTankSelection(tank.id, { shouldPersist: false, skipRecompute: true });
         return;
       }
       persistSelectedTank(null);
     }
-    enterCustomMode({ resetValue: true });
-  }
-
-  function handlePresetChange(event) {
-    const target = event.target;
-    if (!(target instanceof HTMLInputElement) || target.name !== 'tankPreset') {
-      return;
-    }
-    applyPresetSelection(target.value);
-  }
-
-  function handleCustomToggle() {
-    if (!refs.tankCustomDetails || !refs.tankCustomDetails.open) {
-      return;
-    }
-    enterCustomMode({ resetValue: true, fromToggle: true });
-    if (refs.gallons) {
-      requestAnimationFrame(() => {
-        try {
-          refs.gallons.focus({ preventScroll: true });
-        } catch (error) {
-          // focus failures are non-fatal
-        }
-      });
-    }
-  }
-
-  function handleCustomGallonsInput() {
-    if (!refs.gallons) return;
-    enterCustomMode();
-    const value = Number.parseFloat(refs.gallons.value);
-    if (Number.isFinite(value) && value > 0) {
-      state.gallons = value;
-      state.liters = value * LITERS_PER_GALLON;
-    } else {
-      state.gallons = 0;
-      state.liters = 0;
-    }
+    state.selectedTankId = null;
+    state.gallons = 0;
+    state.liters = 0;
+    renderTankSizeOptions();
+    updateTankFootprint(null);
     renderTankFacts();
-    scheduleUpdate();
   }
 
 const supportedSpeciesIds = new Set(SPECIES.map((species) => species.id));
@@ -615,16 +510,6 @@ function updateToggle(button, value) {
 }
 
 function syncStateFromInputs() {
-  if (refs.gallons && !refs.gallons.disabled) {
-    const manualGallons = Number.parseFloat(refs.gallons.value);
-    if (Number.isFinite(manualGallons) && manualGallons > 0) {
-      state.gallons = manualGallons;
-      state.liters = manualGallons * LITERS_PER_GALLON;
-    } else {
-      state.gallons = 0;
-      state.liters = 0;
-    }
-  }
   if (refs.turnover) {
     state.turnover = Number(refs.turnover.value) || state.turnover;
   }
@@ -675,7 +560,7 @@ function renderTankSummaryView() {
   if (!computed) {
     const text = document.createElement('p');
     text.className = 'subtle';
-    text.textContent = 'Select a preset tank size or enter custom gallons to unlock recommendations.';
+    text.textContent = 'Select a tank size to unlock recommendations.';
     container.appendChild(text);
     refs.tankSummary.appendChild(container);
     return;
@@ -858,19 +743,13 @@ if (tipsBtn && tipsPane) {
 }
 
 function bindInputs() {
-  if (refs.tankPresetFieldset) {
-    refs.tankPresetFieldset.addEventListener('change', handlePresetChange);
-  }
-  if (refs.tankCustomDetails) {
-    refs.tankCustomDetails.addEventListener('toggle', handleCustomToggle);
-  }
-  if (refs.gallons) {
-    refs.gallons.addEventListener('focus', () => {
-      if (state.selectedTankId) {
-        enterCustomMode();
+  if (refs.tankSelect) {
+    refs.tankSelect.addEventListener('change', (event) => {
+      const selectedId = event.target.value;
+      if (selectedId) {
+        applyTankSelection(selectedId);
       }
     });
-    refs.gallons.addEventListener('input', handleCustomGallonsInput);
   }
   if (refs.turnover) refs.turnover.addEventListener('input', scheduleUpdate);
   if (refs.temp) refs.temp.addEventListener('input', scheduleUpdate);
@@ -964,7 +843,7 @@ function buildGearPayload() {
 }
 
   function init() {
-    renderTankPresetOptions();
+    renderTankSizeOptions();
     hydrateTankSelection();
     bindPopoverHandlers(document.body);
     pruneMarineEntries();

--- a/stocking.html
+++ b/stocking.html
@@ -628,40 +628,14 @@
         <h2 id="controls-title" class="sr-only">Tank Controls</h2>
         <div class="controls-row">
           <div class="control-field control-field--full">
-            <label for="input-gallons">Tank Size</label>
-            <div class="tank-accordion" id="tank-size-accordion">
-              <details class="tank-accordion__item" open>
-                <summary class="tank-accordion__summary">
-                  <span>Preset Sizes</span>
-                  <span class="tank-accordion__icon" aria-hidden="true"></span>
-                </summary>
-                <div class="tank-accordion__panel">
-                  <fieldset id="tank-preset-fieldset" class="tank-preset-fieldset">
-                    <legend class="sr-only">Choose a preset tank size</legend>
-                    <div id="tank-preset-list" class="tank-preset-list"></div>
-                  </fieldset>
-                </div>
-              </details>
-              <details class="tank-accordion__item" id="tank-custom-details">
-                <summary class="tank-accordion__summary">
-                  <span>Custom Size</span>
-                  <span class="tank-accordion__icon" aria-hidden="true"></span>
-                </summary>
-                <div class="tank-accordion__panel">
-                  <input
-                    class="control tank-custom-input"
-                    id="input-gallons"
-                    type="number"
-                    inputmode="decimal"
-                    min="1"
-                    step="0.1"
-                    aria-describedby="gallons-hint"
-                  />
-                </div>
-              </details>
+            <label for="tank-size-select">Tank Size</label>
+            <div class="tank-size-group">
+              <select id="tank-size-select" name="tankSize" class="control" aria-describedby="tank-facts">
+                <option value="" disabled selected>Select a tank size…</option>
+              </select>
+              <span id="tank-footprint" class="tank-footprint" aria-live="polite" hidden></span>
             </div>
-            <span id="gallons-hint" class="secondary-text">Pick a preset or enter your own gallons.</span>
-            <p id="tank-facts" class="tank-facts subtle" aria-live="polite"></p>
+            <p id="tank-facts" class="tank-facts subtle" aria-live="polite">Select a tank size to begin.</p>
           </div>
 
           <div class="control-field">


### PR DESCRIPTION
## Summary
- replace the preset/custom accordion with a single Tank Size select that is populated from the tank size dataset
- surface the selected footprint and refreshed tank facts whenever a preset is chosen and persisted
- update state wiring so recomputes and persistence are driven by the select-only workflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9853eba8c83328238da6ada7dec58