### PR TITLE
Remove beginner references and refresh contact navigation

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -16,7 +16,7 @@ This repository powers **The Tank Guide**, a static website with aquarium tools 
 - **Media (`/media.html`)** — Video hub, book promotion, blog/article links  
 - **Gear (`/gear.html`)** — Aquarium gear recommendations and guides  
 - **Cycling Coach (`/params.html`)** — Interactive cycle tracker & 24-Hour Challenge  
-- **Contact & Feedback (`/contact-feedback.html`)** — Formspree integration, reCAPTCHA, feedback options  
+- **Contact (`/contact-feedback.html`)** — Formspree integration, reCAPTCHA, feedback options
 
 ---
 

--- a/about.html
+++ b/about.html
@@ -4,18 +4,18 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Tank Guide — FishKeepingLifeCo Story, Mission &amp; Vision</title>
-  <meta name="description" content="Learn about The Tank Guide by FishKeepingLifeCo—our story, mission and vision to make beginner aquarium care simple with stocking, cycling and gear tools." />
+  <meta name="description" content="Learn about The Tank Guide by FishKeepingLifeCo—our story, mission and vision to make aquarium care simple with stocking, cycling and gear tools." />
   <link rel="canonical" href="https://thetankguide.com/about.html" />
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="The Tank Guide" />
   <meta property="og:title" content="The Tank Guide — FishKeepingLifeCo Story, Mission &amp; Vision" />
-  <meta property="og:description" content="Learn about The Tank Guide by FishKeepingLifeCo—our story, mission and vision to make beginner aquarium care simple with stocking, cycling and gear tools." />
+  <meta property="og:description" content="Learn about The Tank Guide by FishKeepingLifeCo—our story, mission and vision to make aquarium care simple with stocking, cycling and gear tools." />
   <meta property="og:url" content="https://thetankguide.com/about.html" />
   <meta property="og:image" content="https://thetankguide.com/logo.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@fishkeepinglife" />
   <meta name="twitter:title" content="The Tank Guide — FishKeepingLifeCo Story, Mission &amp; Vision" />
-  <meta name="twitter:description" content="Learn about The Tank Guide by FishKeepingLifeCo—our story, mission and vision to make beginner aquarium care simple with stocking, cycling and gear tools." />
+  <meta name="twitter:description" content="Learn about The Tank Guide by FishKeepingLifeCo—our story, mission and vision to make aquarium care simple with stocking, cycling and gear tools." />
   <meta name="twitter:image" content="https://thetankguide.com/logo.png" />
   <link rel="icon" href="/favicon.ico" />
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
@@ -226,7 +226,7 @@
   "logo": "https://thetankguide.com/logo.png",
   "image": "https://thetankguide.com/logo.png",
   "slogan": "Educational Aquarium Books & Tools",
-  "description": "FishKeepingLifeCo publishes educational aquarium books and interactive online tools like The Tank Guide to help beginners and hobbyists set up, stock, and maintain thriving aquariums.",
+  "description": "FishKeepingLifeCo publishes educational aquarium books and interactive online tools like The Tank Guide to help aquarists of all experience levels set up, stock, and maintain thriving aquariums.",
   "brand": {
     "@type": "Brand",
     "name": "The Tank Guide"
@@ -240,7 +240,7 @@
     "Nitrogen Cycle",
     "Freshwater Aquariums",
     "Planted Tanks",
-    "Beginner Aquarium Setup",
+    "Aquarium Setup Basics",
     "Water Parameters",
     "Aquarium Cycling"
   ],
@@ -282,7 +282,7 @@
               <button class="accordion-trigger" aria-expanded="false" aria-controls="sec-overview" id="trg-overview">About The Tank Guide</button>
             </h3>
             <div id="sec-overview" class="accordion-panel" role="region" aria-labelledby="trg-overview" hidden>
-              <p>The Tank Guide helps beginners and hobbyists make clear, safe, and confident choices in fishkeeping. We focus on practical steps—cycling, stocking, plants, and gear—designed around aquarium health and fish welfare first. Our tools and guides are tested in real setups and refined by community feedback.</p>
+              <p>The Tank Guide helps new aquarists and hobbyists make clear, safe, and confident choices in fishkeeping. We focus on practical steps—cycling, stocking, plants, and gear—designed around aquarium health and fish welfare first. Our tools and guides are tested in real setups and refined by community feedback.</p>
               <p>Whether you’re setting up your first nano tank or dialing in a planted display, you’ll find straightforward advice without gatekeeping. Want to spotlight your setup and inspire others? Share it in our <a href="https://thetankguide.com/feature-your-tank.html">Feature Your Tank</a> community showcase.</p>
             </div>
           </div>
