### PR TITLE
Remove beginner mode and add contextual info popovers

### DIFF
--- a/js/logic/conflicts.js
+++ b/js/logic/conflicts.js
@@ -115,26 +115,6 @@ export function evaluateInvertSafety(species, tankContext) {
   return { severity: 'ok', reason: '' };
 }
 
-export function beginnerInvertBlock(candidate, existingList, beginnerMode) {
-  if (!beginnerMode) {
-    return { severity: 'ok', reason: '' };
-  }
-  if (!candidate?.species) {
-    return { severity: 'ok', reason: '' };
-  }
-  const mouth = candidate.species.mouth_size_in ?? candidate.species.adult_size_in ?? 0;
-  if (mouth >= 4 && candidate.species.invert_safe === false) {
-    return { severity: 'bad', reason: 'Large predator unsafe with inverts' };
-  }
-  if (mouth >= 2.5 && candidate.species.invert_safe === false) {
-    const hasShrimp = existingList.some((entry) => entry.species?.category === 'shrimp');
-    if (hasShrimp) {
-      return { severity: 'bad', reason: 'Shrimp risk due to mouth size' };
-    }
-  }
-  return { severity: 'ok', reason: '' };
-}
-
 const SUPPORTED_SALINITY = new Set(['fresh', 'brackish-low', 'brackish-high', 'dual']);
 const SALINITY_MARINE_REASON = 'Not compatible – Salinity (Marine not supported)';
 const SALINITY_MIX_REASON = 'Mixed fresh/brackish stock—target brackish-low or use dual-tolerant species.';

--- a/js/logic/envRecommend.js
+++ b/js/logic/envRecommend.js
@@ -47,8 +47,8 @@ const RANGE_KEYS = {
   kH: ['kH', 'min_dKH', 'max_dKH'],
 };
 
