### PR TITLE
Adjust featured video layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -255,6 +255,27 @@ body.theme-light {
   color: #fff;
 }
 
+.video-card .video-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.video-card .video-blurb {
+  flex: 1 1 auto;
+}
+
+.video-card .video-blurb p {
+  margin: 0;
+}
+
+.video-card .video-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: auto;
+}
+
 .hamburger__bars {
   position: relative;
   display: block;

--- a/media.html
+++ b/media.html
@@ -269,15 +269,21 @@
             style="position:absolute;inset:0;width:100%;height:100%;border:0;">
           </iframe>
         </div>
-        <p class="muted now-playing">Now playing: <strong>FishKeepingLifeCo Official Intro</strong></p>
-        <a class="yt-cta" href="https://youtube.com/shorts/l6HkU9nc-SM" target="_blank" rel="noopener">
-          <span class="yt-icon" aria-hidden="true">
-            <svg class="yt-cta-svg" viewBox="0 0 64 64" width="20" height="20" focusable="false" aria-hidden="true">
-              <path d="M22 18 L22 38 L42 28 Z" fill="#fff"></path>
-            </svg>
-          </span>
-          <span class="yt-label">Watch on YouTube</span>
-        </a>
+        <div class="video-meta">
+          <div class="video-blurb">
+            <p class="muted now-playing">Now playing: <strong>FishKeepingLifeCo Official Intro</strong></p>
+          </div>
+          <div class="video-actions">
+            <a class="yt-cta" href="https://youtube.com/shorts/l6HkU9nc-SM" target="_blank" rel="noopener">
+              <span class="yt-icon" aria-hidden="true">
+                <svg class="yt-cta-svg" viewBox="0 0 24 24" width="20" height="20" focusable="false" aria-hidden="true">
+                  <path d="M9 7v10l8-5z" fill="#fff"></path>
+                </svg>
+              </span>
+              <span class="yt-label">Watch on YouTube</span>
+            </a>
+          </div>
+        </div>
       </article>
     </section>
 


### PR DESCRIPTION
## Summary
- wrap the featured video content in a dedicated meta section so the blurb and actions have clear structure
- update the YouTube CTA icon to a crisp play triangle while preserving the existing label and link
- add scoped flexbox styles so the blurb stays above the button and the button remains bottom-right aligned across breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcbca6b58c8332866386290464188b