### PR TITLE
Restyle tank size card toggles

### DIFF
--- a/js/tank-size-card.js
+++ b/js/tank-size-card.js
@@ -1,49 +1,28 @@
 /*
-  tank-size-card.js (page-scope)
-  - Populates the Tank Size <select> from tankSizes.js
-  - Updates app state (gallons/liters/selectedTankId)
-  - Updates footprint + facts display
-  - Triggers existing recompute hooks (if present)
-  Assumptions:
-    • tankSizes.js exports { listTanks, getTankById }
-    • Global/state object exists or can be created at window.appState
-    • Recompute function available as window.recomputeAll?.()
+  tank-size-card.js — stacked toggles, no footprint pill
+  - Populates select from tankSizes.js
+  - Updates state and the facts line
+  - Triggers recompute
 */
 
 import { listTanks, getTankById } from './tankSizes.js';
 
 (function initTankSizeCard(){
-  // DOM
-  const selectEl     = document.getElementById('tank-size-select');
-  const footprintEl  = document.getElementById('tank-footprint');
-  const factsEl      = document.getElementById('tank-facts');
+  const selectEl = document.getElementById('tank-size-select');
+  const factsEl  = document.getElementById('tank-facts');
 
-  if (!selectEl || !footprintEl || !factsEl) return;
+  if (!selectEl || !factsEl) return;
 
-  // State (non-destructive: reuse if app already has one)
   const state = (window.appState = window.appState || {});
   const STORAGE_KEY = 'ttg.selectedTank';
-
-  // ----- Helpers
-  const formatNumber = (value, decimals = 1) => {
-    if (typeof value !== 'number' || Number.isNaN(value)) return '';
-    const factor = 10 ** decimals;
-    const rounded = Math.round(value * factor) / factor;
-    let str = rounded.toFixed(decimals);
-    str = str.replace(/\.0+$/, '').replace(/(\.\d*[1-9])0+$/, '$1');
-    return str;
-  };
-
-  const formatDimensionIn = (value) => formatNumber(value, 2);
-  const formatDimensionCm = (value) => formatNumber(value, 1);
+  const round1 = (n) => Math.round(n * 10) / 10;
 
   function renderOptions() {
-    // Limit to the popular 5–125g sizes requested for this card.
     const tanks = listTanks()
-      .filter((t) => typeof t.gallons === 'number' && t.gallons >= 5 && t.gallons <= 125)
-      .sort((a, b) => (a.gallons - b.gallons) || a.label.localeCompare(b.label));
+      .filter(t => typeof t.gallons === 'number' && t.gallons >= 5 && t.gallons <= 125)
+      .sort((a,b) => (a.gallons - b.gallons) || a.label.localeCompare(b.label));
 
-    // Clear existing (keep placeholder)
+    // clear non-placeholder options
     [...selectEl.querySelectorAll('option:not([disabled])')].forEach(o => o.remove());
 
     for (const t of tanks) {
@@ -54,80 +33,54 @@ import { listTanks, getTankById } from './tankSizes.js';
     }
   }
 
-  function updateFactsUI(tank) {
+  function setFacts(tank) {
     if (!tank) {
-      footprintEl.textContent = '';
-      footprintEl.hidden = true;
       factsEl.textContent = 'Select a tank size to begin.';
       return;
     }
-
-    const footprintIn = `${formatDimensionIn(tank.dimensions_in.l)} × ${formatDimensionIn(tank.dimensions_in.w)} in`;
-    const footprintCm = `${formatDimensionCm(tank.dimensions_cm.l)} × ${formatDimensionCm(tank.dimensions_cm.w)} cm`;
-    footprintEl.textContent = `Footprint: ${footprintIn} (${footprintCm})`;
-    footprintEl.hidden = false;
-
-    const dimsIn = `${formatDimensionIn(tank.dimensions_in.l)} × ${formatDimensionIn(tank.dimensions_in.w)} × ${formatDimensionIn(tank.dimensions_in.h)} in`;
-    const dimsCm = `${formatDimensionCm(tank.dimensions_cm.l)} × ${formatDimensionCm(tank.dimensions_cm.w)} × ${formatDimensionCm(tank.dimensions_cm.h)} cm`;
-    const liters = formatNumber(tank.liters, 1);
-    const line = `${tank.gallons}g • ${liters} L • ${dimsIn} (${dimsCm}) • ~${tank.filled_weight_lbs} lbs filled`;
-    factsEl.textContent = line;
+    const dimsIn = `${tank.dimensions_in.l} × ${tank.dimensions_in.w} × ${tank.dimensions_in.h} in`;
+    const dimsCm = `${round1(tank.dimensions_cm.l)} × ${round1(tank.dimensions_cm.w)} × ${round1(tank.dimensions_cm.h)} cm`;
+    factsEl.textContent = `${tank.gallons}g • ${round1(tank.liters)} L • ${dimsIn} (${dimsCm}) • ~${tank.filled_weight_lbs} lbs filled`;
   }
 
-  function applyTankSelection(id) {
+  function applySelection(id) {
     const t = id ? getTankById(id) : null;
     if (!t) {
-      // Reset UI/state when no selection
       selectEl.value = '';
       state.selectedTankId = null;
       state.gallons = undefined;
       state.liters  = undefined;
-      updateFactsUI(null);
-      try { localStorage.removeItem(STORAGE_KEY); } catch (_) {}
+      setFacts(null);
       return;
     }
 
-    // Update state
     state.selectedTankId = t.id;
     state.gallons = t.gallons;
     state.liters  = t.liters;
 
-    // UI
     selectEl.value = t.id;
-    updateFactsUI(t);
+    setFacts(t);
 
-    // Persist
     try { localStorage.setItem(STORAGE_KEY, t.id); } catch (_) {}
 
-    // Trigger recompute pipeline if available
     if (typeof window.recomputeAll === 'function') {
       window.recomputeAll();
-    } else if (typeof window.dispatchEvent === 'function') {
-      // Fallback: broadcast an event some apps listen for
-      window.dispatchEvent(new CustomEvent('ttg:recompute'));
+    } else {
+      window.dispatchEvent?.(new CustomEvent('ttg:recompute'));
     }
   }
 
-  // ----- Events
-  selectEl.addEventListener('change', (e) => {
-    applyTankSelection(e.target.value);
-  });
+  // events
+  selectEl.addEventListener('change', (e) => applySelection(e.target.value));
 
-  // ----- Init
+  // init
   renderOptions();
-
-  // Hydrate from storage (if valid), else leave placeholder
   let savedId = null;
   try { savedId = localStorage.getItem(STORAGE_KEY) || null; } catch (_) {}
-  if (savedId && getTankById(savedId)) {
-    applyTankSelection(savedId);
-  } else {
-    updateFactsUI(null);
-  }
+  if (savedId && getTankById(savedId)) applySelection(savedId);
+  else setFacts(null);
 
-  // Ensure Beginner Mode remains default OFF (don’t force here—respect existing logic)
+  // keep Beginner Mode default OFF
   const beginnerToggle = document.getElementById('toggle-beginner');
-  if (beginnerToggle && beginnerToggle.checked) {
-    beginnerToggle.checked = false;
-  }
+  if (beginnerToggle) beginnerToggle.checked = false;
 })();

--- a/stocking.html
+++ b/stocking.html
@@ -647,135 +647,123 @@
     </header>
 
     <div class="wrap page-content">
-      <!-- TANK SIZE CARD (Show More Tips removed) -->
+      <!-- TANK SIZE CARD (footprint removed, stacked toggles) -->
       <div class="card tank-size-card" id="tank-size-card">
         <h2 class="card-title">Tank Size</h2>
 
-        <!-- Tank size select -->
+        <!-- Select -->
         <div class="form-row">
           <label for="tank-size-select" class="label">Tank size</label>
           <select id="tank-size-select" name="tankSize" aria-label="Tank size">
             <option value="" disabled selected>Select a tank size…</option>
-            <!-- Options injected by JS from tankSizes.js -->
+            <!-- Options injected by JS -->
           </select>
         </div>
 
-        <!-- Tank footprint pill -->
-        <div
-          id="tank-footprint"
-          class="footprint-pill muted-text"
-          aria-live="polite"
-          hidden
-        ></div>
+        <!-- Facts line (kept) -->
+        <div id="tank-facts" class="facts-line muted-text" aria-live="polite"></div>
 
-        <!-- Tank facts line -->
-        <div
-          id="tank-facts"
-          class="facts-line muted-text"
-          aria-live="polite"
-        >Select a tank size to begin.</div>
-
-        <!-- Planted toggle -->
-        <div class="toggle-row">
-          <label for="toggle-planted">Planted</label>
-          <label class="switch">
-            <input type="checkbox" id="toggle-planted" />
-            <span class="slider round"></span>
-          </label>
+        <!-- Planted (stacked) -->
+        <div class="toggle-group">
+          <div class="toggle-head">
+            <label class="toggle-title" for="toggle-planted">Planted</label>
+          </div>
+          <div class="toggle-control">
+            <label class="switch">
+              <input type="checkbox" id="toggle-planted" />
+              <span class="slider round"></span>
+            </label>
+          </div>
         </div>
 
-        <!-- Beginner Mode toggle (now directly follows Planted) -->
-        <div class="toggle-row">
-          <label for="toggle-beginner">Beginner Mode</label>
-          <label class="switch">
-            <input type="checkbox" id="toggle-beginner" />
-            <span class="slider round"></span>
-          </label>
-          <button
-            type="button"
-            class="info-icon"
-            title="Simplifies recommendations for beginners."
-            aria-label="About Beginner Mode"
-          >
-            i
-          </button>
+        <!-- Beginner Mode (stacked, with info icon beside title) -->
+        <div class="toggle-group">
+          <div class="toggle-head">
+            <label class="toggle-title" for="toggle-beginner">Beginner Mode</label>
+            <button
+              type="button"
+              class="info-icon"
+              aria-label="About Beginner Mode"
+              title="Simplifies recommendations for beginners."
+            >
+              i
+            </button>
+          </div>
+          <div class="toggle-control">
+            <label class="switch">
+              <input type="checkbox" id="toggle-beginner" />
+              <span class="slider round"></span>
+            </label>
+          </div>
         </div>
       </div>
 
-      <!-- SCOPED CSS: Tank Size card layout + interactions -->
+      <!-- SCOPED CSS (append near this card or your page stylesheet) -->
       <style>
+        /* Layout tightening for card */
         .tank-size-card .form-row {
-          margin-bottom: 10px;
+          margin-bottom: 8px;
         }
-
         .tank-size-card .label {
           display: block;
           margin-bottom: 6px;
         }
 
-        .tank-size-card select {
-          width: 100%;
-        }
-
-        .tank-size-card select:focus-visible {
-          outline: 2px solid var(--focus, rgba(0, 200, 255, 0.6));
-          outline-offset: 2px;
-        }
-
-        .tank-size-card .footprint-pill {
-          margin-top: 8px;
-        }
-
-        .tank-size-card .footprint-pill[hidden] {
-          display: none;
+        /* Remove any leftover space where the footprint pill used to be */
+        .tank-size-card #tank-footprint {
+          display: none !important;
         }
 
         .tank-size-card .facts-line {
-          margin-top: 8px;
+          margin-top: 6px;
         }
 
-        .tank-size-card .toggle-row {
-          display: flex;
-          align-items: center;
-          justify-content: space-between;
-          gap: 12px;
-          min-height: 44px;
-          flex-wrap: nowrap;
+        /* Stacked toggle groups */
+        .tank-size-card .toggle-group {
+          margin-top: 12px;
         }
-
-        .tank-size-card .toggle-row + .toggle-row {
+        .tank-size-card .toggle-group + .toggle-group {
           margin-top: 10px;
         }
 
-        .tank-size-card .toggle-row > label:first-of-type {
-          flex: 1;
-          font-weight: 600;
+        .tank-size-card .toggle-head {
+          display: flex;
+          align-items: center;
+          justify-content: flex-start;
+          gap: 8px;
+          margin-bottom: 6px;
+        }
+        .tank-size-card .toggle-title {
+          font-weight: 500;
         }
 
+        .tank-size-card .toggle-control {
+          /* ensure big tap target beneath the label */
+          display: flex;
+          align-items: center;
+          justify-content: flex-start;
+        }
+
+        /* Switch (kept from prior style; include if not global) */
         .tank-size-card .switch {
           position: relative;
           display: inline-block;
           width: 54px;
           height: 30px;
-          flex-shrink: 0;
-          cursor: pointer;
         }
-
         .tank-size-card .switch input {
           opacity: 0;
           width: 0;
           height: 0;
         }
-
         .tank-size-card .slider {
           position: absolute;
           inset: 0;
           border-radius: 9999px;
-          background: var(--switch-off, rgba(255, 255, 255, 0.15));
-          transition: transform 0.2s ease, background 0.2s ease;
+          background: rgba(255, 255, 255, 0.15);
+          transition: transform 0.2s, background 0.2s;
         }
-
-        .tank-size-card .slider::before {
+        .tank-size-card .slider:before {
           content: '';
           position: absolute;
           height: 24px;
@@ -783,45 +771,36 @@
           left: 3px;
           top: 3px;
           border-radius: 50%;
-          background: var(--thumb, #fff);
-          transition: transform 0.2s ease;
+          background: #fff;
+          transition: transform 0.2s;
         }
-
         .tank-size-card .switch input:checked + .slider {
-          background: var(--switch-on, rgba(0, 200, 150, 0.9));
+          background: rgba(0, 200, 150, 0.9);
         }
-
-        .tank-size-card .switch input:checked + .slider::before {
+        .tank-size-card .switch input:checked + .slider:before {
           transform: translateX(24px);
         }
-
         .tank-size-card .switch:focus-within .slider {
-          outline: 2px solid var(--focus, rgba(0, 200, 255, 0.6));
+          outline: 2px solid rgba(0, 200, 255, 0.6);
           outline-offset: 2px;
         }
 
+        /* Info icon beside title */
         .tank-size-card .info-icon {
           display: inline-flex;
           align-items: center;
           justify-content: center;
-          width: 28px;
-          height: 28px;
+          width: 24px;
+          height: 24px;
           border-radius: 50%;
-          border: 1px solid rgba(255, 255, 255, 0.12);
           background: rgba(255, 255, 255, 0.08);
+          border: 1px solid rgba(255, 255, 255, 0.12);
           font-weight: 600;
           line-height: 1;
-          color: inherit;
           cursor: pointer;
-          flex-shrink: 0;
         }
-
-        .tank-size-card .info-icon:hover {
-          background: rgba(255, 255, 255, 0.16);
-        }
-
-        .tank-size-card .info-icon:focus-visible {
-          outline: 2px solid var(--focus, rgba(0, 200, 255, 0.6));
+        .tank-size-card .info-icon:focus {
+          outline: 2px solid rgba(0, 200, 255, 0.6);
           outline-offset: 2px;
         }
       </style>


### PR DESCRIPTION
## Summary
- replace the Tank Size card markup to remove the footprint pill and stack the toggles beneath their labels
- tighten spacing around the select and toggle groups while preserving the facts line
- update the Tank Size card module to match the new markup while keeping Beginner Mode defaulted to off

## Testing
- Screenshot: browser:/invocations/aopixkkx/artifacts/artifacts/tank-card.png

------
https://chatgpt.com/codex/tasks/task_e_68d9ceab7d80833293addb8177a6da88