-export function renderEnvCard({ stock = [], stockCount = null, beginner = false, computed = null } = {}) {
-  const env = deriveEnv(stock, { beginner, computed });
+export function renderEnvCard({ stock = [], stockCount = null, computed = null } = {}) {
+  const env = deriveEnv(stock, { computed });
   const derivedCount = typeof stockCount === 'number' ? stockCount : env.stockLength ?? (Array.isArray(stock) ? stock.length : 0);
   const isEmpty = derivedCount === 0;
   if (typeof document === 'undefined') {
@@ -92,11 +92,11 @@ export function renderEnvCard({ stock = [], stockCount = null, beginner = false,
 }
 
 export function deriveEnv(stock = [], options = {}) {
-  const { beginner = false, computed = null } = options ?? {};
+  const { computed = null } = options ?? {};
   const entries = normalizeStock(stock);
   const stockLength = entries.length;
   if (!stockLength) {
-    return buildDefaultEnv({ beginner, stockLength });
+    return buildDefaultEnv({ stockLength });
   }
 
   const conditions = [];
@@ -250,7 +250,6 @@ export function deriveEnv(stock = [], options = {}) {
   }
 
   return {
-    beginner,
     conditions,
     warnings: dedupeWarnings(warnings),
     chips: dedupeStrings(Array.from(noteCodes)),
@@ -374,13 +373,15 @@ function renderBars(root, env, { isMobile = false, isEmpty = false } = {}) {
   const generalChips = isEmpty ? '' : renderChips(env.detailChips ?? []);
   const bioloadLabel = isEmpty ? '0% → 0% of capacity' : env.bioloadLabel;
   const aggressionLabel = isEmpty ? '0%' : (aggressionPct >= 100 ? '100%' : env.aggressionLabel);
+  const bioloadInfoBtn = '<button type="button" class="info-btn" data-info="Approximate stocking level for your tank size. Stay in green for better stability.">i</button>';
+  const aggressionInfoBtn = '<button type="button" class="info-btn" data-info="Estimated compatibility risk. Adding aggressive or territorial species will raise this.">i</button>';
 
   if (isMobile) {
     root.classList.add('env-bars--xl');
     root.innerHTML = `
       <div class="env-bar env-bar--xl">
         <div class="env-bar__hd">
-          <div class="env-bar__label">Bioload</div>
+          <div class="env-bar__label">Bioload ${bioloadInfoBtn}</div>
           <div class="env-bar__value">${Math.round(bioloadPct)}%</div>
         </div>
         <div class="env-bar__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(bioloadPct)}">
@@ -389,7 +390,7 @@ function renderBars(root, env, { isMobile = false, isEmpty = false } = {}) {
       </div>
       <div class="env-bar env-bar--xl">
         <div class="env-bar__hd">
-          <div class="env-bar__label">Aggression</div>
+          <div class="env-bar__label">Aggression ${aggressionInfoBtn}</div>
           <div class="env-bar__value">${Math.round(aggressionPct)}%</div>
         </div>
         <div class="env-bar__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(aggressionPct)}">
@@ -404,7 +405,7 @@ function renderBars(root, env, { isMobile = false, isEmpty = false } = {}) {
   root.innerHTML = `
     <div class="env-bar">
       <div class="env-bar__hd">
-        <span>Bioload Capacity</span>
+        <span class="env-bar__label">Bioload ${bioloadInfoBtn}</span>
         <span>${escapeHtml(bioloadLabel)}</span>
       </div>
       <div class="env-bar__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(bioloadPct)}">
@@ -414,7 +415,7 @@ function renderBars(root, env, { isMobile = false, isEmpty = false } = {}) {
     </div>
     <div class="env-bar">
       <div class="env-bar__hd">
-        <span>Aggression &amp; Compatibility</span>
+        <span class="env-bar__label">Aggression ${aggressionInfoBtn}</span>
         <span>${escapeHtml(aggressionLabel)}</span>
       </div>
       <div class="env-bar__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(aggressionPct)}">
@@ -482,12 +483,12 @@ function ensureTips(el) {
       <li>Lock in one salinity profile; avoid mixing freshwater and brackish species unless they are noted as dual-tolerant.</li>
       <li>Blackwater lovers appreciate botanicals and tinted water; only mark it required when tannin-dependent species are present.</li>
       <li>Blend flow zones when low- and high-flow species are mixed—use spray bars or directional pumps to create calm refuges.</li>
-      <li>Beginner Mode keeps a conservative buffer on capacity and compatibility. Switch to Advanced only when you can monitor closely.</li>
+      <li>Stay within the green bioload zone for stability and increase filtration or planting before pushing higher loads.</li>
     </ul>`;
   el.dataset.bound = 'true';
 }
 
-function buildDefaultEnv({ beginner, stockLength = 0 }) {
+function buildDefaultEnv({ stockLength = 0 }) {
   const model = defaultEnvModel();
   const conditions = [
     { label: 'Temperature (°F)', value: dash },
@@ -500,7 +501,6 @@ function buildDefaultEnv({ beginner, stockLength = 0 }) {
   ];
   return {
     ...model,
-    beginner,
     conditions,
     warnings: [],
     chips: [],

--- a/js/tank-size-card.js
+++ b/js/tank-size-card.js
@@ -22,7 +22,6 @@ import { listTanks, getTankById } from './tankSizes.js';
 (function initTankSizeCard(){
   const selectEl   = document.getElementById('tank-size-select');
   const factsEl    = document.getElementById('tank-facts');
-  const beginnerEl = document.getElementById('toggle-beginner');
 
   if (!selectEl || !factsEl) return;
 
@@ -87,130 +86,11 @@ import { listTanks, getTankById } from './tankSizes.js';
   // 6) Init
   renderOptions();
 
-  // Beginner Mode defaults OFF
-  if (beginnerEl) beginnerEl.checked = false;
-
   // Hydrate persisted tank choice
   let savedId = null;
   try { savedId = localStorage.getItem(STORAGE_KEY) || null; } catch(_){ }
   if (savedId && getTankById(savedId)) applySelection(savedId);
   else setFacts(null);
-})();
-
-(function beginnerInfoInit(){
-  try{
-    const btn   = document.getElementById('bm-info-button');
-    const pop   = document.getElementById('bm-info-popover');
-    const close = document.getElementById('bm-info-close');
-    const label = document.querySelector('.tank-size-card .toggle-title[for="toggle-beginner"]');
-
-    if(!btn || !pop || !label){
-      console.error('[BeginnerInfo] Missing element(s):', { btn:!!btn, pop:!!pop, label:!!label });
-      return;
-    }
-
-    // Create portal once (top of body, no new stacking context)
-    let portal = document.getElementById('ui-portal');
-    if(!portal){
-      portal = document.createElement('div');
-      portal.id = 'ui-portal';
-      portal.style.position = 'static';
-      portal.style.isolation = 'auto';
-      document.body.appendChild(portal);
-    }
-
-    const getOffsets = () => {
-      const vv = window.visualViewport;
-      return {
-        x: vv && 'pageLeft' in vv ? vv.pageLeft : (window.pageXOffset || document.documentElement.scrollLeft || 0),
-        y: vv && 'pageTop'  in vv ? vv.pageTop  : (window.pageYOffset || document.documentElement.scrollTop  || 0),
-      };
-    };
-
-    function place(){
-      // Reveal to measure natural size
-      const wasHidden = pop.hidden;
-      pop.hidden = false;
-      const oldVis = pop.style.visibility;
-      pop.style.visibility = 'hidden';
-
-      const r  = label.getBoundingClientRect();
-      const pw = pop.offsetWidth || 280;
-      const ph = pop.offsetHeight || 140;
-      const gap = 8;
-      const { x:sx, y:sy } = getOffsets();
-
-      let left = Math.round(r.left + sx);
-      let top  = Math.round(r.bottom + sy + gap);
-
-      left = Math.min(Math.max(8 + sx, left), (window.innerWidth - pw - 8) + sx);
-      top  = Math.min(Math.max(8 + sy, top),  (window.innerHeight - ph - 8) + sy);
-
-      pop.style.left = `${left}px`;
-      pop.style.top  = `${top}px`;
-
-      pop.style.visibility = oldVis;
-      pop.hidden = wasHidden;
-    }
-
-    function open(){
-      // Move into portal (escapes any card stacking contexts)
-      if(pop.parentElement !== portal) portal.appendChild(pop);
-
-      // Position & show
-      place();
-      pop.hidden = false;
-      requestAnimationFrame(()=> pop.classList.add('is-open'));
-      btn.setAttribute('aria-expanded','true');
-
-      // TEMP debug outline (auto remove) so we can SEE it for sure
-      const oldOutline = pop.style.outline;
-      pop.style.outline = '2px solid red';
-      setTimeout(()=>{ pop.style.outline = oldOutline; }, 1000);
-
-      // listeners
-      document.addEventListener('mousedown', onDoc, { capture:true });
-      document.addEventListener('touchstart', onDoc, { capture:true });
-      document.addEventListener('keydown', onEsc, { capture:true });
-
-      window.addEventListener('scroll', onReflow, { passive:true });
-      window.addEventListener('resize', onReflow, { passive:true });
-      window.visualViewport?.addEventListener?.('scroll', onReflow, { passive:true });
-      window.visualViewport?.addEventListener?.('resize', onReflow, { passive:true });
-    }
-
-    function closePop(){
-      pop.classList.remove('is-open');
-      btn.setAttribute('aria-expanded','false');
-      setTimeout(()=>{ pop.hidden = true; }, 140);
-
-      document.removeEventListener('mousedown', onDoc, { capture:true });
-      document.removeEventListener('touchstart', onDoc, { capture:true });
-      document.removeEventListener('keydown', onEsc, { capture:true });
-
-      window.removeEventListener('scroll', onReflow);
-      window.removeEventListener('resize', onReflow);
-      window.visualViewport?.removeEventListener?.('scroll', onReflow);
-      window.visualViewport?.removeEventListener?.('resize', onReflow);
-    }
-
-    function toggle(){ pop.hidden ? open() : closePop(); }
-    function onDoc(e){ if(!pop.contains(e.target) && e.target !== btn) closePop(); }
-    function onEsc(e){ if(e.key === 'Escape') closePop(); }
-    function onReflow(){ if(!pop.hidden) place(); }
-
-    // Bind (idempotent)
-    btn.addEventListener('click', (e)=>{ e.preventDefault(); toggle(); });
-    close?.addEventListener('click', closePop);
-
-    // Final visibility sanity checks (log if something still hides it)
-    const cs = getComputedStyle(pop);
-    if(cs.display === 'none') console.warn('[BeginnerInfo] CSS sets display:none; [hidden] toggling will override with !important.');
-    if(cs.opacity === '0') console.warn('[BeginnerInfo] CSS opacity is 0 until .is-open is applied (expected).');
-    if(parseInt(cs.zIndex || '0',10) < 9999) console.warn('[BeginnerInfo] z-index looks low; ensured via CSS to 2147483647.');
-  } catch(err){
-    console.error('[BeginnerInfo] Init failed:', err);
-  }
 })();
 
 (function wirePlantedOverlay(){

--- a/stocking.html
+++ b/stocking.html
@@ -652,12 +652,12 @@
     <div class="wrap page-content">
       <!-- Tank Size card -->
       <div class="card tank-size-card" id="tank-size-card">
-        <h2 class="card-title">Tank Size</h2>
+        <h2 class="card-title">Tank Size <button type="button" class="info-btn" data-info="Pick a standard tank size to get accurate capacity, footprint, and weight.">i</button></h2>
 
         <div class="form-row">
           <label for="tank-size-select" class="sr-only">Tank size</label>
           <div class="select-wrap" id="tank-size-select-wrap">
-            <select id="tank-size-select" name="tankSize" aria-label="Tank size">
+            <select id="tank-size-select" name="tankSize" aria-label="Tank size" data-testid="tank-gallons">
               <option value="" disabled selected>Select a tank size…</option>
               <!-- Options injected by JS -->
             </select>
@@ -673,53 +673,13 @@
         <!-- Planted (stacked) -->
         <div class="toggle-group">
           <div class="toggle-head">
-            <label class="toggle-title" for="toggle-planted">Planted</label>
+            <label class="toggle-title" for="toggle-planted">Planted <button type="button" class="info-btn" data-info="Planted tanks allow higher bioload and provide stability. Toggle ON if you keep live plants.">i</button></label>
           </div>
           <div class="toggle-control">
             <label class="switch">
               <input type="checkbox" id="toggle-planted" data-testid="toggle-planted" />
               <span class="slider" aria-hidden="true"></span>
             </label>
-          </div>
-        </div>
-
-        <!-- BEGINNER MODE (stacked + working popover above all cards) -->
-        <div class="toggle-group">
-          <div class="toggle-head">
-            <label class="toggle-title" for="toggle-beginner">Beginner Mode</label>
-            <button
-              type="button"
-              class="info-icon"
-              id="bm-info-button"
-              aria-label="What is Beginner Mode?"
-              aria-haspopup="dialog"
-              aria-expanded="false"
-              aria-controls="bm-info-popover"
-            >i</button>
-          </div>
-
-          <div class="toggle-control">
-            <label class="switch">
-              <input type="checkbox" id="toggle-beginner" />
-              <span class="slider" aria-hidden="true"></span>
-            </label>
-          </div>
-
-          <!-- Popover rendered once; JS positions it near the button -->
-          <div
-            id="bm-info-popover"
-            class="bm-popover"
-            role="dialog"
-            aria-modal="false"
-            aria-labelledby="bm-info-title"
-            hidden
-          >
-            <h3 id="bm-info-title" class="bm-popover-title">Beginner Mode</h3>
-            <p class="bm-popover-text">
-              Beginner Mode simplifies recommendations by favoring hardy, easy-care species and safer parameter ranges.
-              Turn it off to see the full catalog and advanced options.
-            </p>
-            <button type="button" class="bm-popover-close" id="bm-info-close" aria-label="Close">OK</button>
           </div>
         </div>
       </div>
@@ -868,55 +828,49 @@
         /* Ensure the card can host positioned children safely */
         .tank-size-card{ position: relative; }
 
-        /* Info icon base (neutral when closed) */
-        .tank-size-card #bm-info-button{
-          position: relative; z-index: 2; pointer-events: auto;
+        /* Info button (small neutral pill) */
+        #stocking-page .info-btn{
           display:inline-flex; align-items:center; justify-content:center;
-          width:24px; height:24px; border-radius:50%;
-          background: rgba(255,255,255,0.08); border:1px solid rgba(255,255,255,0.12);
+          width:22px; height:22px; margin-left:.5rem;
+          border-radius:50%;
+          background: rgba(255,255,255,.08);
+          border:1px solid rgba(255,255,255,.12);
           font-weight:600; line-height:1; cursor:pointer;
+          color:inherit;
         }
-        /* Highlight ONLY when popover is open (aria-expanded=true) */
-        .tank-size-card #bm-info-button[aria-expanded="true"]{
-          background: rgba(20,203,168,0.9); color:#0b1b18; border-color: rgba(20,203,168,0.95);
-          box-shadow: 0 0 0 2px rgba(20,203,168,0.25);
-        }
+        #stocking-page .info-btn:focus{ outline:2px solid rgba(20,203,168,.55); outline-offset:2px; }
 
-        /* Popover above everything: fixed + high z-index; positioned by JS via top/left */
-        :is(.tank-size-card, #ui-portal) .bm-popover{
+        /* Shared popover for all info buttons (portal) */
+        #stocking-page .ttg-popover{
           position: fixed;
           z-index: 2147483647;
           pointer-events: auto;
-          min-width: 240px;
-          max-width: 320px;
+          min-width: 240px; max-width: 320px;
           padding: 12px 12px 10px;
           border-radius: 10px;
-          background: rgba(20, 22, 25, 0.96);
-          border: 1px solid rgba(255, 255, 255, 0.12);
-          box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
-          color: inherit;
+          background: rgba(20,22,25,.96);
+          border: 1px solid rgba(255,255,255,.12);
+          box-shadow: 0 10px 30px rgba(0,0,0,.35);
+          color:inherit;
           transform-origin: top left;
-          opacity: 0;
-          transform: scale(0.98);
-          transition: opacity 0.14s ease, transform 0.14s ease;
+          opacity: 0; transform: scale(.98);
+          transition: opacity .14s ease, transform .14s ease;
         }
-        :is(.tank-size-card, #ui-portal) .bm-popover.is-open{ opacity: 1; transform: scale(1); }
-        :is(.tank-size-card, #ui-portal) .bm-popover[hidden]{ display:none !important; }
+        #stocking-page .ttg-popover.is-open{ opacity:1; transform:scale(1); }
+        #stocking-page .ttg-popover[hidden]{ display:none !important; }
 
-        .tank-size-card .bm-popover-title{ font-size:14px; margin:0 0 6px; font-weight:600; }
-        .tank-size-card .bm-popover-text{ font-size:13px; margin:0 0 10px; line-height:1.4; }
-
-        .tank-size-card .bm-popover-close{
+        #stocking-page .ttg-popover h3{ font-size:14px; margin:0 0 6px; font-weight:600; }
+        #stocking-page .ttg-popover p{ font-size:13px; margin:0 0 10px; line-height:1.4; }
+        #stocking-page .ttg-popover .close{
           display:inline-flex; align-items:center; justify-content:center;
           height:30px; padding:0 10px; border-radius:8px;
-          background: rgba(255,255,255,0.08);
-          border:1px solid rgba(255,255,255,0.12);
+          background: rgba(255,255,255,.08);
+          border:1px solid rgba(255,255,255,.12);
           color:inherit; cursor:pointer;
         }
-        .tank-size-card .bm-popover-close:focus{ outline:2px solid rgba(20,203,168,0.55); outline-offset:2px; }
 
         @media (prefers-reduced-motion: reduce){
-          .tank-size-card .bm-popover{ transition:none; }
+          #stocking-page .ttg-popover{ transition:none; }
         }
       </style>
 
@@ -924,7 +878,7 @@
 
       <section class="card" id="stock-list-card" aria-live="polite">
         <div class="card__hd">
-          <h2>Current Stock</h2>
+          <h2>Current Stock <button type="button" class="info-btn" data-info="This list shows species you’ve added and their quantities. Use +/− to adjust and Remove to clear.">i</button></h2>
           <p class="subtle">Your selected fish and inverts appear here.</p>
         </div>
         <div id="stock-list" class="stock-list" data-testid="species-list"></div>
@@ -933,7 +887,7 @@
       <section class="card tank-env-card env-card" id="env-card" aria-live="polite">
         <div class="card__hd card__hd--split">
           <div class="card__title-stack">
-            <h2>Environmental Recommendations</h2>
+            <h2>Environmental Recommendations <button type="button" class="info-btn" data-info="Derived from your selected stock. Ranges reflect compatible overlaps across all species.">i</button></h2>
             <p class="subtle card__subtitle">Derived from your selected stock.</p>
           </div>
           <button type="button" id="env-tips-toggle" class="linklike" aria-pressed="false">Show More Tips</button>
@@ -950,7 +904,7 @@
         </div>
 
         <div id="env-tips" class="env-tips" hidden>
-          <!-- brief bullets about GH/KH, salinity, blackwater, flow zones, and Beginner Mode -->
+          <!-- brief bullets about GH/KH, salinity, blackwater, and flow zones -->
         </div>
       </section>
 
@@ -988,7 +942,7 @@
             style="display:none;"
             data-testid="status-banner"
           >
-            Beginner safeguards: fix highlighted issues before adding.
+            Stocking safeguards: fix highlighted issues before adding.
           </div>
         </div>
       </section>
@@ -1022,52 +976,5 @@
   <script type="module" src="js/stocking.js?v=2024-06-05a" id="js-stocking"></script>
   <script type="module" src="js/tank-size-card.js"></script>
 
-  <div
-    id="beginner-info"
-    class="popover"
-    data-hidden="true"
-    role="dialog"
-    aria-modal="false"
-    data-testid="info-popover"
-  >
-    <strong>Beginner safeguards</strong>
-    <p style="margin:8px 0 0;">
-      Beginner mode enforces conservative limits: risky pairings, salinity mismatches, and high bioload overages block the add
-      button. Switch to Advanced to accept higher risk with caution banners.
-    </p>
-    <button type="button" class="link-like" data-popover-close data-testid="info-popover-close">Close</button>
-  </div>
-
-  <div
-    id="bioload-why"
-    class="popover"
-    data-hidden="true"
-    role="dialog"
-    aria-modal="false"
-    data-testid="info-popover"
-  >
-    <strong>How capacity is calculated</strong>
-    <p style="margin:8px 0 0;">
-      Effective volume considers sump capacity, filtration turnover, and whether the tank is planted. Beginner mode keeps a 15%
-      safety buffer so new keepers have extra margin.
-    </p>
-    <button type="button" class="link-like" data-popover-close data-testid="info-popover-close">Close</button>
-  </div>
-
-  <div
-    id="aggression-why"
-    class="popover"
-    data-hidden="true"
-    role="dialog"
-    aria-modal="false"
-    data-testid="info-popover"
-  >
-    <strong>Compatibility checks</strong>
-    <p style="margin:8px 0 0;">
-      We compare temperament scores, territorial tags, and known conflict pairs. Longer tanks reduce tension by giving fish room
-      to establish territories.
-    </p>
-    <button type="button" class="link-like" data-popover-close data-testid="info-popover-close">Close</button>
-  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove Beginner Mode from the stocking page and replace it with contextual info icons and copy updates
- simplify the stocking computation pipeline by treating beginner safeguards as always off and cleaning up unused conflict logic
- wire up a shared info-popover controller and refresh the Playwright coverage for the new on-demand guidance

## Testing
- `npm test` *(fails: Playwright browsers not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db155805dc8332ac9a4caefb74540b