### PR TITLE
Fix tank size select to render all presets

### DIFF
--- a/js/tankSizes.js
+++ b/js/tankSizes.js
@@ -48,7 +48,11 @@ export function getTankById(id) {
 }
 
 export function listTanks() {
-  return TANK_SIZES.slice();
+  return TANK_SIZES.slice().sort((a, b) => {
+    const gallonDiff = (a?.gallons ?? 0) - (b?.gallons ?? 0);
+    if (gallonDiff !== 0) return gallonDiff;
+    return String(a?.label ?? '').localeCompare(String(b?.label ?? ''));
+  });
 }
 
 export default TANK_SIZES;


### PR DESCRIPTION
## Summary
- add debugging to confirm imported tank size dataset
- rebuild the tank size option renderer to use the entire dataset with dynamic grouping and placeholder handling
- ensure listTanks returns a sorted copy of all presets for consumers

## Testing
- npm test *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d98e5b57948332a4f9e80c4ef933dc