### PR TITLE
Adjust Now Playing styling in media card

### DIFF
--- a/media.html
+++ b/media.html
@@ -79,18 +79,13 @@
     }
     .now-playing-label {
       font-weight: 700;
-      color: #ff0000;
-      transition: color 0.2s ease;
+      color: #000000;
       cursor: default;
-      text-shadow: -1px 0 0 #000, 1px 0 0 #000, 0 -1px 0 #000, 0 1px 0 #000;
-    }
-    .now-playing-label:hover {
-      color: #cc0000;
     }
     .now-playing-title {
       padding-left: 6px;
       font-weight: 400;
-      color: inherit;
+      color: #333333;
     }
     .center { text-align:center; }
 


### PR DESCRIPTION
## Summary
- update the Featured Videos Now Playing label to render in bold black text without hover or shadow effects
- ensure the Now Playing title uses a regular dark gray color consistent with surrounding copy

## Testing
- Visual verification in Chromium via Playwright at 1280x720 and 390x844 viewports

------
https://chatgpt.com/codex/tasks/task_e_68dcc98fd5cc833285b44e869d4d26fd