@@ -319,7 +319,7 @@
             </h3>
             <div id="sec-mission" class="accordion-panel" role="region" aria-labelledby="trg-mission" hidden>
               <p><strong>Mission:</strong><br />
-              To make fishkeeping approachable for beginners and inspiring for hobbyists by breaking down the complex parts into simple, practical steps—so anyone can build a thriving aquarium with confidence.</p>
+              To make fishkeeping approachable for new aquarists and inspiring for hobbyists by breaking down the complex parts into simple, practical steps—so anyone can build a thriving aquarium with confidence.</p>
               <p><strong>Values:</strong></p>
               <ul>
                 <li><strong>Clarity over confusion</strong> — Straightforward answers, no gatekeeping, no overcomplication.</li>
@@ -340,7 +340,7 @@
               <p>Looking ahead, I see this project expanding in a few key ways:</p>
               <ul>
                 <li><strong>Website growth</strong> — adding more tools and resources like advanced stocking guides, gear recommendations, and water cycle coaches.</li>
-                <li><strong>Books</strong> — creating more titles that take complex aquarium topics and turn them into easy-to-understand stories, making learning fun for kids, families, and beginners.</li>
+                <li><strong>Books</strong> — creating more titles that take complex aquarium topics and turn them into easy-to-understand stories, making learning fun for kids, families, and new aquarists.</li>
                 <li><strong>Community features</strong> — building a space where hobbyists can connect, exchange ideas, and learn from each other.</li>
               </ul>
               <p>Whether it’s through guides, stories, or hands-on tools, my goal is to make fishkeeping easier to understand and more fun to explore—for anyone at any stage of the journey.</p>

--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -5,18 +5,18 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Contact The Tank Guide — Feedback & Aquarium Questions</title>
+  <title>Contact The Tank Guide — Aquarium Questions & Feedback</title>
 
   <!-- SEO / robots (as previously used) -->
   <link rel="canonical" href="https://thetankguide.com/contact-feedback.html" />
   <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1" />
   <meta name="googlebot" content="index,follow" />
-  <meta name="description" content="Share feedback with The Tank Guide by FishKeepingLifeCo — recommend fish, report logic issues, ask aquarium questions, suggest reviews, or ideas for new guides." />
-  <meta property="og:title" content="Contact & Feedback | The Tank Guide" />
+  <meta name="description" content="Contact The Tank Guide by FishKeepingLifeCo — ask aquarium questions, share feedback, recommend fish, or suggest products and guides." />
+  <meta property="og:title" content="Contact | The Tank Guide" />
   <meta property="og:site_name" content="The Tank Guide" />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://thetankguide.com/contact-feedback.html" />
-  <meta property="og:description" content="Recommend a fish, report logic issues, ask questions, suggest reviews, or share general ideas." />
+  <meta property="og:description" content="Ask questions, share feedback, recommend fish, suggest reviews, or send general ideas." />
   <meta name="twitter:card" content="summary" />
 
   <!-- Site styles / nav JS -->
@@ -203,7 +203,7 @@
   "logo": "https://thetankguide.com/logo.png",
   "image": "https://thetankguide.com/logo.png",
   "slogan": "Educational Aquarium Books & Tools",
-  "description": "FishKeepingLifeCo publishes educational aquarium books and interactive online tools like The Tank Guide to help beginners and hobbyists set up, stock, and maintain thriving aquariums.",
+  "description": "FishKeepingLifeCo publishes educational aquarium books and interactive online tools like The Tank Guide to help aquarists of all experience levels set up, stock, and maintain thriving aquariums.",
   "brand": {
     "@type": "Brand",
     "name": "The Tank Guide"
@@ -217,7 +217,7 @@
     "Nitrogen Cycle",
     "Freshwater Aquariums",
     "Planted Tanks",
-    "Beginner Aquarium Setup",
+    "Aquarium Setup Basics",
     "Water Parameters",
     "Aquarium Cycling"
   ],
@@ -245,7 +245,7 @@
 
   <main class="page-wrapper">
     <section class="contact-card">
-      <h1>Contact &amp; Feedback</h1>
+      <h1>Contact</h1>
 
       <p>Use this form to share feedback, report logic issues, or highlight anything that seems off in our tools.</p>
       <p>We also welcome aquarium questions so we can point you toward the right resources for your next build.</p>
@@ -311,7 +311,7 @@
               <option value="Cycling Coach">Cycling Coach</option>
               <option value="Parameters">Parameters</option>
               <option value="Media">Media</option>
-              <option value="Contact &amp; Feedback">Contact &amp; Feedback</option>
+              <option value="Contact">Contact</option>
             </select>
           </div>
           <div class="field-group">
