### PR TITLE
Adjust Environmental Recommendations header layout

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -36,6 +36,8 @@
 .env-xl-nowrap { white-space:nowrap; }
 
 /* Environmental recommendations card refinements */
+#stocking-page .env-header { margin-bottom:6px; }
+#stocking-page .env-subtitle { margin:2px 0 0; font-size:13px; color:rgba(255,255,255,.7); line-height:1.3; }
 #env-card .card__hd { margin-bottom:12px; }
 #env-card .card__hd--split { align-items:flex-start; }
 #env-card .card__title-stack { display:flex; flex-direction:column; gap:4px; min-width:0; }

--- a/stocking.html
+++ b/stocking.html
@@ -1145,22 +1145,24 @@
 
       <section class="card ttg-card tank-env-card env-card" id="env-card" aria-live="polite">
         <div class="card__hd card__hd--split">
-          <div class="row title-row between env-header" id="env-header">
-            <h2 class="card-title">Environmental Recommendations</h2>
-            <!-- SINGLE unified icon: shows popover on first click, toggles tips on next clicks -->
-            <button
-              type="button"
-              id="env-info-toggle"
-              class="info-btn"
-              aria-controls="env-more-tips"
-              aria-expanded="false"
-              aria-label="More info and tips about Environmental Recommendations"
-              data-info="Derived from your selected stock. Ranges reflect compatible overlaps across all species."
-            >
-              i
-            </button>
+          <div class="env-header" id="env-header">
+            <div class="row title-row between">
+              <h2 class="card-title">Environmental Recommendations</h2>
+              <!-- SINGLE unified icon: shows popover on first click, toggles tips on next clicks -->
+              <button
+                type="button"
+                id="env-info-toggle"
+                class="info-btn"
+                aria-controls="env-more-tips"
+                aria-expanded="false"
+                aria-label="More info and tips about Environmental Recommendations"
+                data-info="Derived from your selected stock. Ranges reflect compatible overlaps across all species."
+              >
+                i
+              </button>
+            </div>
+            <p class="env-subtitle">Derived from your selected stock.</p>
           </div>
-          <p class="subtle card__subtitle">Derived from your selected stock.</p>
         </div>
 
         <div id="env-warnings" class="env-warnings" hidden></div>


### PR DESCRIPTION
## Summary
- group the Environmental Recommendations title and info button with its subtitle inside a dedicated header container
- add styling so the subtitle sits below the title with consistent spacing and muted typography

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbefa65bc88332ab1147ce1e4d6d61