### PR TITLE
Remove secondary promo card from media page

### DIFF
--- a/media.html
+++ b/media.html
@@ -74,17 +74,6 @@
     .muted { color: var(--muted); }
     .center { text-align:center; }
 
-    .media-thumb {
-      width: 100%;
-      aspect-ratio: 16 / 9;
-      background: #e9eef3;
-      border: 1px solid var(--border);
-      border-radius: 10px;
-      display:flex; align-items:center; justify-content:center;
-      font-size: 0.95rem; color: var(--muted);
-      margin-bottom: 10px;
-    }
-
     /* --- Featured Resource --- */
     #featured-resource {
       padding: 16px;
@@ -283,12 +272,6 @@
           </div>
           <p class="muted" style="margin:10px 0 0;">Now playing: <strong>FishKeepingLifeCo Official Intro</strong></p>
           <a class="btn" href="https://youtube.com/shorts/l6HkU9nc-SM" target="_blank" rel="noopener">▶ Watch on YouTube</a>
-        </article>
-        <article>
-          <div class="media-thumb">Community Q&amp;A Live Replay</div>
-          <h3>Live Q&amp;A: Tackling Cloudy Water</h3>
-          <p class="muted">We break down bacterial blooms, overfeeding, and filter maintenance during a live chat.</p>
-          <p><a class="btn" href="https://www.youtube.com/@fishkeepinglifeco" target="_blank" rel="noopener noreferrer">Catch the Replay</a></p>
         </article>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- remove the secondary Q&A promo card beneath the featured video on media.html
- clean up the unused media-thumb styles that were only used by the removed block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcad743ed883329539e508a948b032