### PR TITLE
Fix environmental legend toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1370,3 +1370,35 @@ body.planted-active #cycling-coach .cc-title__leaf {
 #env-card {
   transition: padding 180ms ease;
 }
+
+/* Environmental legend toggle */
+#env-card [data-role="env-legend"][hidden] {
+  display: none;
+}
+
+#env-card.info-open [data-role="env-legend"] {
+  display: block;
+}
+
+#env-card [data-role="env-legend"] {
+  transition: opacity 160ms ease;
+  opacity: 0;
+}
+
+#env-card.info-open [data-role="env-legend"] {
+  opacity: 1;
+}
+
+#env-card .meter-row {
+  margin-bottom: 0;
+}
+
+#env-card.info-open .meter-row {
+  margin-bottom: var(--space-4, 16px);
+}
+
+#env-info-btn {
+  position: relative;
+  z-index: 2;
+  pointer-events: auto;
+}

--- a/js/logic/envRecommend.js
+++ b/js/logic/envRecommend.js
@@ -122,7 +122,7 @@ export function renderEnvCard({ stock = [], stockCount = null, computed = null }
   const excelEl = document.getElementById('env-reco-xl');
   const barsEl = document.getElementById('env-bars');
   const warnEl = document.getElementById('env-warnings');
-  const tipsEl = document.getElementById('env-more-tips');
+  const tipsEl = document.getElementById('env-legend');
 
   if (listEl) {
     renderConditions(listEl, env.conditions, { isEmpty });

--- a/stocking.html
+++ b/stocking.html
@@ -686,7 +686,7 @@
         line-height: 1.15;
       }
 
-      #stocking-page #env-info-toggle {
+      #stocking-page #env-info-btn {
         grid-column: 2 / 3;
         align-self: start;
         margin-top: 2px;
@@ -1051,7 +1051,7 @@
         }
 
         /* Env. Recommendations single icon “expanded” state (if present) */
-        #stocking-page #env-info-toggle[aria-expanded="true"],
+        #stocking-page #env-info-btn[aria-expanded="true"],
         #stocking-page [data-role="env-info"][aria-expanded="true"] {
           background: rgba(20, 203, 168, 0.9);
           color: #0b1b18;
@@ -1196,12 +1196,13 @@
             <!-- SINGLE unified icon: shows popover on first click, toggles tips on next clicks -->
             <button
               type="button"
-              id="env-info-toggle"
-              class="info-btn"
+              id="env-info-btn"
               data-role="env-info"
-              aria-controls="env-more-tips"
+              class="info-btn icon-button info"
               aria-expanded="false"
+              aria-controls="env-legend"
               aria-label="More info and tips about Environmental Recommendations"
+              title="Show details"
               data-info="Derived from your selected stock. Ranges reflect compatible overlaps across all species."
             >
               i
@@ -1224,7 +1225,7 @@
             <!-- populated by JS: Bioload Capacity + Aggression & Compatibility -->
           </div>
 
-          <div id="env-more-tips" class="env-more-tips env-tips" data-role="env-legend" hidden>
+          <div id="env-legend" class="env-more-tips env-tips" data-role="env-legend" hidden>
             <!-- brief bullets about GH/KH, salinity, blackwater, and flow zones -->
           </div>
         </div>

--- a/tests/stocking-env-header.spec.ts
+++ b/tests/stocking-env-header.spec.ts
@@ -9,8 +9,8 @@ test.describe('Stocking Advisor — Env. Recommendations unified info icon', () 
   test('desktop: single icon toggles environmental legend', async ({ page }) => {
     await page.goto(url, { waitUntil: 'networkidle' });
 
-    const icon = page.locator('#env-info-toggle');
-    const panel = page.locator('#env-more-tips');
+    const icon = page.locator('#env-info-btn');
+    const panel = page.locator('#env-legend');
 
     await expect(icon).toBeVisible();
     await expect(panel).toBeHidden();
@@ -40,8 +40,8 @@ test.describe('Stocking Advisor — Env. Recommendations unified info icon (mobi
   test('mobile: single icon works and aligns', async ({ page }) => {
     await page.goto(url, { waitUntil: 'networkidle' });
 
-    const icon = page.locator('#env-info-toggle');
-    const panel = page.locator('#env-more-tips');
+    const icon = page.locator('#env-info-btn');
+    const panel = page.locator('#env-legend');
 
     await expect(icon).toBeVisible();
     await expect(icon).toHaveAttribute('aria-expanded', 'false');


### PR DESCRIPTION
## Summary
- update the Environmental Recommendations card markup to use the new env-info button and legend container
- add scoped CSS to control the legend’s visibility, spacing, and button stacking context
- replace legacy toggle logic with a focused initializer and update supporting modules and tests to the new IDs

## Testing
- npm test *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd379577b88332ac620b10784c55ac