### PR TITLE
Add planted overlay effect to Stocking Advisor

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -698,28 +698,28 @@ html {
   }
 }
 
-#stocking-app section[aria-labelledby="controls-title"] {
+#stocking-page section[aria-labelledby="controls-title"] {
   margin-bottom: 16px;
 }
 
-#stocking-app #tank-summary {
+#stocking-page #tank-summary {
   margin-top: 16px;
 }
 
-#stocking-app section[aria-labelledby="water-title"] {
+#stocking-page section[aria-labelledby="water-title"] {
   margin-top: 16px;
 }
 
 @media (min-width: 720px) {
-  #stocking-app section[aria-labelledby="controls-title"] {
+  #stocking-page section[aria-labelledby="controls-title"] {
     margin-bottom: 20px;
   }
 
-  #stocking-app #tank-summary {
+  #stocking-page #tank-summary {
     margin-top: 20px;
   }
 
-  #stocking-app section[aria-labelledby="water-title"] {
+  #stocking-page section[aria-labelledby="water-title"] {
     margin-top: 20px;
   }
 }

--- a/js/tank-size-card.js
+++ b/js/tank-size-card.js
@@ -77,3 +77,17 @@ import { listTanks, getTankById } from './tankSizes.js';
   if (savedId && getTankById(savedId)) applySelection(savedId);
   else setFacts(null);
 })();
+
+(function wirePlantedOverlay(){
+  const page = document.getElementById('stocking-page');
+  const planted = document.getElementById('toggle-planted');
+  if (!page || !planted) return;
+
+  const apply = () => {
+    page.classList.toggle('is-planted', !!planted.checked);
+  };
+
+  apply();
+
+  planted.addEventListener('change', apply, { passive: true });
+})();

--- a/stocking.html
+++ b/stocking.html
@@ -23,6 +23,13 @@
       --ghost: rgba(255, 255, 255, 0.25);
       --shadow: rgba(18, 30, 56, 0.18);
       --popover-bg: rgba(6, 12, 24, 0.96);
+      --sa-plant-r: 20;
+      --sa-plant-g: 203;
+      --sa-plant-b: 168;
+      --sa-plant-wash-soft: 0.12;
+      --sa-plant-wash-strong: 0.18;
+      --sa-plant-border: rgba(20, 203, 168, 0.35);
+      --sa-plant-glow: 0 0 0 1px rgba(20, 203, 168, 0.25), 0 6px 24px rgba(20, 203, 168, 0.18);
     }
 
     html,
@@ -45,6 +52,44 @@
       max-width: 1160px;
       margin: 0 auto;
       padding: 0 18px;
+    }
+
+    .stocking-page {
+      position: relative;
+      isolation: isolate;
+    }
+
+    .stocking-page::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      z-index: -1;
+      pointer-events: none;
+      background:
+        radial-gradient(1200px 800px at 20% -10%,
+          rgba(var(--sa-plant-r), var(--sa-plant-g), var(--sa-plant-b), var(--sa-plant-wash-strong)) 0%,
+          rgba(var(--sa-plant-r), var(--sa-plant-g), var(--sa-plant-b), 0) 60%),
+        linear-gradient(180deg,
+          rgba(var(--sa-plant-r), var(--sa-plant-g), var(--sa-plant-b), var(--sa-plant-wash-soft)) 0%,
+          rgba(var(--sa-plant-r), var(--sa-plant-g), var(--sa-plant-b), 0) 60%);
+      opacity: 0;
+      transition: opacity 0.28s ease;
+      will-change: opacity;
+    }
+
+    .stocking-page.is-planted::before {
+      opacity: 1;
+    }
+
+    .stocking-page.is-planted .tank-size-card {
+      border-color: var(--sa-plant-border);
+      box-shadow: var(--sa-plant-glow);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .stocking-page::before {
+        transition: none;
+      }
     }
 
     .page-content {
@@ -578,7 +623,7 @@
 </head>
 <body class="theme-dark">
   <div id="site-nav"></div>
-  <main id="stocking-app">
+  <main id="stocking-page" class="stocking-page">
     <header class="hero">
       <div class="wrap">
         <div class="hero-header">


### PR DESCRIPTION
## Summary
- wrap the Stocking Advisor content in a dedicated #stocking-page container for scoped styling
- add a CSS-driven planted overlay and tank size card emphasis that mirrors Cycling Coach
- toggle the planted overlay class based on the existing planted checkbox state on load and change

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da036669bc8332bf28fffc2047847b