@@ -456,7 +456,7 @@
       subjectSelect.addEventListener('change', ()=>{
         const v = subjectSelect.value;
         openPanel(v);
-        hiddenSubject.value = v ? `[Contact & Feedback] – ${v}` : '';
+        hiddenSubject.value = v ? `[Contact] – ${v}` : '';
       });
 
       function validateDynamic(){

--- a/copyright-dmca.html
+++ b/copyright-dmca.html
@@ -125,5 +125,18 @@
   }
 }
   </script>
+  <div id="site-footer"></div>
+  <script>
+  (async () => {
+    try {
+      const res = await fetch('footer.v1.2.2.html?v=1.2.2', { cache: 'no-cache' });
+      const html = await res.text();
+      const host = document.getElementById('site-footer');
+      if (host) host.outerHTML = html;
+    } catch (e) {
+      console.error('[Footer] load failed:', e);
+    }
+  })();
+  </script>
 </body>
 </html>

--- a/gear.html
+++ b/gear.html
@@ -82,7 +82,7 @@
   "logo": "https://thetankguide.com/logo.png",
   "image": "https://thetankguide.com/logo.png",
   "slogan": "Educational Aquarium Books & Tools",
-  "description": "FishKeepingLifeCo publishes educational aquarium books and interactive online tools like The Tank Guide to help beginners and hobbyists set up, stock, and maintain thriving aquariums.",
+  "description": "FishKeepingLifeCo publishes educational aquarium books and interactive online tools like The Tank Guide to help aquarists of all experience levels set up, stock, and maintain thriving aquariums.",
   "brand": {
     "@type": "Brand",
     "name": "The Tank Guide"
@@ -96,7 +96,7 @@
     "Nitrogen Cycle",
     "Freshwater Aquariums",
     "Planted Tanks",
-    "Beginner Aquarium Setup",
+    "Aquarium Setup Basics",
     "Water Parameters",
     "Aquarium Cycling"
   ],
@@ -268,7 +268,7 @@
   </main>
 
   <p class="gear-footer-blurb">
-    Not sure what gear you really need for your aquarium? The Gear Guide by FishKeepingLifeCo helps aquarists choose the right equipment — from filters and heaters to lighting and water care supplies. Beginner-friendly recommendations are matched to your tank size, goals, and fish community, making it easy to build a healthy freshwater aquarium setup. And if your goal is a planted aquarium, our guidance helps you select the right lighting, substrate, and tools to keep your plants thriving alongside your fish.
+    Not sure what gear you really need for your aquarium? The Gear Guide by FishKeepingLifeCo helps aquarists choose the right equipment — from filters and heaters to lighting and water care supplies. Clear recommendations are matched to your tank size, goals, and fish community, making it easy to build a healthy freshwater aquarium setup. And if your goal is a planted aquarium, our guidance helps you select the right lighting, substrate, and tools to keep your plants thriving alongside your fish.
   </p>
   <div id="site-footer"></div>
   <script>

--- a/index.html
+++ b/index.html
@@ -5,18 +5,18 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Tank Guide — Stocking Advisor, Cycling Coach and Gear Recommendations | FishKeepingLifeCo</title>
-  <meta name="description" content="The Tank Guide by FishKeepingLifeCo: beginner-friendly aquarium tools including a stocking advisor, cycling coach, and gear tips to build healthy freshwater aquariums.">
+  <meta name="description" content="The Tank Guide by FishKeepingLifeCo: aquarium planning tools including a stocking advisor, cycling coach, and gear tips to build healthy freshwater aquariums.">
   <link rel="canonical" href="https://thetankguide.com/">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="The Tank Guide">
   <meta property="og:title" content="The Tank Guide — Stocking Advisor, Cycling Coach and Gear Recommendations | FishKeepingLifeCo">
-  <meta property="og:description" content="The Tank Guide by FishKeepingLifeCo: beginner-friendly aquarium tools including a stocking advisor, cycling coach, and gear tips to build healthy freshwater aquariums.">
+  <meta property="og:description" content="The Tank Guide by FishKeepingLifeCo: aquarium planning tools including a stocking advisor, cycling coach, and gear tips to build healthy freshwater aquariums.">
   <meta property="og:url" content="https://thetankguide.com/">
   <meta property="og:image" content="https://thetankguide.com/logo.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@fishkeepinglife">
   <meta name="twitter:title" content="The Tank Guide — Stocking Advisor, Cycling Coach and Gear Recommendations | FishKeepingLifeCo">
-  <meta name="twitter:description" content="The Tank Guide by FishKeepingLifeCo: beginner-friendly aquarium tools including a stocking advisor, cycling coach, and gear tips to build healthy freshwater aquariums.">
+  <meta name="twitter:description" content="The Tank Guide by FishKeepingLifeCo: aquarium planning tools including a stocking advisor, cycling coach, and gear tips to build healthy freshwater aquariums.">
   <meta name="twitter:image" content="https://thetankguide.com/logo.png">
 
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
@@ -106,7 +106,7 @@
   "logo": "https://thetankguide.com/logo.png",
   "image": "https://thetankguide.com/logo.png",
   "slogan": "Educational Aquarium Books & Tools",
