### PR TITLE
Add Playwright E2E harness for The Tank Guide

### DIFF
--- a/README-TESTS.md
+++ b/README-TESTS.md
@@ -1,0 +1,35 @@
+# The Tank Guide — End-to-End UI Tests (Playwright)
+
+## Prereqs
+- Node.js 18+ recommended
+
+## Install
+- `npm install`
+- `npx playwright install`
+
+## Run the test suite
+- `npm test` — headless run across Chromium, Firefox, and WebKit
+- `npm run test:headed` — watch the browser interactions live
+- `npm run test:debug` — open the Playwright Inspector for step-through debugging
+- `npm run test:report` — open the HTML report generated in `./playwright-report`
+
+## Targeting different environments
+- Default base URL is https://thetankguide.com
+- Override via environment variable, e.g. `TTG_BASE=http://localhost:5173 npm run test:headed`
+
+## Implementation notes
+- Footer social links load dynamically; the suite includes a short wait before asserting attributes.
+- Session storage assertions only run after the "See Gear" flow triggers navigation.
+
+## Troubleshooting selectors
+Key selectors exercised by the suite:
+- `#ttg-howitworks-opener`, `.ttg-howitworks-link`, `.ttg-overlay`
+- `#ttg-nav-open`, `#ttg-drawer`
+- `input[name="gallons"]`, `input[name="planted"]`, `button:has-text("See Gear")`
+- `#consent_feature`, `#submit_feature`
+- Footer anchors targeting Instagram, TikTok, YouTube, Facebook, Amazon
+
+If elements change, update the selectors in `tests/e2e.spec.js` with similarly resilient fallbacks.
+
+## Continuous integration
+- A GitHub Actions workflow (`.github/workflows/playwright.yml`) can be added to run `npm install`, `npx playwright install`, and `npm test` on pull requests. Follow the conventions in this README if you decide to enable it later.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,12 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "playwright test"
+    "test": "npx playwright test",
+    "test:headed": "npx playwright test --headed",
+    "test:debug": "npx playwright test --debug",
+    "test:report": "npx playwright show-report"
   },
   "devDependencies": {
-    "@playwright/test": "^1.49.1"
+    "@playwright/test": "^1.42.0"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,20 @@
+const { devices } = require('@playwright/test');
+
+module.exports = {
+  timeout: 60 * 1000,
+  testDir: './tests',
+  reporter: [['list'], ['html', { outputFolder: 'playwright-report' }]],
+  use: {
+    headless: true,
+    viewport: { width: 1280, height: 800 },
+    actionTimeout: 10 * 1000,
+    ignoreHTTPSErrors: true,
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure'
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox',  use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit',   use: { ...devices['Desktop Safari'] } }
+  ]
+};

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -1,0 +1,149 @@
+const { test, expect } = require('@playwright/test');
+const BASE = process.env.TTG_BASE || 'https://thetankguide.com';
+
+test.describe('TheTankGuide core UX flows', () => {
+
+  test('Homepage: "How it works" opens/closes with keyboard & mouse', async ({ page }) => {
+    await page.goto(BASE + '/');
+    await expect(page.locator('main')).toBeVisible();
+
+    const opener = page.locator('#ttg-howitworks-opener, .ttg-howitworks-link, text="How it works"').first();
+    await expect(opener).toBeVisible();
+    await opener.click();
+
+    const overlay = page.locator('#ttg-howitworks .ttg-overlay');
+    await expect(overlay).toHaveAttribute('aria-hidden', 'false');
+
+    await page.keyboard.press('Escape');
+    await expect(overlay).toHaveAttribute('aria-hidden', 'true');
+
+    const infoBtn = page.locator('.ttg-info-btn');
+    if (await infoBtn.count()) {
+      await infoBtn.click();
+      await expect(overlay).toHaveAttribute('aria-hidden', 'false');
+      await page.mouse.click(10, 10); // outside click closes
+      await expect(overlay).toHaveAttribute('aria-hidden', 'true');
+    }
+  });
+
+  test('Hamburger: closes on outside click, Esc, and link click', async ({ page }) => {
+    await page.goto(BASE + '/');
+    const toggle = page.locator('#ttg-nav-open, .nav-toggle, [aria-controls="ttg-drawer"]').first();
+    await expect(toggle).toBeVisible();
+    await toggle.click();
+
+    const drawer = page.locator('#ttg-drawer[aria-hidden="false"], #ttg-drawer:not([aria-hidden])');
+    await expect(drawer).toBeVisible();
+
+    // outside click
+    await page.mouse.click(400, 400);
+    await page.waitForTimeout(200);
+    await expect(page.locator('#ttg-drawer')).toHaveAttribute('aria-hidden', 'true');
+
+    // reopen + Esc
+    await toggle.click();
+    await expect(drawer).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#ttg-drawer')).toHaveAttribute('aria-hidden', 'true');
+
+    // reopen + link click
+    await toggle.click();
+    const navLink = page.locator('#ttg-drawer a[href*="stocking"], a[href="/stocking.html"], a:has-text("Stocking")').first();
+    if (await navLink.count()) {
+      await navLink.click();
+      await page.waitForLoadState('networkidle');
+    }
+  });
+
+  test('Stocking Advisor → Gear: sessionStorage handoff exists', async ({ page }) => {
+    await page.goto(BASE + '/stocking.html');
+    await expect(page.locator('h1, main')).toBeVisible();
+
+    const gallons = page.locator('input[name="gallons"], input#gallons, input[type="number"]').first();
+    if (await gallons.count()) {
+      await gallons.fill('40');
+      await gallons.press('Tab');
+    }
+
+    const planted = page.locator('input[name="planted"], .planted-toggle, label:has-text("Planted")').first();
+    if (await planted.count()) await planted.click();
+
+    const seeGear = page.locator('button:has-text("See Gear"), a:has-text("See Gear")').first();
+    if (await seeGear.count()) {
+      await seeGear.click();
+      await page.waitForLoadState('networkidle').catch(() => {});
+      const hasKey = await page.evaluate(() => !!sessionStorage.getItem('ttg_stocking_state'));
+      expect(hasKey).toBeTruthy();
+    }
+  });
+
+  test('Feature Your Tank: consent enables submit (keyboard Space)', async ({ page }) => {
+    await page.goto(BASE + '/feature-your-tank.html');
+    await expect(page.locator('form')).toBeVisible();
+
+    const consent = page.locator('#consent_feature, input[name="consent_feature"]').first();
+    const submit = page.locator('#submit_feature, button[type="submit"]').first();
+
+    if (await consent.count() && await submit.count()) {
+      expect(await submit.isDisabled()).toBeTruthy();
+      await consent.focus();
+      await page.keyboard.press('Space');
+      await page.waitForTimeout(100);
+      expect(await submit.isDisabled()).toBeFalsy();
+
+      await page.keyboard.press('Space');
+      await page.waitForTimeout(100);
+      expect(await submit.isDisabled()).toBeTruthy();
+    }
+  });
+
+  test('About: "Feature Your Tank" link present; paragraph not overly long', async ({ page }) => {
+    await page.goto(BASE + '/about.html');
+    await expect(page.locator('main')).toBeVisible();
+
+    const link = page.locator('a:has-text("Feature Your Tank"), :text("Feature Your Tank")').first();
+    expect(await link.count()).toBeGreaterThan(0);
+
+    const paraText = await page.locator('main p').nth(2).innerText().catch(() => '');
+    const wordCount = paraText.split(/\s+/).filter(Boolean).length;
+    test.info().log('About para words: ' + wordCount);
+    if (wordCount > 50) test.info().log('Consider splitting long sentences for readability.');
+  });
+
+  test('Footer & Media CTAs: rel/target hygiene for socials', async ({ page }) => {
+    await page.goto(BASE + '/');
+    await page.waitForTimeout(500);
+
+    const footerLinks = page.locator('footer a[href*="instagram.com"], footer a[href*="tiktok.com"], footer a[href*="youtube.com"], footer a[href*="facebook.com"], footer a[href*="amazon.com"]');
+    const count = await footerLinks.count();
+    for (let i = 0; i < count; i++) {
+      const el = footerLinks.nth(i);
+      const target = await el.getAttribute('target');
+      const rel = await el.getAttribute('rel');
+      if (target === '_blank') {
+        expect(rel && rel.includes('noopener')).toBeTruthy();
+        expect(rel && rel.includes('noreferrer')).toBeTruthy();
+      }
+    }
+
+    await page.goto(BASE + '/media.html');
+    const yt = page.locator('a:has-text("YouTube"), a[href*="youtube.com"]').first();
+    if (await yt.count()) {
+      const t = await yt.getAttribute('target');
+      const r = await yt.getAttribute('rel');
+      if (t === '_blank') {
+        expect(r && r.includes('noopener')).toBeTruthy();
+        expect(r && r.includes('noreferrer')).toBeTruthy();
+      }
+    }
+  });
+
+  test('Sitemap.xml is valid-looking XML with homepage loc', async ({ page }) => {
+    const res = await page.request.get(BASE + '/sitemap.xml');
+    expect(res.status()).toBe(200);
+    const xml = await res.text();
+    expect(xml.includes('<urlset')).toBeTruthy();
+    expect(xml.includes('<loc>https://thetankguide.com/</loc>') || xml.includes('<loc>https://thetankguide.com</loc>')).toBeTruthy();
+  });
+
+});


### PR DESCRIPTION
## Summary
- configure Playwright with desktop Chromium, Firefox, and WebKit projects and HTML reporting
- add resilient cross-browser UI flow coverage for key TheTankGuide pages with keyboard-driven interactions
- document setup, execution commands, and selector notes for the new end-to-end suite

## Testing
- not run (setup only)


------
https://chatgpt.com/codex/tasks/task_e_68d9a15a745c8332a12eaeecb31ded62