### PR TITLE
Remove redundant tank assumption line

### DIFF
--- a/js/stocking.js
+++ b/js/stocking.js
@@ -484,32 +484,32 @@ function renderTankSummaryView() {
   if (!computed) {
     return;
   }
-  const container = document.createElement('div');
-  container.className = 'tank-summary';
-  const variant = computed.tank.variant;
-  const dims = variant ? `${variant.length}″×${variant.width}″×${variant.height}″` : '—';
-  const text = document.createElement('p');
-  const assumed = variant ? `${variant.name} (${dims})` : 'custom footprint';
-  text.innerHTML = `Tank: ${computed.tank.gallons} gal — assumed: ${assumed}. Best fit for your current species.`;
-  container.appendChild(text);
-
   const variants = getTankVariants(computed.tank.gallons);
   if (variants.length <= 1) {
     variantSelectorOpen = false;
+    shouldRestoreVariantFocus = false;
+    return;
   }
+  const container = document.createElement('div');
+  container.className = 'tank-summary';
+  const controls = document.createElement('div');
+  controls.className = 'tank-summary__controls';
+  container.appendChild(controls);
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'link-like';
+  toggle.textContent = variantSelectorOpen ? 'Close' : 'Change';
+  toggle.dataset.testid = 'variant-toggle';
+  toggle.setAttribute(
+    'aria-label',
+    variantSelectorOpen ? 'Close tank variant options' : 'Change tank dimensions variant',
+  );
+  toggle.addEventListener('click', () => {
+    variantSelectorOpen = !variantSelectorOpen;
+    renderTankSummaryView();
+  });
+  controls.appendChild(toggle);
   if (variants.length > 1) {
-    const toggle = document.createElement('button');
-    toggle.type = 'button';
-    toggle.className = 'link-like';
-    toggle.textContent = variantSelectorOpen ? 'Close' : 'Change';
-    toggle.dataset.testid = 'variant-toggle';
-    toggle.addEventListener('click', () => {
-      variantSelectorOpen = !variantSelectorOpen;
-      renderTankSummaryView();
-    });
-    text.append(' ');
-    text.appendChild(toggle);
-
     if (variantSelectorOpen) {
       const selector = document.createElement('div');
       selector.className = 'variant-selector';
@@ -519,6 +519,7 @@ function renderTankSummaryView() {
         button.type = 'button';
         button.textContent = describeVariant(option);
         button.dataset.active = option.id === computed.tank.variant?.id ? 'true' : 'false';
+        button.dataset.variantId = option.id;
         button.dataset.testid = 'variant-option';
         button.addEventListener('click', () => {
           state.variantId = option.id;

--- a/stocking.html
+++ b/stocking.html
@@ -951,6 +951,22 @@
       border: 0 !important;
     }
 
+    /* Hide any assumption fragments if they slip through */
+    #stocking-page .ttg-card.tank-size .tank-assumption,
+    #stocking-page .ttg-card.tank-size #tank-assumption,
+    #stocking-page .ttg-card.tank-size [data-role="tank-assumption"],
+    #stocking-page .ttg-card.tank-size [data-test="tank-assumption"],
+    #stocking-page .ttg-card.tank-size-card .tank-assumption,
+    #stocking-page .ttg-card.tank-size-card #tank-assumption,
+    #stocking-page .ttg-card.tank-size-card [data-role="tank-assumption"],
+    #stocking-page .ttg-card.tank-size-card [data-test="tank-assumption"] {
+      display: none !important;
+      height: 0 !important;
+      margin: 0 !important;
+      padding: 0 !important;
+      border: 0 !important;
+    }
+
     #stocking-page .tank-size-card + .card-spacer:empty {
       display: none !important;
     }
@@ -1342,121 +1358,57 @@
 })();
 </script>
 <script>
-(function squashDuplicateTankSummary() {
-  const card = document.querySelector('#stocking-page .ttg-card.tank-size-card, #stocking-page [data-card="tank-size"]');
-  if (!card) return;
-
-  const docFragmentNode = typeof Node !== 'undefined' ? Node.DOCUMENT_FRAGMENT_NODE : 11;
-
-  const ensureInCardSummary = () => {
-    let summary = card.querySelector('.tank-assumption, #tank-summary, [data-role="tank-assumption"]');
-    if (!summary) {
-      summary = document.createElement('div');
-      summary.id = 'tank-summary';
-      summary.setAttribute('aria-live', 'polite');
-      summary.dataset.testid = 'tank-summary';
-      const anchor = card.querySelector('.row.toggle-row') || card.lastElementChild;
-      if (anchor) {
-        card.insertBefore(summary, anchor);
-      } else {
-        card.appendChild(summary);
-      }
-    }
-    summary.classList.add('in-card');
-    return summary;
-  };
-
-  const inCardSummary = ensureInCardSummary();
+(function removeRedundantTankAssumption(){
+  const tankCard = document.querySelector(
+    [
+      '#stocking-page .ttg-card.tank-size',
+      '#stocking-page .ttg-card.tank-size-card',
+      '#stocking-page [data-card="tank-size"]',
+      '#tank-size-card',
+    ].join(', '),
+  );
+  if(!tankCard) return;
 
   const selectors = [
-    '#tank-summary',
-    '#tank-assumption',
-    '[data-role="tank-assumption"]',
-    '.tank-assumption',
-    '.tank-assumption-note',
-    '[data-test="tank-assumption"]',
-    '[id^="tank-assumption-"]'
+    '.tank-assumption', '#tank-assumption',
+    '[data-role="tank-assumption"]', '[data-test="tank-assumption"]'
   ];
 
-  const selectorString = selectors.join(',');
+  function isAssumptionText(el){
+    const txt = (el.textContent || '').trim();
+    // Matches “Tank: 32 gal — assumed: … Best fit …”
+    return /^Tank:\s*\d+(\.\d+)?\s*gal\s*—\s*assumed:/i.test(txt);
+  }
 
-  const removeIfOutside = (node) => {
-    if (!node) return;
-    if (node.nodeType === docFragmentNode) {
-      node.querySelectorAll?.(selectorString).forEach((el) => {
-        if (!card.contains(el)) {
-          el.remove();
-        }
-      });
-      Array.from(node.childNodes || []).forEach((child) => removeIfOutside(child));
-      return;
-    }
-    if (node.nodeType !== 1) return;
-    if (!card.contains(node)) {
-      if (node.matches?.(selectorString)) {
-        node.remove();
-        return;
-      }
-      const txt = (node.textContent || '').trim();
-      if (/^Tank:\s*\d+(\.\d+)?\s*gal\s*—\s*assumed:/i.test(txt)) {
-        node.remove();
-        return;
-      }
-    }
-    node.querySelectorAll?.(selectorString).forEach((el) => {
-      if (!card.contains(el)) {
-        el.remove();
-      }
+  function sweep(){
+    // Remove any known-labeled nodes inside the Tank Size card
+    tankCard.querySelectorAll(selectors.join(',')).forEach((n) => n.remove());
+    // Heuristic fallback: any direct child paragraphs matching the pattern
+    Array.from(tankCard.querySelectorAll('p, div')).forEach((el) => {
+      if (isAssumptionText(el)) el.remove();
     });
-  };
+    // Remove now-empty spacers immediately following the main details block
+    Array.from(tankCard.children).forEach((ch) => {
+      if (ch.textContent && !ch.textContent.trim()) ch.remove();
+    });
+  }
 
-  document.querySelectorAll(selectorString).forEach((node) => {
-    if (!card.contains(node)) {
-      node.remove();
+  // Initial sweep
+  sweep();
+
+  // Prevent re-insertion by observing the Tank Size card only
+  const mo = new MutationObserver((muts) => {
+    let changed = false;
+    for (const m of muts){
+      if (m.type === 'childList' && (m.addedNodes?.length || m.removedNodes?.length)){
+        changed = true;
+      } else if (m.type === 'attributes' && m.attributeName === 'data-assumption') {
+        changed = true;
+      }
     }
+    if (changed) sweep();
   });
-
-  if (card.parentElement) {
-    const siblings = Array.from(card.parentElement.children);
-    const index = siblings.indexOf(card);
-    if (index > -1) {
-      for (let i = index + 1; i < Math.min(index + 3, siblings.length); i += 1) {
-        const el = siblings[i];
-        if (!el) continue;
-        const text = (el.textContent || '').trim();
-        if (/^Tank:\s*\d+(\.\d+)?\s*gal\s*—\s*assumed:/i.test(text)) {
-          el.remove();
-          continue;
-        }
-        if (!text) {
-          el.remove();
-        }
-      }
-    }
-  }
-
-  const inCardMatches = card.querySelectorAll('.tank-assumption, #tank-summary, [data-role="tank-assumption"]');
-  if (inCardMatches.length > 1) {
-    inCardMatches.forEach((el, idx) => {
-      if (idx > 0) {
-        el.remove();
-      }
-    });
-  }
-
-  const root = document.getElementById('stocking-page') || document.body;
-  const observer = new MutationObserver((mutations) => {
-    mutations.forEach((mutation) => {
-      Array.from(mutation.addedNodes || []).forEach((node) => {
-        removeIfOutside(node);
-      });
-    });
-  });
-  observer.observe(root, { childList: true, subtree: true });
-
-  if (inCardSummary) {
-    removeIfOutside(inCardSummary);
-  }
+  mo.observe(tankCard, { childList:true, subtree:true, attributes:true, attributeFilter:['data-assumption'] });
 })();
 </script>
   <script type="module" src="js/logic/speciesSchema.js"></script>

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -30,7 +30,7 @@ async function selectTank(page, gallons) {
     await control.selectOption(optionValue);
   }
   await page.keyboard.press('Tab');
-  await expect(page.getByTestId('tank-summary')).toContainText(`${gallons}`, { timeout: 6000 });
+  await expect(page.locator('#tank-facts')).toContainText(`${gallons}`, { timeout: 6000 });
   return control;
 }
 
@@ -106,8 +106,8 @@ test.describe('Stocking Advisor accessibility flows', () => {
   test('Tank selection updates summary and stock meters', async ({ page }, testInfo) => {
     await selectTank(page, 40);
 
-    const summary = page.getByTestId('tank-summary');
-    await expect(summary).toContainText(/40/);
+    const facts = page.locator('#tank-facts');
+    await expect(facts).toContainText(/40/);
 
     const bars = page.locator('[data-testid="stock-bars"] .env-bar__fill').first();
     await expect(bars).toBeVisible();
@@ -133,11 +133,12 @@ test.describe('Stocking Advisor accessibility flows', () => {
         break;
       }
     }
-    const targetText = (await target.textContent())?.trim() || '';
+    const targetVariantId = await target.getAttribute('data-variant-id');
+    expect(targetVariantId).toBeTruthy();
     await target.click();
 
     await expect(toggle).toBeFocused();
-    await expect(page.getByTestId('tank-summary')).toContainText(targetText, { timeout: 6000 });
+    await expect.poll(async () => page.evaluate(() => window.appState?.variantId || null)).toBe(targetVariantId);
     await expect(page.getByTestId('variant-selector')).toHaveCount(0);
     await capture(page, testInfo, 'variant-selector.png');
   });


### PR DESCRIPTION
## Summary
- stop rendering the redundant "Tank: … — assumed" line inside the Tank Size card and keep only the variant toggle
- add runtime, CSS, and data guards so assumption snippets cannot be reinserted and spacing stays tight
- update end-to-end tests to verify tank facts output and confirm variant selection via state

## Testing
- python3 -m http.server 8000
- Playwright desktop capture (tank-card-desktop-1)
- Playwright desktop capture (tank-card-desktop-2)
- Playwright mobile capture (tank-card-mobile-portrait)
- Playwright mobile capture (tank-card-mobile-landscape)


------
https://chatgpt.com/codex/tasks/task_e_68dc630518708332b9e3d5efb7dde7e5