### PR TITLE
Add divider and spacing refinements to featured video card

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1325,4 +1325,14 @@ body.planted-active #cycling-coach .cc-title__leaf {
 }
 
 /* Ensure spacing looks good inside the card only */
-.featured-videos-card .video-meta{ padding-top:.25rem; }
+.featured-videos-card .now-playing{ margin:12px 0 4px; }
+.featured-videos-card .media-divider{
+  border:0;
+  border-top:1px solid var(--border);
+  width:100%;
+  margin:4px 0 4px;
+}
+.featured-videos-card .video-meta{
+  padding-top:.25rem;
+  margin-top:0;
+}

--- a/media.html
+++ b/media.html
@@ -270,6 +270,7 @@
           </iframe>
         </div>
         <p class="muted now-playing">Now playing: <strong>FishKeepingLifeCo Official Intro</strong></p>
+        <hr class="media-divider" />
         <div class="video-meta">
           <p class="video-blurb">
             Our official intro — The Tank Guide, a product of FishKeepingLifeCo. Explore aquarium tools like the Stocking Advisor, along with setup tips, care guides, and resources to help every aquarist, from beginner tanks to advanced planted aquariums.


### PR DESCRIPTION
## Summary
- insert a subtle divider beneath the featured video's now playing copy
- tune spacing around the now playing text and divider while preserving the CTA alignment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcc31c3da48332a3af87e7dd88ffb0