### PR TITLE
Align Cycling Coach bottom blurb styling with homepage

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1026,29 +1026,40 @@ nav[role="navigation"] + .hero-header{
 
 /* conditions grid */
 
-/* Cycling Coach blurbs — fallback to match homepage sizing exactly */
-#cc-blurbs .home-subtext {
+/* ==== Cycling Coach bottom blurb — fallback to match homepage look ==== */
+#cc-bottom {
+  margin: 16px 0 20px;      /* same vertical rhythm as homepage blurb area */
+}
+#cc-bottom .home-subtext {
   font: inherit;
   font-size: var(--home-subtext-size, 0.95rem);
-  line-height: var(--home-subtext-leading, 1.5);
-  color: var(--text-muted, rgba(255,255,255,0.8));
-  margin: 12px 0 10px;
+  line-height: var(--home-subtext-leading, 1.55);
+  color: var(--text-muted, rgba(255,255,255,0.82));
+  margin: 0 0 10px;
 }
-#cc-blurbs .home-blurb {
+#cc-bottom .home-blurb {
   font: inherit;
   font-size: var(--home-blurb-size, 1.05rem);
   line-height: var(--home-blurb-leading, 1.7);
   color: var(--text-primary, #fff);
-  margin: 0 0 18px;
-}
-/* Neutralize any accidental oversized styles coming from cards/containers */
-#cc-blurbs .home-subtext,
-#cc-blurbs .home-blurb {
-  font-weight: var(--home-blurb-weight, 400);
+  margin: 0;
+  max-width: 68ch;          /* keep readable line length like homepage */
 }
 @media (min-width: 768px) {
-  #cc-blurbs .home-subtext { font-size: var(--home-subtext-size-md, 1rem); }
-  #cc-blurbs .home-blurb { font-size: var(--home-blurb-size-md, 1.1rem); }
+  #cc-bottom .home-subtext { font-size: var(--home-subtext-size-md, 1.0rem); }
+  #cc-bottom .home-blurb   { font-size: var(--home-blurb-size-md, 1.1rem); }
+}
+/* Neutralize any accidental “card” or large-heading overrides in this area */
+#cc-bottom .home-subtext,
+#cc-bottom .home-blurb {
+  font-weight: 400;
+}
+
+/* Optional: align left with page content column if a grid/container is used */
+#cc-bottom {
+  /* uncomment if needed to snap to the same left edge as content/cards */
+  /* max-width: var(--content-max, 1100px); */
+  /* margin-left: auto; margin-right: auto; */
 }
 
 /* Cycling Coach — compact left-aligned title block */

--- a/params.html
+++ b/params.html
@@ -680,9 +680,14 @@
         </div>
       </details>
 
-      <section id="cc-blurbs" class="cc-blurbs" aria-label="About Cycling Coach">
-        <p class="home-subtext cc-disclaimer">Cycling Coach is an educational tool. Always confirm with your own testing and judgment before making aquarium decisions.</p>
-        <p class="home-blurb cc-seo">Cycling Coach is your aquarium cycling assistant. Enter your test results for ammonia (NH₃/NH₄⁺), nitrite (NO₂⁻), and nitrate (NO₃⁻) to see how your tank is progressing through the nitrogen cycle. Whether you’re doing a fishless cycle or cycling with fish, the tool helps you track water parameters, understand the next steps, and maintain a safe environment for your fish.</p>
+      <section id="cc-bottom" class="cc-bottom" aria-label="About Cycling Coach">
+        <p class="home-subtext cc-disclaimer">
+          Cycling Coach is an educational tool. Always confirm with your own testing and judgment before making aquarium decisions.
+        </p>
+
+        <p class="home-blurb cc-seo">
+          Cycling Coach is your aquarium cycling assistant. Enter your test results for ammonia (NH₃/NH₄⁺), nitrite (NO₂⁻), and nitrate (NO₃⁻) to see how your tank is progressing through the nitrogen cycle. Whether you’re doing a fishless cycle or cycling with fish, the tool helps you track water parameters, understand the next steps, and maintain a safe environment for your fish.
+        </p>
       </section>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- update the Cycling Coach disclaimer and blurb markup to match the homepage structure
- add a scoped fallback so the bottom blurb inherits the homepage typography and spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd254bdab8833282f454e71e293b8b