### PR TITLE
Compact Cycling Coach disclaimer layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1370,3 +1370,38 @@ body.planted-active #cycling-coach .cc-title__leaf {
 #env-card {
   transition: padding 180ms ease;
 }
+/* Cycling Coach — compact bottom disclaimer + blurb */
+#cc-bottom {
+  margin: 8px 0 10px;
+  padding: 0;
+  max-width: 68ch;
+}
+#cc-bottom .home-subtext {
+  font: inherit;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  color: var(--text-muted, rgba(255,255,255,0.8));
+  margin: 0 0 6px 0;
+}
+#cc-bottom .home-blurb {
+  font: inherit;
+  font-size: 0.98rem;
+  line-height: 1.45;
+  color: var(--text-primary, #fff);
+  margin: 0;
+}
+/* Desktop slight scale up without adding height */
+@media (min-width: 768px) {
+  #cc-bottom .home-subtext { font-size: 0.95rem; }
+  #cc-bottom .home-blurb   { font-size: 1.02rem; }
+}
+/* Neutralize any card/section styles that inflate spacing in this zone */
+#cc-bottom p { padding: 0; }
+#cc-bottom .home-subtext,
+#cc-bottom .home-blurb { font-weight: 400; }
+
+/* Ensure the block hugs the same left content line as cards */
+#cycling-coach #cc-bottom { /* if a container/grid is used, it will inherit alignment */ }
+
+/* Guard against large margins from preceding sections */
+#cc-bottom:where(*) { scroll-margin-top: 24px; }

--- a/params.html
+++ b/params.html
@@ -681,13 +681,8 @@
       </details>
 
       <section id="cc-bottom" class="cc-bottom" aria-label="About Cycling Coach">
-        <p class="home-subtext cc-disclaimer">
-          Cycling Coach is an educational tool. Always confirm with your own testing and judgment before making aquarium decisions.
-        </p>
-
-        <p class="home-blurb cc-seo">
-          Cycling Coach is your aquarium cycling assistant. Enter your test results for ammonia (NH₃/NH₄⁺), nitrite (NO₂⁻), and nitrate (NO₃⁻) to see how your tank is progressing through the nitrogen cycle. Whether you’re doing a fishless cycle or cycling with fish, the tool helps you track water parameters, understand the next steps, and maintain a safe environment for your fish.
-        </p>
+        <p class="home-subtext cc-disclaimer">Cycling Coach is an educational tool. Always confirm with your own testing and judgment before making aquarium decisions.</p>
+        <p class="home-blurb cc-seo">Cycling Coach is your aquarium cycling assistant. Enter your test results for ammonia (NH₃/NH₄⁺), nitrite (NO₂⁻), and nitrate (NO₃⁻) to see how your tank is progressing through the nitrogen cycle. Whether you’re doing a fishless cycle or cycling with fish, the tool helps you track water parameters, understand the next steps, and maintain a safe environment for your fish.</p>
       </section>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- tighten the Cycling Coach footer disclaimer and SEO blurb into a single compact wrapper
- add scoped CSS to keep the disclaimer block left-aligned with reduced spacing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd387386188332a29de9a4aa0684d1