### PR TITLE
Update media library heading and add mission card

### DIFF
--- a/media.html
+++ b/media.html
@@ -306,9 +306,15 @@
 
     <!-- Articles -->
     <section class="section" aria-labelledby="articles">
-      <h2 id="articles">Recent Articles</h2>
+      <h2 id="articles">Aquarium Library</h2>
+      <p class="subline">Explore a collection of guides, research articles, transcripts, and more.</p>
       <p class="lead">From cycling checklists to stocking blueprints — dive into the blog.</p>
       <div class="card stack">
+        <article>
+          <h3>Mission &amp; Values</h3>
+          <p class="muted">Explore the values behind FishKeepingLifeCo: clear guidance, hands-on learning, responsible care, and a supportive fishkeeping community.</p>
+          <p><a class="btn" href="/about.html#mission">Read Our Mission</a></p>
+        </article>
         <article>
           <h3>Ultimate Stocking Checklist</h3>
           <p class="muted">Everything you need to plan a compatible community, including tank footprint, water parameters, and behavior notes.</p>


### PR DESCRIPTION
## Summary
- rename the Recent Articles section to Aquarium Library and add a matching subline paragraph
- add a Mission & Values card at the top of the Aquarium Library stack that links to the mission anchor

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd2330b7908332ab5e89c4535c6b16