### PR TITLE
Make Bioload/Aggression card compact by default

### DIFF
--- a/stocking.html
+++ b/stocking.html
@@ -834,42 +834,53 @@
       margin-bottom: 0;
     }
 
-    /* ----- Compact card defaults ----- */
-    #stocking-page #bioagg-card.is-compact{
-      padding-top: 8px;
-      padding-bottom: 10px;
+    /* ----- Compact Bioload/Aggression card adjustments ----- */
+    #stocking-page #bioagg-card {
+      display: block;
+      min-height: unset !important;
+      height: auto !important;
+      flex: 0 0 auto !important;
     }
 
-    /* Tighter spacing for meter rows in compact state */
+    #stocking-page #bioagg-card.is-compact {
+      padding-top: 8px;
+      padding-bottom: 10px;
+      margin-bottom: 12px;
+    }
+
     #stocking-page #bioagg-card.is-compact .metric-row,
-    #stocking-page #bioagg-card.is-compact .bar-row{
+    #stocking-page #bioagg-card.is-compact .bar-row {
       margin-top: 6px;
       margin-bottom: 6px;
     }
 
-    /* Slightly shorter progress bar track when compact */
     #stocking-page #bioagg-card.is-compact .progress-track,
-    #stocking-page #bioagg-card.is-compact .meter-track{
-      height: 8px;           /* keep touch target via surrounding row, not the track */
+    #stocking-page #bioagg-card.is-compact .meter-track {
+      height: 8px;
     }
 
-    /* Labels + info badge area: small gap */
-    #stocking-page #bioagg-card.is-compact .metric-label{
-      margin-bottom: 4px;
+    #stocking-page #bioagg-card .card-spacer:empty,
+    #stocking-page #bioagg-card .card-footer:empty {
+      display: none !important;
     }
 
-    /* Normal (expanded) state remains your existing styling; we only add a min expansion baseline */
-    #stocking-page #bioagg-card:not(.is-compact){
-      padding-top: 12px;
-      padding-bottom: 14px;
+    #stocking-page #bioagg-card.is-compact::after,
+    #stocking-page #bioagg-card.is-compact::before {
+      height: 0 !important;
+    }
+
+    #stocking-page #bioagg-card .bioagg-body {
+      min-height: 0 !important;
+      height: auto !important;
     }
 
     /* Ensure popovers render above the card after tightening */
-    #stocking-page .ttg-popover{ z-index: 2147483647; }
+    #stocking-page .ttg-popover {
+      z-index: 2147483647;
+    }
 
-    /* Mobile micro-tweak */
-    @media (max-width: 480px){
-      #stocking-page #bioagg-card.is-compact{
+    @media (orientation: portrait) and (max-width: 480px) {
+      #stocking-page #bioagg-card.is-compact {
         padding-top: 6px;
         padding-bottom: 8px;
       }


### PR DESCRIPTION
## Summary
- override the Bioload/Aggression card styling so the compact variant collapses to the meter rows without extra height and survives theme flex/min-height overrides
- harden the compact-mode controller to strip injected heights, watch for card re-rendering, and automatically expand only while supplemental info is shown

## Testing
- Manual: attempted to load stocking.html locally (Playwright automation timed out while targeting the DOM)


------
https://chatgpt.com/codex/tasks/task_e_68dc2d0032c88332811f21250736385a