### PR TITLE
Remove tank variant chooser from stocking page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -778,10 +778,6 @@ html {
   margin-bottom: 16px;
 }
 
-#stocking-page #tank-summary {
-  margin-top: 16px;
-}
-
 #stocking-page section[aria-labelledby="water-title"] {
   margin-top: 16px;
 }
@@ -789,10 +785,6 @@ html {
 @media (min-width: 720px) {
   #stocking-page section[aria-labelledby="controls-title"] {
     margin-bottom: 20px;
-  }
-
-  #stocking-page #tank-summary {
-    margin-top: 20px;
   }
 
   #stocking-page section[aria-labelledby="water-title"] {

--- a/stocking.html
+++ b/stocking.html
@@ -217,33 +217,9 @@
       text-decoration: underline;
     }
 
-    .tank-summary {
-      display: flex;
-      flex-direction: column;
-      gap: 10px;
-      color: var(--muted);
-      font-size: 0.98rem;
-    }
-
-    .variant-selector {
-      display: flex;
-      gap: 6px;
-      flex-wrap: wrap;
-    }
-
-    .variant-selector button {
-      border-radius: 999px;
-      border: 1px solid rgba(255, 255, 255, 0.18);
-      background: rgba(255, 255, 255, 0.12);
-      color: var(--fg);
-      padding: 6px 12px;
-      cursor: pointer;
-      font-size: 0.92rem;
-    }
-
-    .variant-selector button[data-active="true"] {
-      border-color: rgba(163, 200, 255, 0.9);
-      background: rgba(163, 200, 255, 0.16);
+    [data-role="tank-spec"] {
+      pointer-events: none;
+      text-decoration: none;
     }
 
     .conditions-list {
@@ -949,11 +925,8 @@
           </div>
         </div>
 
-        <!-- Facts line stays; starts EMPTY to avoid duplicate helper text -->
-        <div id="tank-facts" class="facts-line muted-text" aria-live="polite"></div>
-
-        <!-- Tank summary rendered inside the card -->
-        <div id="tank-summary" aria-live="polite" data-testid="tank-summary"></div>
+          <!-- Facts line stays; starts EMPTY to avoid duplicate helper text -->
+          <div class="facts-line muted-text" data-role="tank-spec" aria-live="polite"></div>
 
         <!-- Planted (stacked) -->
         <div class="row toggle-row">
@@ -1300,8 +1273,8 @@
   <script type="module" src="js/fish-data.js"></script>
   <script type="module" src="js/logic/compute.js"></script>
   <script type="module" src="js/logic/conflicts.js"></script>
-  <script type="module" src="js/stocking.js?v=2024-07-09a" id="js-stocking"></script>
-  <script type="module" src="js/tank-size-card.js?v=2024-07-09a"></script>
+  <script type="module" src="js/stocking.js?v=2024-07-09b" id="js-stocking"></script>
+  <script type="module" src="js/tank-size-card.js?v=2024-07-09b"></script>
 
 </body>
 </html>

--- a/tests/e2e.spec.js
+++ b/tests/e2e.spec.js
@@ -30,7 +30,7 @@ async function selectTank(page, gallons) {
     await control.selectOption(optionValue);
   }
   await page.keyboard.press('Tab');
-  await expect(page.locator('#tank-facts')).toContainText(`${gallons}`, { timeout: 6000 });
+  await expect(page.locator('[data-role="tank-spec"]')).toContainText(`${gallons}`, { timeout: 6000 });
   return control;
 }
 
@@ -106,7 +106,7 @@ test.describe('Stocking Advisor accessibility flows', () => {
   test('Tank selection updates summary and stock meters', async ({ page }, testInfo) => {
     await selectTank(page, 40);
 
-    const facts = page.locator('#tank-facts');
+    const facts = page.locator('[data-role="tank-spec"]');
     await expect(facts).toContainText(/40/);
 
     const bars = page.locator('[data-testid="stock-bars"] .env-bar__fill').first();


### PR DESCRIPTION
## Summary
- remove the tank variant chooser markup, styles, and runtime logic from the stocking page so the dropdown is the only selector
- render a non-interactive tank spec line from the size card script and add a guard that strips any injected variant UI
- update e2e expectations and cache-busting query strings to reflect the new tank spec selector

## Testing
- `npx playwright test tests/e2e.spec.js --project=chromium-desktop` *(fails: browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dcbdd8ce948332919f42720f8c7797