### PR TITLE
Revamp tank size card layout

### DIFF
--- a/stocking.html
+++ b/stocking.html
@@ -653,7 +653,7 @@
 
         <!-- Tank size select -->
         <div class="form-row">
-          <label for="tank-size-select" class="label">Select a tank size…</label>
+          <label for="tank-size-select" class="label">Tank size</label>
           <select id="tank-size-select" name="tankSize" aria-label="Tank size">
             <option value="" disabled selected>Select a tank size…</option>
             <!-- Options injected by JS from tankSizes.js -->
@@ -661,10 +661,19 @@
         </div>
 
         <!-- Tank footprint pill -->
-        <div id="tank-footprint" class="footprint-pill muted-text" aria-live="polite"></div>
+        <div
+          id="tank-footprint"
+          class="footprint-pill muted-text"
+          aria-live="polite"
+          hidden
+        ></div>
 
         <!-- Tank facts line -->
-        <div id="tank-facts" class="facts-line muted-text" aria-live="polite"></div>
+        <div
+          id="tank-facts"
+          class="facts-line muted-text"
+          aria-live="polite"
+        >Select a tank size to begin.</div>
 
         <!-- Planted toggle -->
         <div class="toggle-row">
@@ -693,18 +702,127 @@
         </div>
       </div>
 
-      <!-- SCOPED CSS: tighten spacing since Show More Tips row was removed -->
+      <!-- SCOPED CSS: Tank Size card layout + interactions -->
       <style>
-        .tank-size-card .toggle-row + .toggle-row {
-          margin-top: 10px;
+        .tank-size-card .form-row {
+          margin-bottom: 10px;
         }
-        .tank-size-card .facts-line,
-        .tank-size-card .footprint-pill {
-          margin-top: 10px;
-        }
+
         .tank-size-card .label {
           display: block;
           margin-bottom: 6px;
+        }
+
+        .tank-size-card select {
+          width: 100%;
+        }
+
+        .tank-size-card select:focus-visible {
+          outline: 2px solid var(--focus, rgba(0, 200, 255, 0.6));
+          outline-offset: 2px;
+        }
+
+        .tank-size-card .footprint-pill {
+          margin-top: 8px;
+        }
+
+        .tank-size-card .footprint-pill[hidden] {
+          display: none;
+        }
+
+        .tank-size-card .facts-line {
+          margin-top: 8px;
+        }
+
+        .tank-size-card .toggle-row {
+          display: flex;
+          align-items: center;
+          justify-content: space-between;
+          gap: 12px;
+          min-height: 44px;
+          flex-wrap: nowrap;
+        }
+
+        .tank-size-card .toggle-row + .toggle-row {
+          margin-top: 10px;
+        }
+
+        .tank-size-card .toggle-row > label:first-of-type {
+          flex: 1;
+          font-weight: 600;
+        }
+
+        .tank-size-card .switch {
+          position: relative;
+          display: inline-block;
+          width: 54px;
+          height: 30px;
+          flex-shrink: 0;
+          cursor: pointer;
+        }
+
+        .tank-size-card .switch input {
+          opacity: 0;
+          width: 0;
+          height: 0;
+        }
+
+        .tank-size-card .slider {
+          position: absolute;
+          inset: 0;
+          border-radius: 9999px;
+          background: var(--switch-off, rgba(255, 255, 255, 0.15));
+          transition: transform 0.2s ease, background 0.2s ease;
+        }
+
+        .tank-size-card .slider::before {
+          content: '';
+          position: absolute;
+          height: 24px;
+          width: 24px;
+          left: 3px;
+          top: 3px;
+          border-radius: 50%;
+          background: var(--thumb, #fff);
+          transition: transform 0.2s ease;
+        }
+
+        .tank-size-card .switch input:checked + .slider {
+          background: var(--switch-on, rgba(0, 200, 150, 0.9));
+        }
+
+        .tank-size-card .switch input:checked + .slider::before {
+          transform: translateX(24px);
+        }
+
+        .tank-size-card .switch:focus-within .slider {
+          outline: 2px solid var(--focus, rgba(0, 200, 255, 0.6));
+          outline-offset: 2px;
+        }
+
+        .tank-size-card .info-icon {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 28px;
+          height: 28px;
+          border-radius: 50%;
+          border: 1px solid rgba(255, 255, 255, 0.12);
+          background: rgba(255, 255, 255, 0.08);
+          font-weight: 600;
+          line-height: 1;
+          color: inherit;
+          cursor: pointer;
+          flex-shrink: 0;
+        }
+
+        .tank-size-card .info-icon:hover {
+          background: rgba(255, 255, 255, 0.16);
+        }
+
+        .tank-size-card .info-icon:focus-visible {
+          outline: 2px solid var(--focus, rgba(0, 200, 255, 0.6));
+          outline-offset: 2px;
         }
       </style>
 


### PR DESCRIPTION
## Summary
- refresh the Tank Size card markup to clean up labeling, helper text, and inline Beginner Mode info icon
- add scoped styles for the Tank Size card switches, info icon, and tightened spacing
- update the tank-size-card module to format footprint/fact strings, show helper messaging, and persist selection cleanly

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9cc5078508332a63168743d8293d6