### PR TITLE
Refine featured video block on media page

### DIFF
--- a/media.html
+++ b/media.html
@@ -256,24 +256,22 @@
     <section class="section" aria-labelledby="videos">
       <h2 id="videos">Featured Videos</h2>
       <p class="lead">Catch our latest upload or explore the full channel for more.</p>
-      <div class="card stack">
-        <article>
-          <h3 class="visually-hidden">Latest video</h3>
-          <div style="position:relative;width:100%;aspect-ratio:16 / 9;border:1px solid var(--border);border-radius:10px;overflow:hidden;background:#000;">
-            <iframe
-              src="https://www.youtube-nocookie.com/embed/l6HkU9nc-SM?rel=0"
-              title="FishKeepingLifeCo Official Intro"
-              loading="lazy"
-              referrerpolicy="strict-origin-when-cross-origin"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-              allowfullscreen
-              style="position:absolute;inset:0;width:100%;height:100%;border:0;">
-            </iframe>
-          </div>
-          <p class="muted" style="margin:10px 0 0;">Now playing: <strong>FishKeepingLifeCo Official Intro</strong></p>
-          <a class="btn" href="https://youtube.com/shorts/l6HkU9nc-SM" target="_blank" rel="noopener">▶ Watch on YouTube</a>
-        </article>
-      </div>
+      <article class="card">
+        <h3 class="visually-hidden">Latest video</h3>
+        <div style="position:relative;width:100%;aspect-ratio:16 / 9;border:1px solid var(--border);border-radius:10px;overflow:hidden;background:#000;">
+          <iframe
+            src="https://www.youtube-nocookie.com/embed/l6HkU9nc-SM?rel=0"
+            title="FishKeepingLifeCo Official Intro"
+            loading="lazy"
+            referrerpolicy="strict-origin-when-cross-origin"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowfullscreen
+            style="position:absolute;inset:0;width:100%;height:100%;border:0;">
+          </iframe>
+        </div>
+        <p class="muted" style="margin:10px 0 0;">Now playing: <strong>FishKeepingLifeCo Official Intro</strong></p>
+        <a class="btn" href="https://youtube.com/shorts/l6HkU9nc-SM" target="_blank" rel="noopener">▶ Watch on YouTube</a>
+      </article>
     </section>
 
     <!-- Articles -->


### PR DESCRIPTION
## Summary
- flatten the featured video markup on media.html so the remaining card stands on its own after removing the old Q&A promo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcb14d7b908332ae4c1d42a6cc8106