### PR TITLE
Adjust Stocking Advisor hero spacing

### DIFF
--- a/stocking.html
+++ b/stocking.html
@@ -52,7 +52,16 @@
     }
 
     .hero {
-      padding: 56px 0 32px;
+      padding: 12px 0 32px;
+      text-align: left;
+    }
+
+    .hero-title {
+      margin: 0 0 4px;
+    }
+
+    .hero-subline {
+      margin: 0 0 6px;
     }
 
     .brand-name {
@@ -81,10 +90,14 @@
 
     .hero .lead {
       max-width: 36rem;
-      margin: 12px 0 0;
+      margin: 6px 0 10px;
       color: var(--muted);
       font-size: 1.05rem;
       line-height: 1.5;
+    }
+
+    .page-content > .panel:first-of-type {
+      margin-top: 10px;
     }
 
     .panel {
@@ -604,6 +617,16 @@
         animation-iteration-count: 1 !important;
         transition-duration: 0.01ms !important;
         scroll-behavior: auto !important;
+      }
+    }
+
+    @media (min-width: 1024px) {
+      .hero {
+        padding-top: 16px;
+      }
+
+      .page-content > .panel:first-of-type {
+        margin-top: 14px;
       }
     }
   </style>


### PR DESCRIPTION
## Summary
- reduce the Stocking Advisor hero padding to bring the header group to the top-left of the content area
- tighten spacing between the title, subline, blurb, and first panel for improved rhythm on mobile and desktop
- add responsive tweaks to keep the hero comfortable on wider viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b77910f88332a7aebfd11f82f99b