### PR TITLE
Ensure Environmental Recommendations tooltip layers above cards

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -934,7 +934,7 @@ html {
 
 [data-role="env-info-tip"]{
   position: absolute;
-  z-index: 20;
+  z-index: 9999;
   top: calc(100% + 8px);
   right: 0;
   max-width: 280px;

--- a/js/stocking.js
+++ b/js/stocking.js
@@ -860,6 +860,8 @@ bootstrapStocking();
   const freshBtn = btn.cloneNode(true);
   btn.replaceWith(freshBtn);
 
+  const card = freshBtn.closest('#env-card, .env-card, [data-role="env-card"]') || null;
+
   let open = !tip.hidden;
   let outsideHandler = null;
   let escHandler = null;
@@ -869,6 +871,9 @@ bootstrapStocking();
     freshBtn.setAttribute('aria-expanded', open ? 'true' : 'false');
     tip.hidden = !open;
     tip.setAttribute('aria-hidden', open ? 'false' : 'true');
+    if (card) {
+      card.classList.toggle('is-tooltip-open', open);
+    }
   };
 
   const closeTip = () => {

--- a/stocking.html
+++ b/stocking.html
@@ -661,6 +661,16 @@
 
     #stocking-page .env-header {
       position: relative;
+      overflow: visible;
+    }
+
+    #stocking-page #env-card {
+      overflow: visible;
+      position: relative;
+    }
+
+    #stocking-page #env-card.is-tooltip-open {
+      z-index: 30;
     }
 
     #stocking-page .env-header .title-row {
@@ -668,6 +678,7 @@
       align-items: center;
       justify-content: space-between;
       gap: 10px;
+      position: relative;
     }
 
     @media (orientation: portrait) and (max-width: 480px) {


### PR DESCRIPTION
## Summary
- raise the Environmental Recommendations tooltip z-index so it renders above neighboring cards
- allow the Environmental Recommendations card and header to overflow so the tooltip is never clipped
- elevate the Environmental Recommendations card when the tooltip opens so it layers above Plan Your Stock and anchor the header row for absolute positioning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd3f49f49083328a8b5af4c4bba929