### PR TITLE
Replace Latest video placeholder with official intro short embed

### DIFF
--- a/media.html
+++ b/media.html
@@ -262,10 +262,20 @@
       <p class="lead">Catch our latest upload or explore the full channel for more.</p>
       <div class="card stack">
         <article>
-          <div class="media-thumb">Latest Video Placeholder</div>
-          <h3>How to Cycle a Freshwater Aquarium</h3>
-          <p class="muted">Step-by-step walkthrough of the fishless cycle with test schedule and safety tips.</p>
-          <p><a class="btn" href="https://www.youtube.com/@fishkeepinglifeco" target="_blank" rel="noopener noreferrer">Watch on YouTube</a></p>
+          <h3 class="visually-hidden">Latest video</h3>
+          <div style="position:relative;width:100%;aspect-ratio:16 / 9;border:1px solid var(--border);border-radius:10px;overflow:hidden;background:#000;">
+            <iframe
+              src="https://www.youtube-nocookie.com/embed/l6HkU9nc-SM?rel=0"
+              title="FishKeepingLifeCo Official Intro"
+              loading="lazy"
+              referrerpolicy="strict-origin-when-cross-origin"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowfullscreen
+              style="position:absolute;inset:0;width:100%;height:100%;border:0;">
+            </iframe>
+          </div>
+          <p class="muted" style="margin:10px 0 0;">Now playing: <strong>FishKeepingLifeCo Official Intro</strong></p>
+          <a class="btn" href="https://youtube.com/shorts/l6HkU9nc-SM" target="_blank" rel="noopener">▶ Watch on YouTube</a>
         </article>
         <article>
           <div class="media-thumb">Community Q&amp;A Live Replay</div>


### PR DESCRIPTION
## Summary
- replace the Latest video placeholder card with a responsive, privacy-friendly YouTube embed for the official intro short
- add an accessible caption and call-to-action button linking to the intro short

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dca6464b548332bf8dd94d1eff5e57