### PR TITLE
Adjust bioload/aggression card compact behaviour

### DIFF
--- a/js/logic/envRecommend.js
+++ b/js/logic/envRecommend.js
@@ -379,22 +379,24 @@ function renderBars(root, env, { isMobile = false, isEmpty = false } = {}) {
   if (isMobile) {
     root.classList.add('env-bars--xl');
     root.innerHTML = `
-      <div class="env-bar env-bar--xl">
-        <div class="env-bar__hd">
-          <div class="env-bar__label">Bioload ${bioloadInfoBtn}</div>
-          <div class="env-bar__value">${Math.round(bioloadPct)}%</div>
+      <div id="bioagg-card" class="ttg-card bioagg-card is-compact">
+        <div class="env-bar env-bar--xl bar-row">
+          <div class="env-bar__hd">
+            <div class="env-bar__label metric-label">Bioload ${bioloadInfoBtn}</div>
+            <div class="env-bar__value">${Math.round(bioloadPct)}%</div>
+          </div>
+          <div class="env-bar__track meter-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(bioloadPct)}">
+            <div class="env-bar__fill" style="width:${bioloadPct}%; background:${bioloadColor};"></div>
+          </div>
         </div>
-        <div class="env-bar__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(bioloadPct)}">
-          <div class="env-bar__fill" style="width:${bioloadPct}%; background:${bioloadColor};"></div>
-        </div>
-      </div>
-      <div class="env-bar env-bar--xl">
-        <div class="env-bar__hd">
-          <div class="env-bar__label">Aggression ${aggressionInfoBtn}</div>
-          <div class="env-bar__value">${Math.round(aggressionPct)}%</div>
-        </div>
-        <div class="env-bar__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(aggressionPct)}">
-          <div class="env-bar__fill" style="width:${aggressionPct}%; background:${aggressionColor};"></div>
+        <div class="env-bar env-bar--xl bar-row">
+          <div class="env-bar__hd">
+            <div class="env-bar__label metric-label">Aggression ${aggressionInfoBtn}</div>
+            <div class="env-bar__value">${Math.round(aggressionPct)}%</div>
+          </div>
+          <div class="env-bar__track meter-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(aggressionPct)}">
+            <div class="env-bar__fill" style="width:${aggressionPct}%; background:${aggressionColor};"></div>
+          </div>
         </div>
       </div>
     `;
@@ -403,27 +405,29 @@ function renderBars(root, env, { isMobile = false, isEmpty = false } = {}) {
 
   root.classList.remove('env-bars--xl');
   root.innerHTML = `
-    <div class="env-bar">
-      <div class="env-bar__hd">
-        <span class="env-bar__label">Bioload ${bioloadInfoBtn}</span>
-        <span>${escapeHtml(bioloadLabel)}</span>
+    <div id="bioagg-card" class="ttg-card bioagg-card is-compact">
+      <div class="env-bar metric-row">
+        <div class="env-bar__hd">
+          <span class="env-bar__label metric-label">Bioload ${bioloadInfoBtn}</span>
+          <span>${escapeHtml(bioloadLabel)}</span>
+        </div>
+        <div class="env-bar__track progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(bioloadPct)}">
+          <div class="env-bar__fill" style="width:${bioloadPct}%; background:${bioloadColor};"></div>
+        </div>
+        ${bioloadNotes}
       </div>
-      <div class="env-bar__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(bioloadPct)}">
-        <div class="env-bar__fill" style="width:${bioloadPct}%; background:${bioloadColor};"></div>
+      <div class="env-bar metric-row">
+        <div class="env-bar__hd">
+          <span class="env-bar__label metric-label">Aggression ${aggressionInfoBtn}</span>
+          <span>${escapeHtml(aggressionLabel)}</span>
+        </div>
+        <div class="env-bar__track progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(aggressionPct)}">
+          <div class="env-bar__fill" style="width:${aggressionPct}%; background:${aggressionColor};"></div>
+        </div>
+        ${aggressionNotes}
       </div>
-      ${bioloadNotes}
-    </div>
-    <div class="env-bar">
-      <div class="env-bar__hd">
-        <span class="env-bar__label">Aggression ${aggressionInfoBtn}</span>
-        <span>${escapeHtml(aggressionLabel)}</span>
-      </div>
-      <div class="env-bar__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(aggressionPct)}">
-        <div class="env-bar__fill" style="width:${aggressionPct}%; background:${aggressionColor};"></div>
-      </div>
-      ${aggressionNotes}
-    </div>
-    ${generalChips}`;
+      ${generalChips}
+    </div>`;
 }
 
 function renderWarnings(root, warnings) {

--- a/js/stocking.js
+++ b/js/stocking.js
@@ -911,6 +911,9 @@ bootstrapStocking();
     titleEl.textContent = 'Info';
     textEl.textContent  = info;
 
+    if (btn.closest('#bioagg-card')) pop.dataset.bioagg = '1';
+    else delete pop.dataset.bioagg;
+
     placeUnder(btn);
     pop.hidden = false;
     requestAnimationFrame(()=> pop.classList.add('is-open'));
@@ -928,6 +931,7 @@ bootstrapStocking();
   function closePop(){
     pop.classList.remove('is-open');
     setTimeout(()=>{ pop.hidden = true; }, 140);
+    delete pop.dataset.bioagg;
     currentBtn = null;
 
     document.removeEventListener('mousedown', onDoc, { capture:true });
@@ -952,4 +956,52 @@ bootstrapStocking();
     else closePop();
   });
   closeEl.addEventListener('click', closePop);
+})();
+
+(function compactBioAggController(){
+  function getCard(){
+    return document.getElementById('bioagg-card');
+  }
+
+  function infoVisible(card){
+    if (!card) return false;
+    const openPop = document.querySelector('.ttg-popover.is-open[data-bioagg="1"]');
+    if (openPop) return true;
+
+    const activeEl = document.activeElement;
+    if (activeEl && card.contains(activeEl) && activeEl.classList.contains('info-btn')) {
+      return true;
+    }
+
+    const expanded = card.querySelector('[aria-expanded="true"]');
+    if (expanded) return true;
+
+    return false;
+  }
+
+  function update(){
+    const card = getCard();
+    if (!card) return;
+    if (infoVisible(card)) {
+      card.classList.remove('is-compact');
+    } else {
+      card.classList.add('is-compact');
+    }
+  }
+
+  document.addEventListener('click', ()=> setTimeout(update, 0), true);
+  document.addEventListener('keydown', (e)=>{
+    if (e.key === 'Escape') setTimeout(update, 0);
+  }, true);
+  window.addEventListener('resize', ()=> setTimeout(update, 0));
+  window.visualViewport?.addEventListener?.('resize', ()=> setTimeout(update, 0));
+  window.visualViewport?.addEventListener?.('scroll', ()=> setTimeout(update, 0));
+
+  const envBars = document.getElementById('env-bars');
+  if (envBars) {
+    const observer = new MutationObserver(()=> setTimeout(update, 0));
+    observer.observe(envBars, { childList: true });
+  }
+
+  update();
 })();

--- a/stocking.html
+++ b/stocking.html
@@ -834,6 +834,47 @@
       margin-bottom: 0;
     }
 
+    /* ----- Compact card defaults ----- */
+    #stocking-page #bioagg-card.is-compact{
+      padding-top: 8px;
+      padding-bottom: 10px;
+    }
+
+    /* Tighter spacing for meter rows in compact state */
+    #stocking-page #bioagg-card.is-compact .metric-row,
+    #stocking-page #bioagg-card.is-compact .bar-row{
+      margin-top: 6px;
+      margin-bottom: 6px;
+    }
+
+    /* Slightly shorter progress bar track when compact */
+    #stocking-page #bioagg-card.is-compact .progress-track,
+    #stocking-page #bioagg-card.is-compact .meter-track{
+      height: 8px;           /* keep touch target via surrounding row, not the track */
+    }
+
+    /* Labels + info badge area: small gap */
+    #stocking-page #bioagg-card.is-compact .metric-label{
+      margin-bottom: 4px;
+    }
+
+    /* Normal (expanded) state remains your existing styling; we only add a min expansion baseline */
+    #stocking-page #bioagg-card:not(.is-compact){
+      padding-top: 12px;
+      padding-bottom: 14px;
+    }
+
+    /* Ensure popovers render above the card after tightening */
+    #stocking-page .ttg-popover{ z-index: 2147483647; }
+
+    /* Mobile micro-tweak */
+    @media (max-width: 480px){
+      #stocking-page #bioagg-card.is-compact{
+        padding-top: 6px;
+        padding-bottom: 8px;
+      }
+    }
+
     #stocking-page button:not(.info-btn),
     #stocking-page select {
       min-height: 44px;


### PR DESCRIPTION
## Summary
- wrap the bioload/aggression bars in a dedicated bioagg-card container that defaults to the compact state
- add scoped styling to tighten spacing for the compact card while preserving the expanded layout
- toggle the compact class dynamically when info popovers or expanded panels are shown

## Testing
- Manual verification in desktop and mobile viewports

------
https://chatgpt.com/codex/tasks/task_e_68dc09f081188332b38c408eb514d4c8