### PR TITLE
Remove info buttons from tank size and current stock headers

### DIFF
--- a/stocking.html
+++ b/stocking.html
@@ -880,7 +880,6 @@
         <div class="row title-row between">
           <div class="title-left">
             <h2 class="card-title">Tank Size</h2>
-            <button type="button" class="info-btn" data-info="Pick a standard tank size to get accurate capacity, footprint, and weight." aria-label="About Tank Size">i</button>
           </div>
         </div>
 
@@ -1122,7 +1121,6 @@
           <div class="row title-row between">
             <div class="title-left">
               <h2 class="card-title">Current Stock</h2>
-              <button type="button" class="info-btn" data-info="This list shows species you’ve added and their quantities. Use +/− to adjust and Remove to clear." aria-label="About Current Stock">i</button>
             </div>
           </div>
           <p class="subtle">Your selected fish and inverts appear here.</p>


### PR DESCRIPTION
## Summary
- remove the informational icon buttons from the Tank Size and Current Stock card headers on the stocking page

## Testing
- Manual - Viewed stocking page on desktop
- Manual - Viewed stocking page on mobile

------
https://chatgpt.com/codex/tasks/task_e_68dbd8e4620c8332b0640c9dc58c2da6