### PR TITLE
Media card copy + YouTube CTA

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1202,3 +1202,40 @@ body.planted-active #cycling-coach .cc-title__leaf {
     margin: 6px 10px;
   }
 }
+
+/* Featured Videos card heading moved inside */
+.video-card h2 { margin: 0 0 8px; }
+.video-card .subline { margin: 0 0 12px; opacity: .9; }
+
+/* Pill CTA based on YouTube brand (black background) */
+.yt-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  background: #000;
+  color: #fff;
+  border-radius: 999px;
+  padding: 10px 16px;
+  text-decoration: none;
+  font-weight: 600;
+  line-height: 1;
+  box-shadow: 0 1px 2px rgba(0,0,0,.25);
+}
+.yt-cta:focus { outline: 2px solid #ffffff; outline-offset: 2px; }
+.yt-cta:hover { filter: brightness(1.08); }
+.yt-cta:active { transform: translateY(1px); }
+
+/* Red play icon (SVG via CSS background) */
+.yt-icon {
+  width: 22px; height: 16px; flex: 0 0 22px;
+  background:
+    /* white play triangle */
+    conic-gradient(from 330deg at 9px 8px, #fff 0 60deg, transparent 0) no-repeat 7px 3px / 8px 10px,
+    /* red rounded rect */
+    #FF0033;
+  border-radius: 4px / 6px;
+}
+
+.video-card > iframe,
+.video-card .embed-wrapper { margin-top: 12px; }
+.video-card .now-playing { margin: 12px 0 10px; }

--- a/media.html
+++ b/media.html
@@ -254,11 +254,11 @@
   <main class="wrap" id="content">
     <!-- Featured Videos -->
     <section class="section" aria-labelledby="videos">
-      <h2 id="videos">Featured Videos</h2>
-      <p class="lead">Catch our latest upload or explore the full channel for more.</p>
-      <article class="card">
+      <article class="card video-card">
+        <h2 id="videos">Featured Videos</h2>
+        <p class="subline">Catch our latest upload or explore the full channel for more.</p>
         <h3 class="visually-hidden">Latest video</h3>
-        <div style="position:relative;width:100%;aspect-ratio:16 / 9;border:1px solid var(--border);border-radius:10px;overflow:hidden;background:#000;">
+        <div class="embed-wrapper" style="position:relative;width:100%;aspect-ratio:16 / 9;border:1px solid var(--border);border-radius:10px;overflow:hidden;background:#000;">
           <iframe
             src="https://www.youtube-nocookie.com/embed/l6HkU9nc-SM?rel=0"
             title="FishKeepingLifeCo Official Intro"
@@ -269,8 +269,11 @@
             style="position:absolute;inset:0;width:100%;height:100%;border:0;">
           </iframe>
         </div>
-        <p class="muted" style="margin:10px 0 0;">Now playing: <strong>FishKeepingLifeCo Official Intro</strong></p>
-        <a class="btn" href="https://youtube.com/shorts/l6HkU9nc-SM" target="_blank" rel="noopener">▶ Watch on YouTube</a>
+        <p class="muted now-playing">Now playing: <strong>FishKeepingLifeCo Official Intro</strong></p>
+        <a class="yt-cta" href="https://youtube.com/shorts/l6HkU9nc-SM" target="_blank" rel="noopener">
+          <span class="yt-icon" aria-hidden="true"></span>
+          <span class="yt-label">Watch on YouTube</span>
+        </a>
       </article>
     </section>
 


### PR DESCRIPTION
## Summary
- move the Featured Videos heading and description into the video card so the copy sits with the embed
- restyle the YouTube link as an on-brand black pill CTA while keeping the existing destination and accessibility text

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68dcb4393c0483328115a891c2cba2b7