### PR TITLE
Update footer partial to v1.2.2 and normalize loader

### DIFF
--- a/about.html
+++ b/about.html
@@ -19,7 +19,7 @@
   <meta name="twitter:image" content="https://thetankguide.com/logo.png" />
   <link rel="icon" href="/favicon.ico" />
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <script defer src="js/nav.js?v=1.0.8"></script>
   <style>
     *, *::before, *::after {
@@ -355,16 +355,21 @@
   <div id="site-footer"></div>
 
   <script>
-  (async () => {
-    try {
-      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
-      const html = await res.text();
-      const host = document.getElementById('site-footer');
-      if (host) host.outerHTML = html;
-    } catch (e) {
-      console.error('Footer load failed:', e);
+(async () => {
+  try {
+    const res = await fetch('footer.v1.2.2.html?v=' + Date.now(), { cache: 'no-cache' });
+    const html = await res.text();
+    const host = document.getElementById('site-footer');
+    if (host) {
+      host.outerHTML = html;
+      console.log('[Footer] injected v1.2.2 with socials row');
+    } else {
+      console.warn('[Footer] #site-footer placeholder not found on this page');
     }
-  })();
+  } catch (e) {
+    console.error('[Footer] load failed:', e);
+  }
+})();
 </script>
   <script>
     (() => {

--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -21,7 +21,7 @@
 
   <!-- Site styles / nav JS -->
   <link rel="stylesheet" href="css/style.css?v=1.0.9" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <script defer src="js/nav.js?v=1.0.9"></script>
 
   <style>
@@ -397,16 +397,21 @@
 
   <div id="site-footer"></div>
   <script>
-  (async () => {
-    try {
-      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
-      const html = await res.text();
-      const host = document.getElementById('site-footer');
-      if (host) host.outerHTML = html;
-    } catch (e) {
-      console.error('Footer load failed:', e);
+(async () => {
+  try {
+    const res = await fetch('footer.v1.2.2.html?v=' + Date.now(), { cache: 'no-cache' });
+    const html = await res.text();
+    const host = document.getElementById('site-footer');
+    if (host) {
+      host.outerHTML = html;
+      console.log('[Footer] injected v1.2.2 with socials row');
+    } else {
+      console.warn('[Footer] #site-footer placeholder not found on this page');
     }
-  })();
+  } catch (e) {
+    console.error('[Footer] load failed:', e);
+  }
+})();
 </script>
 
   <!-- Scripts -->

--- a/copyright-dmca.html
+++ b/copyright-dmca.html
@@ -17,7 +17,7 @@
   <meta name="twitter:description" content="Copyright notice, permitted use, and DMCA takedown process for The Tank Guide." />
   <meta name="twitter:image" content="https://thetankguide.com/logo.png" />
   <link rel="stylesheet" href="css/style.css?v=1.0.9" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <script defer src="js/nav.js?v=1.0.9"></script>
   <style>
     body{background:#0c1b2d;color:#f4f7fb;font-family:"Segoe UI",Roboto,Arial,sans-serif;margin:0;}

--- a/css/style.css
+++ b/css/style.css
@@ -1141,7 +1141,7 @@ body.planted-active #cycling-coach .cc-title__leaf {
   padding: 20px;
   background: #111;
   color: #fff;
-  font-size: 0.9rem;
+  font-size: .9rem;
 }
 
 .social-strip {
@@ -1153,7 +1153,7 @@ body.planted-active #cycling-coach .cc-title__leaf {
   margin: 0 8px;
   color: #fff;
   font-size: 1.4rem;
-  transition: color 0.3s, transform 0.15s ease-out;
+  transition: color .3s, transform .15s ease-out;
 }
 
 .social-strip a:hover {
@@ -1163,7 +1163,7 @@ body.planted-active #cycling-coach .cc-title__leaf {
 
 .footer-links {
   margin: 4px 0 12px 0;
-  font-size: 0.95rem;
+  font-size: .95rem;
 }
 
 .footer-links a {
@@ -1177,8 +1177,8 @@ body.planted-active #cycling-coach .cc-title__leaf {
 }
 
 .footer-links .dot {
-  opacity: 0.6;
-  margin: 0 0.5ch;
+  opacity: .6;
+  margin: 0 .5ch;
 }
 
 .footer-note {

--- a/feature-your-tank.html
+++ b/feature-your-tank.html
@@ -6,7 +6,7 @@
   <title>Feature Your Tank — The Tank Guide</title>
   <meta name="description" content="Submit your aquarium’s Quick Facts to be featured on The Tank Guide: size, stock, substrate, filtration, lighting, and more." />
   <link rel="stylesheet" href="css/style.css?v=1.0.9" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <script defer src="js/nav.js?v=1.0.9"></script>
   <style>
     body.page-gradient {
@@ -318,17 +318,22 @@
   </main>
 
   <div id="site-footer"></div>
-  <script>
-  (async () => {
-    try {
-      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
-      const html = await res.text();
-      const host = document.getElementById('site-footer');
-      if (host) host.outerHTML = html;
-    } catch (e) {
-      console.error('Footer load failed:', e);
+<script>
+(async () => {
+  try {
+    const res = await fetch('footer.v1.2.2.html?v=' + Date.now(), { cache: 'no-cache' });
+    const html = await res.text();
+    const host = document.getElementById('site-footer');
+    if (host) {
+      host.outerHTML = html;
+      console.log('[Footer] injected v1.2.2 with socials row');
+    } else {
+      console.warn('[Footer] #site-footer placeholder not found on this page');
     }
-  })();
+  } catch (e) {
+    console.error('[Footer] load failed:', e);
+  }
+})();
 </script>
   <script src="https://www.google.com/recaptcha/api.js" async defer></script>
   <script defer src="js/feature-tank.js?v=1.0.0"></script>

--- a/footer.v1.2.2.html
+++ b/footer.v1.2.2.html
@@ -1,0 +1,44 @@
+<!-- FOOTER v1.2.2 — socials restored ABOVE legal links -->
+<footer class="site-footer">
+  <!-- SOCIALS (icon row) -->
+  <div class="social-strip" role="navigation" aria-label="Social links">
+    <a href="https://www.instagram.com/FishKeepingLifeCo" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on Instagram">
+      <i class="fab fa-instagram" aria-hidden="true"></i>
+    </a>
+    <a href="https://www.tiktok.com/@FishKeepingLifeCo" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on TikTok">
+      <i class="fab fa-tiktok" aria-hidden="true"></i>
+    </a>
+    <a href="https://www.facebook.com/fishkeepinglifeco" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on Facebook">
+      <i class="fab fa-facebook" aria-hidden="true"></i>
+    </a>
+    <a href="https://x.com/fishkeepinglife?s=21" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on X (Twitter)">
+      <i class="fab fa-x-twitter" aria-hidden="true"></i>
+    </a>
+    <a href="https://www.youtube.com/@fishkeepinglifeco" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on YouTube">
+      <i class="fab fa-youtube" aria-hidden="true"></i>
+    </a>
+    <a href="https://www.amazon.com/author/fishkeepinglifeco" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on Amazon">
+      <i class="fab fa-amazon" aria-hidden="true"></i>
+    </a>
+  </div>
+
+  <!-- LEGAL LINKS -->
+  <nav class="footer-links" aria-label="Footer links">
+    <a href="/privacy-legal.html">Privacy &amp; Legal</a>
+    <span class="dot">·</span>
+    <a href="/terms.html">Terms of Use</a>
+    <span class="dot">·</span>
+    <a href="/copyright-dmca.html">Copyright &amp; DMCA</a>
+  </nav>
+
+  <!-- COPYRIGHT + AMAZON CTA -->
+  <p class="footer-note">
+    © 2025 The Tank Guide • FishKeepingLifeCo
+    <br>
+    As an Amazon Associate, we earn from qualifying purchases.
+    <br>
+    <a class="amazon-cta" href="https://www.amazon.com/author/fishkeepinglifeco" target="_blank" rel="noopener noreferrer">
+      Shop our books on Amazon »
+    </a>
+  </p>
+</footer>

--- a/gear.html
+++ b/gear.html
@@ -19,7 +19,7 @@
   <meta name="twitter:description" content="The Tank Guide Gear Guide: aquarium gear recommendations for filters, heaters, lighting, substrate, test kits, and planted aquarium setups.">
   <meta name="twitter:image" content="https://thetankguide.com/logo.png">
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="icon" href="/favicon.ico" />
 
   <style>
@@ -272,16 +272,21 @@
   </p>
   <div id="site-footer"></div>
   <script>
-  (async () => {
-    try {
-      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
-      const html = await res.text();
-      const host = document.getElementById('site-footer');
-      if (host) host.outerHTML = html;
-    } catch (e) {
-      console.error('Footer load failed:', e);
+(async () => {
+  try {
+    const res = await fetch('footer.v1.2.2.html?v=' + Date.now(), { cache: 'no-cache' });
+    const html = await res.text();
+    const host = document.getElementById('site-footer');
+    if (host) {
+      host.outerHTML = html;
+      console.log('[Footer] injected v1.2.2 with socials row');
+    } else {
+      console.warn('[Footer] #site-footer placeholder not found on this page');
     }
-  })();
+  } catch (e) {
+    console.error('[Footer] load failed:', e);
+  }
+})();
 </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <meta name="twitter:image" content="https://thetankguide.com/logo.png">
 
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 
   <style>
     :root{
@@ -247,16 +247,21 @@
 
 <div id="site-footer"></div>
 <script>
-  (async () => {
-    try {
-      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
-      const html = await res.text();
-      const host = document.getElementById('site-footer');
-      if (host) host.outerHTML = html;
-    } catch (e) {
-      console.error('Footer load failed:', e);
+(async () => {
+  try {
+    const res = await fetch('footer.v1.2.2.html?v=' + Date.now(), { cache: 'no-cache' });
+    const html = await res.text();
+    const host = document.getElementById('site-footer');
+    if (host) {
+      host.outerHTML = html;
+      console.log('[Footer] injected v1.2.2 with socials row');
+    } else {
+      console.warn('[Footer] #site-footer placeholder not found on this page');
     }
-  })();
+  } catch (e) {
+    console.error('[Footer] load failed:', e);
+  }
+})();
 </script>
 <style>
   /* TTG Popup Theme v1 — High-Contrast Minimal (scoped to #ttg-howitworks) */

--- a/media.html
+++ b/media.html
@@ -19,7 +19,7 @@
   <meta name="twitter:image" content="https://thetankguide.com/logo.png">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="icon" href="/favicon.ico" />
   <!-- Page-scoped styles -->
   <style>
@@ -312,16 +312,21 @@
 
   <div id="site-footer"></div>
   <script>
-  (async () => {
-    try {
-      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
-      const html = await res.text();
-      const host = document.getElementById('site-footer');
-      if (host) host.outerHTML = html;
-    } catch (e) {
-      console.error('Footer load failed:', e);
+(async () => {
+  try {
+    const res = await fetch('footer.v1.2.2.html?v=' + Date.now(), { cache: 'no-cache' });
+    const html = await res.text();
+    const host = document.getElementById('site-footer');
+    if (host) {
+      host.outerHTML = html;
+      console.log('[Footer] injected v1.2.2 with socials row');
+    } else {
+      console.warn('[Footer] #site-footer placeholder not found on this page');
     }
-  })();
+  } catch (e) {
+    console.error('[Footer] load failed:', e);
+  }
+})();
 </script>
 </body>
 </html>

--- a/params.html
+++ b/params.html
@@ -6,7 +6,7 @@
   <title>The Tank Guide — Aquarium Cycling Coach & 24-Hour Challenge</title>
   <meta name="description" content="Use the Cycling Coach to enter ammonia, nitrite, and nitrate readings, track cycle progress, and take the 24-Hour Challenge for safe fishkeeping guidance — by FishKeepingLifeCo." />
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="icon" href="/favicon.ico" />
   <script defer src="js/nav.js?v=1.0.8"></script>
   <style>
@@ -688,17 +688,22 @@
   </main>
 
   <div id="site-footer"></div>
-  <script>
-  (async () => {
-    try {
-      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
-      const html = await res.text();
-      const host = document.getElementById('site-footer');
-      if (host) host.outerHTML = html;
-    } catch (e) {
-      console.error('Footer load failed:', e);
+<script>
+(async () => {
+  try {
+    const res = await fetch('footer.v1.2.2.html?v=' + Date.now(), { cache: 'no-cache' });
+    const html = await res.text();
+    const host = document.getElementById('site-footer');
+    if (host) {
+      host.outerHTML = html;
+      console.log('[Footer] injected v1.2.2 with socials row');
+    } else {
+      console.warn('[Footer] #site-footer placeholder not found on this page');
     }
-  })();
+  } catch (e) {
+    console.error('[Footer] load failed:', e);
+  }
+})();
 </script>
   <script type="module" src="js/params.js?v=2.0.0"></script>
 </body>

--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -18,7 +18,7 @@
   <meta name="twitter:image" content="https://thetankguide.com/logo.png" />
   <link rel="icon" href="/favicon.ico" />
   <link rel="stylesheet" href="css/style.css?v=1.0.9" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <script defer src="js/nav.js?v=1.0.9"></script>
   <style>
     :root {
@@ -459,16 +459,21 @@
   <div id="site-footer"></div>
 
   <script>
-  (async () => {
-    try {
-      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
-      const html = await res.text();
-      const host = document.getElementById('site-footer');
-      if (host) host.outerHTML = html;
-    } catch (e) {
-      console.error('Footer load failed:', e);
+(async () => {
+  try {
+    const res = await fetch('footer.v1.2.2.html?v=' + Date.now(), { cache: 'no-cache' });
+    const html = await res.text();
+    const host = document.getElementById('site-footer');
+    if (host) {
+      host.outerHTML = html;
+      console.log('[Footer] injected v1.2.2 with socials row');
+    } else {
+      console.warn('[Footer] #site-footer placeholder not found on this page');
     }
-  })();
+  } catch (e) {
+    console.error('[Footer] load failed:', e);
+  }
+})();
 </script>
 
   <script>

--- a/stocking.html
+++ b/stocking.html
@@ -19,7 +19,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" id="css-main" href="css/style.css?v=2024-06-05a" />
   <link rel="stylesheet" href="css/site.css?v=2024-07-05a" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="icon" href="/favicon.ico" />
   <script defer src="js/nav.js?v=1.0.8"></script>
   <style>
@@ -1313,17 +1313,22 @@
   </main>
 
   <div id="site-footer"></div>
-  <script>
-  (async () => {
-    try {
-      const res = await fetch('footer.html?v=1.2.1', { cache: 'no-cache' });
-      const html = await res.text();
-      const host = document.getElementById('site-footer');
-      if (host) host.outerHTML = html;
-    } catch (e) {
-      console.error('Footer load failed:', e);
+<script>
+(async () => {
+  try {
+    const res = await fetch('footer.v1.2.2.html?v=' + Date.now(), { cache: 'no-cache' });
+    const html = await res.text();
+    const host = document.getElementById('site-footer');
+    if (host) {
+      host.outerHTML = html;
+      console.log('[Footer] injected v1.2.2 with socials row');
+    } else {
+      console.warn('[Footer] #site-footer placeholder not found on this page');
     }
-  })();
+  } catch (e) {
+    console.error('[Footer] load failed:', e);
+  }
+})();
 </script>
   <script type="module" src="js/logic/speciesSchema.js"></script>
   <script type="module" src="js/fish-data.js"></script>

--- a/terms.html
+++ b/terms.html
@@ -17,7 +17,7 @@
   <meta name="twitter:description" content="Terms of Use governing The Tank Guide website, tools, and community." />
   <meta name="twitter:image" content="https://thetankguide.com/logo.png" />
   <link rel="stylesheet" href="css/style.css?v=1.0.9" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <script defer src="js/nav.js?v=1.0.9"></script>
   <style>
     body{background:#0d1a29;color:#f1f5f9;font-family:"Segoe UI",Roboto,Arial,sans-serif;margin:0;}


### PR DESCRIPTION
## Summary
- add the new `footer.v1.2.2.html` partial with restored social icons and Amazon CTA
- normalize the footer loader scripts across site pages to fetch the new partial with cache busting and logging
- standardize the Font Awesome include and ensure footer styling lives in `css/style.css`

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68dc4f4ef2a08332aa524ec5a2e77afb