-  "description": "FishKeepingLifeCo publishes educational aquarium books and interactive online tools like The Tank Guide to help beginners and hobbyists set up, stock, and maintain thriving aquariums.",
+  "description": "FishKeepingLifeCo publishes educational aquarium books and interactive online tools like The Tank Guide to help new aquarists and hobbyists set up, stock, and maintain thriving aquariums.",
   "brand": {
     "@type": "Brand",
     "name": "The Tank Guide"
@@ -120,7 +120,7 @@
     "Nitrogen Cycle",
     "Freshwater Aquariums",
     "Planted Tanks",
-    "Beginner Aquarium Setup",
+    "Aquarium Setup Basics",
     "Water Parameters",
     "Aquarium Cycling"
   ],
@@ -195,13 +195,12 @@
           </article>
 
           <article class="card" aria-labelledby="card-contact-title">
-            <h3 id="card-contact-title">Contact &amp; Feedback</h3>
+            <h3 id="card-contact-title">Contact</h3>
             <p>
-              Questions, ideas, or spot a logic issue? Recommend a fish, suggest a product to review, or share your insights.
-              We appreciate all feedback and information as we continue improving The Tank Guide.
+              Questions, ideas, or spot a logic issue? Reach out with feedback, recommend fish or gear to review, or share your insights.
             </p>
             <div class="actions">
-              <a class="btn" href="/contact-feedback.html" aria-label="Open Contact &amp; Feedback form">Contact Us</a>
+              <a class="btn" href="/contact-feedback.html" aria-label="Open Contact form">Contact Us</a>
             </div>
           </article>
         </div>

