### PR TITLE
Update footer to v1.2.1 and add copyright-dmca page

### DIFF
--- a/about.html
+++ b/about.html
@@ -357,7 +357,7 @@
   <script>
   (async () => {
     try {
-      const res = await fetch('footer.html?v=1.2.0', { cache: 'no-cache' });
+      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
       const html = await res.text();
       const host = document.getElementById('site-footer');
       if (host) host.outerHTML = html;

--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -399,7 +399,7 @@
   <script>
   (async () => {
     try {
-      const res = await fetch('footer.html?v=1.2.0', { cache: 'no-cache' });
+      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
       const html = await res.text();
       const host = document.getElementById('site-footer');
       if (host) host.outerHTML = html;

--- a/copyright-dmca.html
+++ b/copyright-dmca.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Copyright & Content Usage | The Tank Guide</title>
+  <meta name="description" content="Copyright notice, permitted use, and DMCA takedown process for The Tank Guide." />
+  <link rel="canonical" href="https://thetankguide.com/copyright-dmca.html" />
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="The Tank Guide" />
+  <meta property="og:title" content="Copyright & Content Usage | The Tank Guide" />
+  <meta property="og:description" content="Copyright notice, permitted use, and DMCA takedown process for The Tank Guide." />
+  <meta property="og:url" content="https://thetankguide.com/copyright-dmca.html" />
+  <meta property="og:image" content="https://thetankguide.com/logo.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Copyright & Content Usage | The Tank Guide" />
+  <meta name="twitter:description" content="Copyright notice, permitted use, and DMCA takedown process for The Tank Guide." />
+  <meta name="twitter:image" content="https://thetankguide.com/logo.png" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.9" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
+  <script defer src="js/nav.js?v=1.0.9"></script>
+  <style>
+    body{background:#0c1b2d;color:#f4f7fb;font-family:"Segoe UI",Roboto,Arial,sans-serif;margin:0;}
+    main{padding:80px 20px 120px;}
+    .legal-wrapper{max-width:860px;margin:0 auto;background:rgba(8,20,34,0.7);border:1px solid rgba(241,245,249,0.1);border-radius:22px;padding:44px 40px;backdrop-filter:blur(12px);box-shadow:0 24px 68px rgba(5,12,24,0.48);}
+    h1{margin-top:0;font-size:2.3rem;font-weight:800;color:#e5eeff;}
+    h2{margin-top:40px;font-size:1.55rem;color:#9cc9ff;}
+    p,li{line-height:1.65;color:rgba(229,238,255,0.88);}
+    a{color:#7dd3fc;text-decoration:underline;}
+    ul{padding-left:24px;}
+    .dmca-table{width:100%;border-collapse:collapse;margin-top:20px;font-size:0.95rem;}
+    .dmca-table th,.dmca-table td{border:1px solid rgba(255,255,255,0.15);padding:12px 16px;text-align:left;}
+    .dmca-table th{background:rgba(125,211,252,0.12);color:#e5f4ff;}
+    .meta{margin-top:28px;font-size:0.95rem;color:rgba(229,238,255,0.75);}
+    @media (max-width:640px){
+      main{padding:60px 14px 80px;}
+      .legal-wrapper{padding:32px 24px;}
+      .dmca-table{display:block;overflow-x:auto;}
+    }
+  </style>
+</head>
+<body>
+  <div id="site-nav"></div>
+  <main>
+    <article class="legal-wrapper">
+      <h1>Copyright & Content Usage</h1>
+      <p>All text, graphics, tools, code, and media published on TheTankGuide.com are © FishKeepingLifeCo unless otherwise noted. These materials are protected by United States and international copyright laws.</p>
+
+      <h2>Permitted Personal Use</h2>
+      <ul>
+        <li>Download or print single copies of pages for personal, non-commercial reference.</li>
+        <li>Share links to TheTankGuide.com on social media with proper attribution.</li>
+        <li>Embed our public YouTube videos using the official platform embed.</li>
+      </ul>
+
+      <h2>Restricted Uses</h2>
+      <ul>
+        <li>Do not republish articles, data, or images without written permission.</li>
+        <li>Do not mirror, scrape, or bulk download the site.</li>
+        <li>Do not use our branding, trademarks, or photography in your products or ads without consent.</li>
+      </ul>
+
+      <h2>Content Usage Requests</h2>
+      <p>For syndication, licensing, or collaboration inquiries, email <a href="mailto:info@thetankguide.com">info@thetankguide.com</a> with a description of the intended use and audience.</p>
+
+      <h2>DMCA Takedown Process</h2>
+      <p>If you believe your copyrighted work has been used on TheTankGuide.com without authorization, provide a DMCA notice containing the following information:</p>
+      <table class="dmca-table">
+        <thead>
+          <tr>
+            <th>Required Information</th>
+            <th>Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Your contact details</td>
+            <td>Name, mailing address, telephone number, and email.</td>
+          </tr>
+          <tr>
+            <td>Work identification</td>
+            <td>Description or link to the copyrighted work you claim has been infringed.</td>
+          </tr>
+          <tr>
+            <td>Infringing material</td>
+            <td>URL(s) on TheTankGuide.com where the material is located.</td>
+          </tr>
+          <tr>
+            <td>Statement of ownership</td>
+            <td>A statement that you have a good-faith belief the use is unauthorized, and that the information in the notice is accurate.</td>
+          </tr>
+          <tr>
+            <td>Signature</td>
+            <td>Physical or electronic signature of the copyright owner or authorized agent.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>Email completed notices to <a href="mailto:dmca@thetankguide.com">dmca@thetankguide.com</a>.</p>
+
+      <h2>Counter-Notification</h2>
+      <p>If you believe your content was removed in error, submit a counter-notice containing your contact information, identification of the removed content, and a statement under penalty of perjury that the removal was a mistake. We will notify the original complainant and restore the material within 10 business days unless they file an action seeking a court order.</p>
+
+      <h2>Watermarking & Protective Measures</h2>
+      <p>Featured imagery may include subtle watermarking or downscaled resolutions to deter unauthorized commercial reuse while preserving user experience.</p>
+
+      <p class="meta">Effective date: September 30, 2025</p>
+    </article>
+  </main>
+  <script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "name": "Copyright & Content Usage",
+  "url": "https://thetankguide.com/copyright-dmca.html",
+  "datePublished": "2025-09-30",
+  "dateModified": "2025-09-30",
+  "publisher": {
+    "@type": "Organization",
+    "name": "FishKeepingLifeCo",
+    "url": "https://thetankguide.com",
+    "logo": {
+      "@type": "ImageObject",
+      "url": "https://thetankguide.com/logo.png"
+    }
+  }
+}
+  </script>
+</body>
+</html>

--- a/copyright.html
+++ b/copyright.html
@@ -2,128 +2,14 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Copyright & Content Usage | The Tank Guide</title>
-  <meta name="description" content="Copyright notice, permitted use, and DMCA takedown process for The Tank Guide." />
-  <link rel="canonical" href="https://thetankguide.com/copyright.html" />
-  <meta property="og:type" content="website" />
-  <meta property="og:site_name" content="The Tank Guide" />
-  <meta property="og:title" content="Copyright & Content Usage | The Tank Guide" />
-  <meta property="og:description" content="Copyright notice, permitted use, and DMCA takedown process for The Tank Guide." />
-  <meta property="og:url" content="https://thetankguide.com/copyright.html" />
-  <meta property="og:image" content="https://thetankguide.com/logo.png" />
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Copyright & Content Usage | The Tank Guide" />
-  <meta name="twitter:description" content="Copyright notice, permitted use, and DMCA takedown process for The Tank Guide." />
-  <meta name="twitter:image" content="https://thetankguide.com/logo.png" />
-  <link rel="stylesheet" href="css/style.css?v=1.0.9" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
-  <script defer src="js/nav.js?v=1.0.9"></script>
-  <style>
-    body{background:#0c1b2d;color:#f4f7fb;font-family:"Segoe UI",Roboto,Arial,sans-serif;margin:0;}
-    main{padding:80px 20px 120px;}
-    .legal-wrapper{max-width:860px;margin:0 auto;background:rgba(8,20,34,0.7);border:1px solid rgba(241,245,249,0.1);border-radius:22px;padding:44px 40px;backdrop-filter:blur(12px);box-shadow:0 24px 68px rgba(5,12,24,0.48);}
-    h1{margin-top:0;font-size:2.3rem;font-weight:800;color:#e5eeff;}
-    h2{margin-top:40px;font-size:1.55rem;color:#9cc9ff;}
-    p,li{line-height:1.65;color:rgba(229,238,255,0.88);}
-    a{color:#7dd3fc;text-decoration:underline;}
-    ul{padding-left:24px;}
-    .dmca-table{width:100%;border-collapse:collapse;margin-top:20px;font-size:0.95rem;}
-    .dmca-table th,.dmca-table td{border:1px solid rgba(255,255,255,0.15);padding:12px 16px;text-align:left;}
-    .dmca-table th{background:rgba(125,211,252,0.12);color:#e5f4ff;}
-    .meta{margin-top:28px;font-size:0.95rem;color:rgba(229,238,255,0.75);}
-    @media (max-width:640px){
-      main{padding:60px 14px 80px;}
-      .legal-wrapper{padding:32px 24px;}
-      .dmca-table{display:block;overflow-x:auto;}
-    }
-  </style>
+  <meta http-equiv="refresh" content="0; url=/copyright-dmca.html" />
+  <link rel="canonical" href="https://thetankguide.com/copyright-dmca.html" />
+  <title>Redirecting…</title>
+  <script>
+    window.location.replace('/copyright-dmca.html');
+  </script>
 </head>
 <body>
-  <div id="site-nav"></div>
-  <main>
-    <article class="legal-wrapper">
-      <h1>Copyright & Content Usage</h1>
-      <p>All text, graphics, tools, code, and media published on TheTankGuide.com are © FishKeepingLifeCo unless otherwise noted. These materials are protected by United States and international copyright laws.</p>
-
-      <h2>Permitted Personal Use</h2>
-      <ul>
-        <li>Download or print single copies of pages for personal, non-commercial reference.</li>
-        <li>Share links to TheTankGuide.com on social media with proper attribution.</li>
-        <li>Embed our public YouTube videos using the official platform embed.</li>
-      </ul>
-
-      <h2>Restricted Uses</h2>
-      <ul>
-        <li>Do not republish articles, data, or images without written permission.</li>
-        <li>Do not mirror, scrape, or bulk download the site.</li>
-        <li>Do not use our branding, trademarks, or photography in your products or ads without consent.</li>
-      </ul>
-
-      <h2>Content Usage Requests</h2>
-      <p>For syndication, licensing, or collaboration inquiries, email <a href="mailto:info@thetankguide.com">info@thetankguide.com</a> with a description of the intended use and audience.</p>
-
-      <h2>DMCA Takedown Process</h2>
-      <p>If you believe your copyrighted work has been used on TheTankGuide.com without authorization, provide a DMCA notice containing the following information:</p>
-      <table class="dmca-table">
-        <thead>
-          <tr>
-            <th>Required Information</th>
-            <th>Details</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Your contact details</td>
-            <td>Name, mailing address, telephone number, and email.</td>
-          </tr>
-          <tr>
-            <td>Work identification</td>
-            <td>Description or link to the copyrighted work you claim has been infringed.</td>
-          </tr>
-          <tr>
-            <td>Infringing material</td>
-            <td>URL(s) on TheTankGuide.com where the material is located.</td>
-          </tr>
-          <tr>
-            <td>Statement of ownership</td>
-            <td>A statement that you have a good-faith belief the use is unauthorized, and that the information in the notice is accurate.</td>
-          </tr>
-          <tr>
-            <td>Signature</td>
-            <td>Physical or electronic signature of the copyright owner or authorized agent.</td>
-          </tr>
-        </tbody>
-      </table>
-      <p>Email completed notices to <a href="mailto:dmca@thetankguide.com">dmca@thetankguide.com</a>.</p>
-
-      <h2>Counter-Notification</h2>
-      <p>If you believe your content was removed in error, submit a counter-notice containing your contact information, identification of the removed content, and a statement under penalty of perjury that the removal was a mistake. We will notify the original complainant and restore the material within 10 business days unless they file an action seeking a court order.</p>
-
-      <h2>Watermarking & Protective Measures</h2>
-      <p>Featured imagery may include subtle watermarking or downscaled resolutions to deter unauthorized commercial reuse while preserving user experience.</p>
-
-      <p class="meta">Effective date: September 30, 2025</p>
-    </article>
-  </main>
-  <script type="application/ld+json">
-{
-  "@context": "https://schema.org",
-  "@type": "WebPage",
-  "name": "Copyright & Content Usage",
-  "url": "https://thetankguide.com/copyright.html",
-  "datePublished": "2025-09-30",
-  "dateModified": "2025-09-30",
-  "publisher": {
-    "@type": "Organization",
-    "name": "FishKeepingLifeCo",
-    "url": "https://thetankguide.com",
-    "logo": {
-      "@type": "ImageObject",
-      "url": "https://thetankguide.com/logo.png"
-    }
-  }
-}
-  </script>
+  <p>If you are not redirected, <a href="/copyright-dmca.html">view our Copyright &amp; DMCA page</a>.</p>
 </body>
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -1145,45 +1145,40 @@ body.planted-active #cycling-coach .cc-title__leaf {
 }
 
 .social-strip {
-  margin-bottom: 10px;
-}
-
-.footer-links {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-  margin: 0 auto 12px;
-  color: rgba(255, 255, 255, 0.7);
-  font-size: 0.85rem;
-}
-
-.footer-links a {
-  color: #d5ddff;
-  text-decoration: none;
-  font-weight: 500;
-}
-
-.footer-links a:hover {
-  color: #7dd3fc;
-  text-decoration: underline;
-}
-
-.footer-links span {
-  color: rgba(255, 255, 255, 0.35);
+  margin-bottom: 12px;
 }
 
 .social-strip a {
+  display: inline-block;
   margin: 0 8px;
   color: #fff;
   font-size: 1.4rem;
-  transition: color 0.3s;
+  transition: color 0.3s, transform 0.15s ease-out;
 }
 
-.social-strip a:hover,
-.footer-note a:hover {
-  color: #1e90ff; /* hover highlight */
+.social-strip a:hover {
+  color: #1e90ff;
+  transform: translateY(-1px);
+}
+
+.footer-links {
+  margin: 4px 0 12px 0;
+  font-size: 0.95rem;
+}
+
+.footer-links a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.footer-links a:hover {
+  color: #1e90ff;
+  text-decoration: underline;
+}
+
+.footer-links .dot {
+  opacity: 0.6;
+  margin: 0 0.5ch;
 }
 
 .footer-note {
@@ -1196,6 +1191,14 @@ body.planted-active #cycling-coach .cc-title__leaf {
   text-decoration: none;
   font-weight: 500;
 }
+
 .footer-note .amazon-cta:hover {
   text-decoration: underline;
+}
+
+/* Small screens: allow icons to wrap neatly */
+@media (max-width: 420px) {
+  .social-strip a {
+    margin: 6px 10px;
+  }
 }

--- a/feature-your-tank.html
+++ b/feature-your-tank.html
@@ -321,7 +321,7 @@
   <script>
   (async () => {
     try {
-      const res = await fetch('footer.html?v=1.2.0', { cache: 'no-cache' });
+      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
       const html = await res.text();
       const host = document.getElementById('site-footer');
       if (host) host.outerHTML = html;

--- a/footer.html
+++ b/footer.html
@@ -1,5 +1,6 @@
-<!-- FOOTER -->
+<!-- FOOTER v1.2.1 — socials restored ABOVE legal links -->
 <footer class="site-footer">
+  <!-- SOCIALS (icon row) -->
   <div class="social-strip" role="navigation" aria-label="Social links">
     <a href="https://www.instagram.com/FishKeepingLifeCo" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on Instagram">
       <i class="fab fa-instagram" aria-hidden="true"></i>
@@ -21,14 +22,16 @@
     </a>
   </div>
 
-  <nav class="footer-links" aria-label="Legal">
+  <!-- LEGAL LINKS -->
+  <nav class="footer-links" aria-label="Footer links">
     <a href="/privacy-legal.html">Privacy &amp; Legal</a>
-    <span aria-hidden="true">•</span>
+    <span class="dot">·</span>
     <a href="/terms.html">Terms of Use</a>
-    <span aria-hidden="true">•</span>
-    <a href="/copyright.html">Copyright &amp; DMCA</a>
+    <span class="dot">·</span>
+    <a href="/copyright-dmca.html">Copyright &amp; DMCA</a>
   </nav>
 
+  <!-- COPYRIGHT + AMAZON CTA -->
   <p class="footer-note">
     © 2025 The Tank Guide • FishKeepingLifeCo
     <br>

--- a/gear.html
+++ b/gear.html
@@ -274,7 +274,7 @@
   <script>
   (async () => {
     try {
-      const res = await fetch('footer.html?v=1.2.0', { cache: 'no-cache' });
+      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
       const html = await res.text();
       const host = document.getElementById('site-footer');
       if (host) host.outerHTML = html;

--- a/hardening/sitemap.xml
+++ b/hardening/sitemap.xml
@@ -41,7 +41,7 @@
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://thetankguide.com/copyright.html</loc>
+    <loc>https://thetankguide.com/copyright-dmca.html</loc>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/index.html
+++ b/index.html
@@ -249,7 +249,7 @@
 <script>
   (async () => {
     try {
-      const res = await fetch('footer.html?v=1.2.0', { cache: 'no-cache' });
+      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
       const html = await res.text();
       const host = document.getElementById('site-footer');
       if (host) host.outerHTML = html;

--- a/media.html
+++ b/media.html
@@ -314,7 +314,7 @@
   <script>
   (async () => {
     try {
-      const res = await fetch('footer.html?v=1.2.0', { cache: 'no-cache' });
+      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
       const html = await res.text();
       const host = document.getElementById('site-footer');
       if (host) host.outerHTML = html;

--- a/params.html
+++ b/params.html
@@ -691,7 +691,7 @@
   <script>
   (async () => {
     try {
-      const res = await fetch('footer.html?v=1.2.0', { cache: 'no-cache' });
+      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
       const html = await res.text();
       const host = document.getElementById('site-footer');
       if (host) host.outerHTML = html;

--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -461,7 +461,7 @@
   <script>
   (async () => {
     try {
-      const res = await fetch('footer.html?v=1.2.0', { cache: 'no-cache' });
+      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
       const html = await res.text();
       const host = document.getElementById('site-footer');
       if (host) host.outerHTML = html;

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -61,7 +61,7 @@
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://thetankguide.com/copyright.html</loc>
+    <loc>https://thetankguide.com/copyright-dmca.html</loc>
     <lastmod>2025-09-30</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>

--- a/stocking.html
+++ b/stocking.html
@@ -1316,7 +1316,7 @@
   <script>
   (async () => {
     try {
-      const res = await fetch('footer.html?v=1.2.0', { cache: 'no-cache' });
+      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
       const html = await res.text();
       const host = document.getElementById('site-footer');
       if (host) host.outerHTML = html;


### PR DESCRIPTION
## Summary
- refresh the shared footer markup and styling to match the v1.2.1 layout with restored social icon row
- bump footer loader references to the new version and link to the Copyright & DMCA page
- add a dedicated copyright-dmca.html page and update sitemaps plus a redirect from the old slug

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4c2d7ac08332a7b312fd0b248f22