### PR TITLE
Align tank size card styles with new markup

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -757,7 +757,7 @@ html {
   max-width: 320px;
 }
 
-.tank-footprint {
+.tank-size-card .footprint-pill {
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -772,7 +772,7 @@ html {
   min-height: 32px;
 }
 
-.tank-facts {
+.tank-size-card .facts-line {
   margin: 0;
   font-size: 0.95rem;
   padding-top: 4px;


### PR DESCRIPTION
## Summary
- retarget the tank size card footprint and facts styling to the new element classes used in the refreshed markup

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9c08cee508332b4677d8dce03c4d8