--- a/js/stocking.js
+++ b/js/stocking.js
@@ -107,10 +107,7 @@ function bootstrapStocking() {
     pageTitle: document.getElementById('page-title'),
     plantIcon: document.getElementById('plant-icon'),
     planted: document.getElementById('toggle-planted'),
-    tips: document.getElementById('toggle-tips'),
     envInfoToggle: document.getElementById('env-info-toggle'),
-    blackwater: document.getElementById('toggle-blackwater'),
-    turnover: document.getElementById('input-turnover'),
     temp: document.getElementById('input-temp'),
     ph: document.getElementById('input-ph'),
     gh: document.getElementById('input-gh'),
@@ -510,9 +507,6 @@ function updateToggle(control, value) {
   }
 
 function syncStateFromInputs() {
-  if (refs.turnover) {
-    state.turnover = Number(refs.turnover.value) || state.turnover;
-  }
   if (refs.temp) {
     state.water.temperature = Number(refs.temp.value) || state.water.temperature;
   }
@@ -619,10 +613,6 @@ function renderTankSummaryView() {
 
 function syncToggles() {
   updateToggle(refs.planted, state.planted);
-  if (refs.tips) {
-    updateToggle(refs.tips, state.showTips);
-  }
-  updateToggle(refs.blackwater, state.water.blackwater);
   if (refs.envTips || refs.envInfoToggle) {
     applyEnvTipsState(state.showTips, { animate: envTipsInitialized });
     envTipsInitialized = true;
@@ -736,7 +726,6 @@ window.addEventListener('ttg:recompute', () => {
   });
 
 function bindInputs() {
-  if (refs.turnover) refs.turnover.addEventListener('input', scheduleUpdate);
   if (refs.temp) refs.temp.addEventListener('input', scheduleUpdate);
   if (refs.ph) refs.ph.addEventListener('input', scheduleUpdate);
   if (refs.gh) refs.gh.addEventListener('input', scheduleUpdate);
@@ -747,22 +736,6 @@ function bindInputs() {
   if (refs.planted) {
     refs.planted.addEventListener('change', () => {
       state.planted = Boolean(refs.planted.checked);
-      syncToggles();
-      scheduleUpdate();
-    });
-  }
-
-  if (refs.tips) {
-    refs.tips.addEventListener('click', () => {
-      state.showTips = !state.showTips;
-      syncToggles();
-      scheduleUpdate();
-    });
-  }
-
-  if (refs.blackwater) {
-    refs.blackwater.addEventListener('click', () => {
-      state.water.blackwater = !state.water.blackwater;
       syncToggles();
       scheduleUpdate();
     });

--- a/js/tankSizes.js
+++ b/js/tankSizes.js
@@ -53,7 +53,7 @@ export const TANK_SIZES = [
     footprint_in: '20.3 × 10.5',
     category: 'Nano',
     popular: true,
-    notes: 'Common starter size; fits many beginner species.',
+    notes: 'Common starter size; fits many hardy community species.',
   },
   {
     id: 'g15h',

--- a/media.html
+++ b/media.html
@@ -4,18 +4,18 @@
 <head>
   <meta charset="UTF-8" />
   <title>Media & Books — The Tank Guide by FishKeepingLifeCo</title>
-  <meta name="description" content="Explore The Tank Guide media and books by FishKeepingLifeCo—beginner aquarium education, previews, and resources to help you build healthy freshwater aquariums." />
+  <meta name="description" content="Explore The Tank Guide media and books by FishKeepingLifeCo—aquarium education, previews, and resources to help you build healthy freshwater aquariums." />
   <link rel="canonical" href="https://thetankguide.com/media.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="The Tank Guide">
   <meta property="og:title" content="Media & Books — The Tank Guide by FishKeepingLifeCo">
-  <meta property="og:description" content="Explore The Tank Guide media and books by FishKeepingLifeCo—beginner aquarium education, previews, and resources to help you build healthy freshwater aquariums.">
+  <meta property="og:description" content="Explore The Tank Guide media and books by FishKeepingLifeCo—aquarium education, previews, and resources to help you build healthy freshwater aquariums.">
   <meta property="og:url" content="https://thetankguide.com/media.html">
   <meta property="og:image" content="https://thetankguide.com/logo.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@fishkeepinglife">
   <meta name="twitter:title" content="Media & Books — The Tank Guide by FishKeepingLifeCo">
-  <meta name="twitter:description" content="Explore The Tank Guide media and books by FishKeepingLifeCo—beginner aquarium education, previews, and resources to help you build healthy freshwater aquariums.">
+  <meta name="twitter:description" content="Explore The Tank Guide media and books by FishKeepingLifeCo—aquarium education, previews, and resources to help you build healthy freshwater aquariums.">
   <meta name="twitter:image" content="https://thetankguide.com/logo.png">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" href="css/style.css?v=1.0.8" />
@@ -188,7 +188,7 @@
   "logo": "https://thetankguide.com/logo.png",
   "image": "https://thetankguide.com/logo.png",
   "slogan": "Educational Aquarium Books & Tools",
-  "description": "FishKeepingLifeCo publishes educational aquarium books and interactive online tools like The Tank Guide to help beginners and hobbyists set up, stock, and maintain thriving aquariums.",
+  "description": "FishKeepingLifeCo publishes educational aquarium books and interactive online tools like The Tank Guide to help aquarists of all experience levels set up, stock, and maintain thriving aquariums.",
   "brand": {
     "@type": "Brand",
     "name": "The Tank Guide"
@@ -202,7 +202,7 @@
     "Nitrogen Cycle",
     "Freshwater Aquariums",
     "Planted Tanks",
-    "Beginner Aquarium Setup",
+    "Aquarium Setup Basics",
     "Water Parameters",
     "Aquarium Cycling"
   ],
@@ -235,7 +235,7 @@
   "author": { "@type": "Organization", "name": "FishKeepingLifeCo" },
   "publisher": { "@type": "Organization", "name": "FishKeepingLifeCo" },
   "audience": { "@type": "Audience", "audienceType": "Children 6–12" },
-  "about": ["Aquariums", "Fishkeeping", "Nitrogen Cycle", "Beginner Aquarium Setup"],
+  "about": ["Aquariums", "Fishkeeping", "Nitrogen Cycle", "Aquarium Setup Basics"],
   "bookFormat": "https://schema.org/Hardcover",
   "offers": {
     "@type": "Offer",
@@ -303,7 +303,7 @@
         </a>
         <div class="resource-content">
           <p class="resource-title">The Tank Guide: Cycling &amp; Stocking Companion</p>
-          <p class="resource-desc">“Life in Balance: The Hidden Magic of Aquariums” takes the confusion out of aquarium care, turning the nitrogen cycle into a simple, engaging story. Accurate yet easy to understand, it sparks curiosity in young readers while giving parents, teachers, and beginners the confidence to start their own aquarium journey.</p>
+          <p class="resource-desc">“Life in Balance: The Hidden Magic of Aquariums” takes the confusion out of aquarium care, turning the nitrogen cycle into a simple, engaging story. Accurate yet easy to understand, it sparks curiosity in young readers while giving parents, teachers, and new aquarists the confidence to start their own aquarium journey.</p>
           <a class="btn btn-amazon" href="https://amzn.to/3Kh34I1" target="_blank" rel="sponsored noopener noreferrer">Buy Book On Amazon</a>
         </div>
       </div>

--- a/nav.html
+++ b/nav.html
@@ -23,7 +23,7 @@
       <a href="/params.html" class="nav__link">Cycling Coach</a>
       <a href="/media.html" class="nav__link">Media</a>
       <a href="/feature-your-tank.html" class="nav__link">Feature Your Tank</a>
-      <a href="/contact-feedback.html" class="nav__link">Feedback</a>
+      <a href="/contact-feedback.html" class="nav__link">Contact</a>
       <a href="/about.html" class="nav__link">About</a>
     </nav>
   </div>
@@ -41,7 +41,7 @@
       <a href="/params.html" class="nav__link">Cycling Coach</a>
       <a href="/media.html" class="nav__link">Media</a>
       <a href="/feature-your-tank.html" class="nav__link">Feature Your Tank</a>
-      <a href="/contact-feedback.html" class="nav__link">Feedback</a>
+      <a href="/contact-feedback.html" class="nav__link">Contact</a>
       <a href="/about.html" class="nav__link">About</a>
     </nav>
   </aside>

--- a/params.html
+++ b/params.html
@@ -493,7 +493,7 @@
   "logo": "https://thetankguide.com/logo.png",
   "image": "https://thetankguide.com/logo.png",
   "slogan": "Educational Aquarium Books & Tools",
-  "description": "FishKeepingLifeCo publishes educational aquarium books and interactive online tools like The Tank Guide to help beginners and hobbyists set up, stock, and maintain thriving aquariums.",
+  "description": "FishKeepingLifeCo publishes educational aquarium books and interactive online tools like The Tank Guide to help aquarists of all experience levels set up, stock, and maintain thriving aquariums.",
   "brand": {
     "@type": "Brand",
     "name": "The Tank Guide"
@@ -507,7 +507,7 @@
     "Nitrogen Cycle",
     "Freshwater Aquariums",
     "Planted Tanks",
-    "Beginner Aquarium Setup",
+    "Aquarium Setup Basics",
     "Water Parameters",
     "Aquarium Cycling"
   ],
@@ -548,36 +548,36 @@
         <div class="card__header">
           <h2 class="card__title" id="inputs-heading">Inputs</h2>
         </div>
-        <form id="coach-form" novalidate>
+        <form id="coach-form" novalidate data-testid="coach-form">
           <div class="form-grid">
             <div class="field">
               <div class="label-row">
                 <label for="ammonia">Ammonia (NH₃/NH₄⁺)</label>
-                <button type="button" class="info-btn" data-tooltip="Waste from fish/food. Even tiny amounts are toxic." aria-label="Ammonia info" aria-describedby="tip-ammonia">ⓘ</button>
+                <button type="button" class="info-btn" data-tooltip="Waste from fish/food. Even tiny amounts are toxic." aria-label="Ammonia info" aria-describedby="tip-ammonia" data-testid="info-ammonia">ⓘ</button>
               </div>
-              <input type="number" id="ammonia" name="ammonia" step="0.01" min="0" inputmode="decimal" />
+              <input type="number" id="ammonia" name="ammonia" step="0.01" min="0" inputmode="decimal" data-testid="ammonia" />
               <span id="tip-ammonia" class="visually-hidden">Waste from fish/food. Even tiny amounts are toxic.</span>
             </div>
             <div class="field">
               <div class="label-row">
                 <label for="nitrite">Nitrite (NO₂⁻)</label>
-                <button type="button" class="info-btn" data-tooltip="Mid-stage of the cycle; also toxic." aria-label="Nitrite info" aria-describedby="tip-nitrite">ⓘ</button>
+                <button type="button" class="info-btn" data-tooltip="Mid-stage of the cycle; also toxic." aria-label="Nitrite info" aria-describedby="tip-nitrite" data-testid="info-nitrite">ⓘ</button>
               </div>
-              <input type="number" id="nitrite" name="nitrite" step="0.01" min="0" inputmode="decimal" />
+              <input type="number" id="nitrite" name="nitrite" step="0.01" min="0" inputmode="decimal" data-testid="nitrite" />
               <span id="tip-nitrite" class="visually-hidden">Mid-stage of the cycle; also toxic.</span>
             </div>
             <div class="field">
               <div class="label-row">
                 <label for="nitrate">Nitrate (NO₃⁻)</label>
-                <button type="button" class="info-btn" data-tooltip="End product; safer but must be controlled with water changes." aria-label="Nitrate info" aria-describedby="tip-nitrate">ⓘ</button>
+                <button type="button" class="info-btn" data-tooltip="End product; safer but must be controlled with water changes." aria-label="Nitrate info" aria-describedby="tip-nitrate" data-testid="info-nitrate">ⓘ</button>
               </div>
-              <input type="number" id="nitrate" name="nitrate" step="0.1" min="0" inputmode="decimal" />
+              <input type="number" id="nitrate" name="nitrate" step="0.1" min="0" inputmode="decimal" data-testid="nitrate" />
               <span id="tip-nitrate" class="visually-hidden">End product; safer but must be controlled with water changes.</span>
             </div>
             <div class="field">
               <div class="label-row">
                 <label for="cycle-method">Cycle Method</label>
-                <button type="button" class="info-btn" data-tooltip="Fishless = add ammonia without fish. Fish-in = cycle with fish; requires extra care." aria-label="Cycle method info" aria-describedby="tip-method">ⓘ</button>
+                <button type="button" class="info-btn" data-tooltip="Fishless = add ammonia without fish. Fish-in = cycle with fish; requires extra care." aria-label="Cycle method info" aria-describedby="tip-method" data-testid="info-cycle-method">ⓘ</button>
               </div>
               <select id="cycle-method" name="cycle-method">
                 <option value="fishless" selected>Fishless</option>
@@ -601,18 +601,18 @@
         <div class="card__header">
           <div class="status-label">
             <h2 class="card__title" id="results-heading">Results</h2>
-            <button type="button" class="info-btn" data-tooltip="High-level snapshot of where your tank stands." aria-label="Status info" aria-describedby="tip-status">ⓘ</button>
+            <button type="button" class="info-btn" data-tooltip="High-level snapshot of where your tank stands." aria-label="Status info" aria-describedby="tip-status" data-testid="info-status">ⓘ</button>
           </div>
           <span id="tip-status" class="visually-hidden">High-level snapshot of where your tank stands.</span>
         </div>
-        <div class="status-row" aria-live="polite">
+        <div class="status-row" aria-live="polite" data-testid="result-status">
           <span class="status-badge" id="status-badge">⚪ Incomplete</span>
           <p class="results-summary" id="results-summary">Ammonia: — ppm • Nitrite: — ppm • Nitrate: — ppm • Method: Fishless • Planted: No</p>
         </div>
-        <div class="actions-block" id="actions-block" hidden>
+        <div class="actions-block" id="actions-block" hidden data-testid="result-actions">
           <header>
             <span>Action steps</span>
-            <button type="button" class="info-btn" data-tooltip="Quick, practical steps based on your readings." aria-label="Action steps info" aria-describedby="tip-actions">ⓘ</button>
+            <button type="button" class="info-btn" data-tooltip="Quick, practical steps based on your readings." aria-label="Action steps info" aria-describedby="tip-actions" data-testid="info-actions">ⓘ</button>
           </header>
           <span id="tip-actions" class="visually-hidden">Quick, practical steps based on your readings.</span>
           <ul class="actions-list" id="actions-list"></ul>
@@ -622,7 +622,7 @@
       <section class="card" id="challengeCard" aria-labelledby="challenge-heading" hidden>
         <div class="card__header">
           <h2 class="card__title" id="challenge-heading">24-Hour Challenge</h2>
-          <button type="button" class="info-btn" data-tooltip="Shows your filter can process 2 ppm ammonia to 0 ammonia and 0 nitrite in 24 hours." aria-label="Challenge info" aria-describedby="tip-challenge">ⓘ</button>
+          <button type="button" class="info-btn" data-tooltip="Shows your filter can process 2 ppm ammonia to 0 ammonia and 0 nitrite in 24 hours." aria-label="Challenge info" aria-describedby="tip-challenge" data-testid="info-challenge">ⓘ</button>
           <span id="tip-challenge" class="visually-hidden">Shows your filter can process two ppm ammonia to zero ammonia and zero nitrite in twenty-four hours.</span>
         </div>
         <div class="challenge-card">
@@ -645,7 +645,7 @@
           <div class="actions-block" id="challenge-results" hidden>
             <header>
               <span>Challenge test</span>
-              <button type="button" class="info-btn" data-tooltip="Shows your filter can process 2 ppm ammonia to 0 ammonia and 0 nitrite in 24 hours." aria-label="Challenge test info" aria-describedby="tip-challenge-inline">ⓘ</button>
+              <button type="button" class="info-btn" data-tooltip="Shows your filter can process 2 ppm ammonia to 0 ammonia and 0 nitrite in 24 hours." aria-label="Challenge test info" aria-describedby="tip-challenge-inline" data-testid="info-challenge-inline">ⓘ</button>
             </header>
             <span id="tip-challenge-inline" class="visually-hidden">Shows your filter can process two ppm ammonia to zero ammonia and zero nitrite in twenty-four hours.</span>
             <ul class="actions-list" id="challenge-list"></ul>
@@ -659,12 +659,12 @@
           <div class="advanced-grid">
             <div class="field">
               <label for="ph">pH</label>
-              <input type="number" id="ph" name="ph" step="0.1" inputmode="decimal" />
+              <input type="number" id="ph" name="ph" step="0.1" inputmode="decimal" data-testid="ph" />
             </div>
             <div class="field">
               <label for="temperature">Temperature</label>
               <div class="temp-toggle">
-                <input type="number" id="temperature" name="temperature" step="0.1" inputmode="decimal" />
+                <input type="number" id="temperature" name="temperature" step="0.1" inputmode="decimal" data-testid="temp" />
                 <button type="button" id="temp-toggle" aria-label="Switch temperature unit">°F</button>
               </div>
             </div>
@@ -673,7 +673,7 @@
             <span>Estimated toxic NH₃:</span>
             <span class="value" id="nh3-value">—</span>
             <span class="nh3-badge" id="nh3-badge" hidden>⚠️ Caution</span>
-            <button type="button" class="info-btn" data-tooltip="Test kits read TAN (NH₃ + NH₄⁺). Only NH₃ is toxic and increases with pH/temperature." aria-label="Advanced NH3 info" aria-describedby="tip-advanced">ⓘ</button>
+            <button type="button" class="info-btn" data-tooltip="Test kits read TAN (NH₃ + NH₄⁺). Only NH₃ is toxic and increases with pH/temperature." aria-label="Advanced NH3 info" aria-describedby="tip-advanced" data-testid="info-advanced">ⓘ</button>
             <span id="tip-advanced" class="visually-hidden">Test kits read TAN, which is NH3 plus NH4. Only NH3 is toxic and increases with pH and temperature.</span>
           </div>
           <p class="advanced-note"><a href="/media.html" target="_blank" rel="noopener">See Media page for Sources &amp; Further Reading.</a></p>

--- a/stocking.html
+++ b/stocking.html
@@ -3,18 +3,18 @@
 <head>
   <meta charset="UTF-8" />
   <title>Stocking Advisor — Plan a Healthy Aquarium | The Tank Guide</title>
-  <meta name="description" content="Plan a healthy freshwater aquarium with The Tank Guide Stocking Advisor—compatibility checks, bioload guidance, and beginner-friendly stocking suggestions.">
+  <meta name="description" content="Plan a healthy freshwater aquarium with The Tank Guide Stocking Advisor—compatibility checks, bioload guidance, and smart stocking suggestions.">
   <link rel="canonical" href="https://thetankguide.com/stocking.html">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="The Tank Guide">
   <meta property="og:title" content="Stocking Advisor — Plan a Healthy Aquarium | The Tank Guide">
-  <meta property="og:description" content="Plan a healthy freshwater aquarium with The Tank Guide Stocking Advisor—compatibility checks, bioload guidance, and beginner-friendly stocking suggestions.">
+  <meta property="og:description" content="Plan a healthy freshwater aquarium with The Tank Guide Stocking Advisor—compatibility checks, bioload guidance, and smart stocking suggestions.">
   <meta property="og:url" content="https://thetankguide.com/stocking.html">
   <meta property="og:image" content="https://thetankguide.com/logo.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@fishkeepinglife">
   <meta name="twitter:title" content="Stocking Advisor — Plan a Healthy Aquarium | The Tank Guide">
-  <meta name="twitter:description" content="Plan a healthy freshwater aquarium with The Tank Guide Stocking Advisor—compatibility checks, bioload guidance, and beginner-friendly stocking suggestions.">
+  <meta name="twitter:description" content="Plan a healthy freshwater aquarium with The Tank Guide Stocking Advisor—compatibility checks, bioload guidance, and smart stocking suggestions.">
   <meta name="twitter:image" content="https://thetankguide.com/logo.png">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link rel="stylesheet" id="css-main" href="css/style.css?v=2024-06-05a" />

--- a/terms.html
+++ b/terms.html
@@ -104,5 +104,18 @@
   }
 }
   </script>
+  <div id="site-footer"></div>
+  <script>
+  (async () => {
+    try {
+      const res = await fetch('footer.v1.2.2.html?v=1.2.2', { cache: 'no-cache' });
+      const html = await res.text();
+      const host = document.getElementById('site-footer');
+      if (host) host.outerHTML = html;
+    } catch (e) {
+      console.error('[Footer] load failed:', e);
+    }
+  })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove beginner-mode copy and update nav/contact labeling across home, gear, about, media, and contact pages
- strip unused Stocking Advisor toggle wiring, add shared footer include to legal pages, and refresh copy for tank size notes
- add Cycling Coach testing hooks and revise Playwright flows for keyboard popovers and the gear CTA session payload

## Testing
- npx playwright test *(fails: Playwright browsers missing in container)*
- npx playwright install *(fails: CDN responded 403 when attempting to download Chromium)*

------
https://chatgpt.com/codex/tasks/task_e_68dc7a0f3c3483329d161178a40ded0c