### PR TITLE
Update SEO metadata across The Tank Guide pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,6 +12,11 @@
   <meta property="og:description" content="Learn about The Tank Guide by FishKeepingLifeCo—our story, mission and vision to make beginner aquarium care simple with stocking, cycling and gear tools." />
   <meta property="og:url" content="https://thetankguide.com/about.html" />
   <meta property="og:image" content="https://thetankguide.com/logo.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:site" content="@fishkeepinglife" />
+  <meta name="twitter:title" content="The Tank Guide — FishKeepingLifeCo Story, Mission &amp; Vision" />
+  <meta name="twitter:description" content="Learn about The Tank Guide by FishKeepingLifeCo—our story, mission and vision to make beginner aquarium care simple with stocking, cycling and gear tools." />
+  <meta name="twitter:image" content="https://thetankguide.com/logo.png" />
   <link rel="icon" href="/favicon.ico" />
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />

--- a/gear.html
+++ b/gear.html
@@ -3,9 +3,21 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>The Tank Guide — Aquarium Gear, Tanks, Filters & Lighting</title>
+  <title>Gear Guide — Aquarium Filters, Heaters & Lighting | The Tank Guide</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="description" content="The Tank Guide Gear Guide: aquarium gear recommendations for filters, heaters, lighting, substrate, test kits, and planted aquarium setups.">
+  <link rel="canonical" href="https://thetankguide.com/gear.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="The Tank Guide">
+  <meta property="og:title" content="Gear Guide — Aquarium Filters, Heaters & Lighting | The Tank Guide">
+  <meta property="og:description" content="The Tank Guide Gear Guide: aquarium gear recommendations for filters, heaters, lighting, substrate, test kits, and planted aquarium setups.">
+  <meta property="og:url" content="https://thetankguide.com/gear.html">
+  <meta property="og:image" content="https://thetankguide.com/logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@fishkeepinglife">
+  <meta name="twitter:title" content="Gear Guide — Aquarium Filters, Heaters & Lighting | The Tank Guide">
+  <meta name="twitter:description" content="The Tank Guide Gear Guide: aquarium gear recommendations for filters, heaters, lighting, substrate, test kits, and planted aquarium setups.">
+  <meta name="twitter:image" content="https://thetankguide.com/logo.png">
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <link rel="icon" href="/favicon.ico" />

--- a/index.html
+++ b/index.html
@@ -6,6 +6,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Tank Guide — Stocking Advisor, Cycling Coach and Gear Recommendations | FishKeepingLifeCo</title>
   <meta name="description" content="The Tank Guide by FishKeepingLifeCo: beginner-friendly aquarium tools including a stocking advisor, cycling coach, and gear tips to build healthy freshwater aquariums.">
+  <link rel="canonical" href="https://thetankguide.com/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="The Tank Guide">
+  <meta property="og:title" content="The Tank Guide — Stocking Advisor, Cycling Coach and Gear Recommendations | FishKeepingLifeCo">
+  <meta property="og:description" content="The Tank Guide by FishKeepingLifeCo: beginner-friendly aquarium tools including a stocking advisor, cycling coach, and gear tips to build healthy freshwater aquariums.">
+  <meta property="og:url" content="https://thetankguide.com/">
+  <meta property="og:image" content="https://thetankguide.com/logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@fishkeepinglife">
+  <meta name="twitter:title" content="The Tank Guide — Stocking Advisor, Cycling Coach and Gear Recommendations | FishKeepingLifeCo">
+  <meta name="twitter:description" content="The Tank Guide by FishKeepingLifeCo: beginner-friendly aquarium tools including a stocking advisor, cycling coach, and gear tips to build healthy freshwater aquariums.">
+  <meta name="twitter:image" content="https://thetankguide.com/logo.png">
 
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />

--- a/media.html
+++ b/media.html
@@ -3,17 +3,24 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>The Tank Guide — Media: Videos, Book & Aquarium Guides</title>
+  <title>Media & Books — The Tank Guide by FishKeepingLifeCo</title>
+  <meta name="description" content="Explore The Tank Guide media and books by FishKeepingLifeCo—beginner aquarium education, previews, and resources to help you build healthy freshwater aquariums." />
+  <link rel="canonical" href="https://thetankguide.com/media.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="The Tank Guide">
+  <meta property="og:title" content="Media & Books — The Tank Guide by FishKeepingLifeCo">
+  <meta property="og:description" content="Explore The Tank Guide media and books by FishKeepingLifeCo—beginner aquarium education, previews, and resources to help you build healthy freshwater aquariums.">
+  <meta property="og:url" content="https://thetankguide.com/media.html">
+  <meta property="og:image" content="https://thetankguide.com/logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@fishkeepinglife">
+  <meta name="twitter:title" content="Media & Books — The Tank Guide by FishKeepingLifeCo">
+  <meta name="twitter:description" content="Explore The Tank Guide media and books by FishKeepingLifeCo—beginner aquarium education, previews, and resources to help you build healthy freshwater aquariums.">
+  <meta name="twitter:image" content="https://thetankguide.com/logo.png">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="description" content="Watch aquarium videos and tutorials, read articles, and discover our children’s book on the nitrogen cycle—buy on Amazon—curated by FishKeepingLifeCo." />
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <link rel="icon" href="/favicon.ico" />
-  <meta property="og:title" content="The Tank Guide — Media Hub" />
-  <meta property="og:description" content="Watch • Read • Explore — videos and blogs for every aquarist." />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://thetankguide.com/media.html" />
-
   <!-- Page-scoped styles -->
   <style>
     :root {

--- a/stocking.html
+++ b/stocking.html
@@ -2,7 +2,20 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>The Tank Guide — Stocking Advisor</title>
+  <title>Stocking Advisor — Plan a Healthy Aquarium | The Tank Guide</title>
+  <meta name="description" content="Plan a healthy freshwater aquarium with The Tank Guide Stocking Advisor—compatibility checks, bioload guidance, and beginner-friendly stocking suggestions.">
+  <link rel="canonical" href="https://thetankguide.com/stocking.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="The Tank Guide">
+  <meta property="og:title" content="Stocking Advisor — Plan a Healthy Aquarium | The Tank Guide">
+  <meta property="og:description" content="Plan a healthy freshwater aquarium with The Tank Guide Stocking Advisor—compatibility checks, bioload guidance, and beginner-friendly stocking suggestions.">
+  <meta property="og:url" content="https://thetankguide.com/stocking.html">
+  <meta property="og:image" content="https://thetankguide.com/logo.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@fishkeepinglife">
+  <meta name="twitter:title" content="Stocking Advisor — Plan a Healthy Aquarium | The Tank Guide">
+  <meta name="twitter:description" content="Plan a healthy freshwater aquarium with The Tank Guide Stocking Advisor—compatibility checks, bioload guidance, and beginner-friendly stocking suggestions.">
+  <meta name="twitter:image" content="https://thetankguide.com/logo.png">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" id="css-main" href="css/style.css?v=2024-06-05a" />
   <link rel="stylesheet" href="css/site.css?v=2024-07-05a" />


### PR DESCRIPTION
## Summary
- align homepage, gear, stocking, media, and about pages with the refreshed SEO titles, descriptions, canonicals, and Open Graph tags
- add Twitter card metadata using the @fishkeepinglife handle to match the updated social profile

## Testing
- python - <<'PY' ... (metadata verification script)


------
https://chatgpt.com/codex/tasks/task_e_68dafb6c9e948332a0a9510b40d5da1e