### PR TITLE
Consolidate tank size usage around canonical dataset

### DIFF
--- a/gear.html
+++ b/gear.html
@@ -138,12 +138,7 @@
       <div class="card">
         <div class="row">
           <label for="tank-size"><strong>Choose size:</strong></label>
-          <select id="tank-size" aria-label="Tank size">
-            <option value="">-- Select --</option>
-            <option>10</option><option>20</option><option>29</option><option>40</option>
-            <option>50</option><option>55</option><option>75</option><option>90</option>
-            <option>120</option><option>125</option>
-          </select>
+          <select id="tank-size" aria-label="Tank size"></select>
           <span class="chip" id="size-chip" style="display:none;"></span>
         </div>
 
@@ -281,5 +276,6 @@
   } catch (e) { console.error('[Footer] load failed:', e); }
 })();
 </script>
+  <script type="module" src="js/gear.js?v=2024-09-01"></script>
 </body>
 </html>

--- a/js/logic/compute.js
+++ b/js/logic/compute.js
@@ -159,12 +159,13 @@ function calcTank(state, entries, overrideVariant) {
   const hasTankGallons = Number.isFinite(tankState.gallons) && tankState.gallons > 0;
   const gallonsSource = hasTankGallons ? tankState.gallons : Number(state.gallons) || 0;
   const gallons = clamp(gallonsSource, 0, 999);
+  const tankId = tankState?.id ?? null;
   const sump = clamp(Number(state.sumpGallons) || 0, 0, 400);
   const planted = Boolean(state.planted);
   const manualVariant = overrideVariant ?? state.variantId ?? null;
-  const variant = pickTankVariant({ gallons, speciesEntries: entries, manualSelection: manualVariant })
-    ?? pickTankVariant({ gallons, speciesEntries: [], manualSelection: manualVariant })
-    ?? getTankVariants(gallons)[0]
+  const variant = pickTankVariant({ tankId, gallons, speciesEntries: entries, manualSelection: manualVariant })
+    ?? pickTankVariant({ tankId, gallons, speciesEntries: [], manualSelection: manualVariant })
+    ?? getTankVariants({ tankId, gallons })[0]
     ?? null;
 
   const length = Number.isFinite(tankState.lengthIn) && tankState.lengthIn > 0 ? tankState.lengthIn : variant?.length ?? 0;

--- a/js/stocking.js
+++ b/js/stocking.js
@@ -650,7 +650,8 @@ function updateToggle(control, value) {
 function syncStateFromInputs() {
   if (state.variantId) {
     const gallons = state.tank?.gallons ?? 0;
-    const valid = getTankVariants(gallons).some((variant) => variant.id === state.variantId);
+    const tankId = state.tank?.id ?? null;
+    const valid = getTankVariants({ tankId, gallons }).some((variant) => variant.id === state.variantId);
     if (!valid) {
       state.variantId = null;
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -176,6 +176,12 @@ export function getTankById(id) {
   return TANK_SIZES.find((tank) => tank.id === id) ?? null;
 }
 
+export function getTankLabel(id) {
+  if (!id) return '';
+  const tank = getTankById(id);
+  return tank?.label ?? '';
+}
+
 export function normalizeLegacyTankSelection(oldValue) {
   const fallback = '29g';
   if (!oldValue) {

--- a/stocking.html
+++ b/stocking.html
@@ -1273,8 +1273,8 @@
   <script type="module" src="js/fish-data.js"></script>
   <script type="module" src="js/logic/compute.js"></script>
   <script type="module" src="js/logic/conflicts.js"></script>
-  <script type="module" src="js/stocking.js?v=2024-07-09b" id="js-stocking"></script>
-  <script type="module" src="js/tank-size-card.js?v=2024-07-09b"></script>
+  <script type="module" src="js/stocking.js?v=2024-09-01" id="js-stocking"></script>
+  <script type="module" src="js/tank-size-card.js?v=2024-09-01"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild `js/logic/sizeMap.js` to derive tank variants from the canonical `TANK_SIZES` helpers
- switch the gear page to populate its size selector and product cards from the shared tank data instead of local catalogs
- add a `getTankLabel` utility and bump module version strings so stocking and gear reuse the unified tank list

## Testing
- npm test *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd1e1fced883328c8a7164384d335f