### PR TITLE
Refine Aquarium Library card layout

### DIFF
--- a/media.html
+++ b/media.html
@@ -306,10 +306,9 @@
 
     <!-- Articles -->
     <section class="section" aria-labelledby="articles">
-      <h2 id="articles">Aquarium Library</h2>
-      <p class="subline">Explore a collection of guides, research articles, transcripts, and more.</p>
-      <p class="lead">From cycling checklists to stocking blueprints — dive into the blog.</p>
       <div class="card stack">
+        <h2 id="articles">Aquarium Library</h2>
+        <p class="subline">Explore a collection of guides, research articles, transcripts, and more.</p>
         <article>
           <h3>Mission &amp; Values</h3>
           <p class="muted">Explore the values behind FishKeepingLifeCo: clear guidance, hands-on learning, responsible care, and a supportive fishkeeping community.</p>


### PR DESCRIPTION
## Summary
- move the Aquarium Library heading and description inside the card container to match the Featured Videos layout
- remove the stray subtitle line that previously sat outside the card

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd262ee1c083328e5834b1a1f38b7e