### PR TITLE
Add Store link to site navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -18,9 +18,9 @@
   <meta name="twitter:description" content="Learn about The Tank Guide by FishKeepingLifeCo—our story, mission and vision to make aquarium care simple with stocking, cycling and gear tools." />
   <meta name="twitter:image" content="https://thetankguide.com/logo.png" />
   <link rel="icon" href="/favicon.ico" />
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.9" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
-  <script defer src="js/nav.js?v=1.0.8"></script>
+  <script defer src="js/nav.js?v=1.0.9"></script>
   <style>
     *, *::before, *::after {
       box-sizing: border-box;

--- a/css/style.css
+++ b/css/style.css
@@ -114,7 +114,19 @@ body.theme-light {
   margin-left: auto;
   display: flex;
   align-items: center;
+}
+
+#global-nav .links .nav__list {
+  display: flex;
+  align-items: center;
   gap: var(--nav-inline-gap);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#global-nav .links .nav__item {
+  display: flex;
 }
 
 #global-nav .links .nav__link {
@@ -374,10 +386,20 @@ body.theme-light {
 }
 
 #global-nav #ttg-drawer .drawer-links {
-  display: flex;
-  flex-direction: column;
   padding: 12px 0 24px;
   overflow-y: auto;
+}
+
+#global-nav #ttg-drawer .drawer-links .nav__list {
+  display: flex;
+  flex-direction: column;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+#global-nav #ttg-drawer .drawer-links .nav__item {
+  display: block;
 }
 
 #global-nav #ttg-drawer .drawer-links .nav__link {

--- a/gear.html
+++ b/gear.html
@@ -18,7 +18,7 @@
   <meta name="twitter:title" content="Gear Guide — Aquarium Filters, Heaters & Lighting | The Tank Guide">
   <meta name="twitter:description" content="The Tank Guide Gear Guide: aquarium gear recommendations for filters, heaters, lighting, substrate, test kits, and planted aquarium setups.">
   <meta name="twitter:image" content="https://thetankguide.com/logo.png">
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.9" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="icon" href="/favicon.ico" />
 
@@ -68,7 +68,7 @@
     .muted{color:var(--muted);}
     /* ... rest of your CSS unchanged ... */
   </style>
-  <script defer src="js/nav.js?v=1.0.8"></script>
+  <script defer src="js/nav.js?v=1.0.9"></script>
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <meta name="twitter:description" content="The Tank Guide by FishKeepingLifeCo: aquarium planning tools including a stocking advisor, cycling coach, and gear tips to build healthy freshwater aquariums.">
   <meta name="twitter:image" content="https://thetankguide.com/logo.png">
 
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.9" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
 
   <style>
@@ -92,7 +92,7 @@
     }
     .seo-intro strong{color:var(--fg)}
   </style>
-  <script defer src="js/nav.js?v=1.0.8"></script>
+  <script defer src="js/nav.js?v=1.0.9"></script>
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/js/modules/nav.js
+++ b/js/modules/nav.js
@@ -1,4 +1,4 @@
-const NAV_VERSION = '1.3.1';
+const NAV_VERSION = '1.3.2';
 const NAV_ENDPOINT = `/nav.html?v=${NAV_VERSION}`;
 const SKIP_PATHS = new Set(['/', '/index.html']);
 const OVERLAY_HIDE_DELAY = 320;

--- a/js/nav.js
+++ b/js/nav.js
@@ -1,5 +1,5 @@
 (() => {
-  const NAV_VERSION = '1.0.8';
+  const NAV_VERSION = '1.0.9';
   const NAV_PLACEHOLDER_ID = 'site-nav';
   const HOME_PATH = '/index.html';
 

--- a/media.html
+++ b/media.html
@@ -205,7 +205,7 @@
     }
 
   </style>
-  <script defer src="js/nav.js?v=1.0.8"></script>
+  <script defer src="js/nav.js?v=1.0.9"></script>
   <script type="application/ld+json">
 {
   "@context": "https://schema.org",

--- a/nav.html
+++ b/nav.html
@@ -17,14 +17,17 @@
       <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
     </a>
     <nav class="site-links links" aria-label="Primary">
-      <a href="/" class="nav__link">Home</a>
-      <a href="/stocking.html" class="nav__link">Stocking Advisor</a>
-      <a href="/gear.html" class="nav__link">Gear</a>
-      <a href="/params.html" class="nav__link">Cycling Coach</a>
-      <a href="/media.html" class="nav__link">Media</a>
-      <a href="/feature-your-tank.html" class="nav__link">Feature Your Tank</a>
-      <a href="/contact-feedback.html" class="nav__link">Contact &amp; Feedback</a>
-      <a href="/about.html" class="nav__link">About</a>
+      <ul class="nav__list">
+        <li class="nav__item"><a href="/" class="nav__link">Home</a></li>
+        <li class="nav__item"><a href="/stocking.html" class="nav__link">Stocking Advisor</a></li>
+        <li class="nav__item"><a href="/gear.html" class="nav__link">Gear</a></li>
+        <li class="nav__item"><a href="/params.html" class="nav__link">Cycling Coach</a></li>
+        <li class="nav__item"><a href="/media.html" class="nav__link">Media</a></li>
+        <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link">Feature Your Tank</a></li>
+        <li class="nav__item"><a href="/store.html" class="nav__link">Store</a></li>
+        <li class="nav__item"><a href="/contact-feedback.html" class="nav__link">Contact &amp; Feedback</a></li>
+        <li class="nav__item"><a href="/about.html" class="nav__link">About</a></li>
+      </ul>
     </nav>
   </div>
   <aside id="ttg-drawer" aria-label="Site" data-nav="drawer" aria-hidden="true">
@@ -35,14 +38,17 @@
       </button>
     </div>
     <nav class="drawer-links" aria-label="Mobile">
-      <a href="/" class="nav__link">Home</a>
-      <a href="/stocking.html" class="nav__link">Stocking Advisor</a>
-      <a href="/gear.html" class="nav__link">Gear</a>
-      <a href="/params.html" class="nav__link">Cycling Coach</a>
-      <a href="/media.html" class="nav__link">Media</a>
-      <a href="/feature-your-tank.html" class="nav__link">Feature Your Tank</a>
-      <a href="/contact-feedback.html" class="nav__link">Contact &amp; Feedback</a>
-      <a href="/about.html" class="nav__link">About</a>
+      <ul class="nav__list nav__list--drawer">
+        <li class="nav__item"><a href="/" class="nav__link">Home</a></li>
+        <li class="nav__item"><a href="/stocking.html" class="nav__link">Stocking Advisor</a></li>
+        <li class="nav__item"><a href="/gear.html" class="nav__link">Gear</a></li>
+        <li class="nav__item"><a href="/params.html" class="nav__link">Cycling Coach</a></li>
+        <li class="nav__item"><a href="/media.html" class="nav__link">Media</a></li>
+        <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link">Feature Your Tank</a></li>
+        <li class="nav__item"><a href="/store.html" class="nav__link">Store</a></li>
+        <li class="nav__item"><a href="/contact-feedback.html" class="nav__link">Contact &amp; Feedback</a></li>
+        <li class="nav__item"><a href="/about.html" class="nav__link">About</a></li>
+      </ul>
     </nav>
   </aside>
   <div id="ttg-overlay" data-nav="overlay" aria-hidden="true"></div>

--- a/params.html
+++ b/params.html
@@ -5,10 +5,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>The Tank Guide — Aquarium Cycling Coach & 24-Hour Challenge</title>
   <meta name="description" content="Use the Cycling Coach to enter ammonia, nitrite, and nitrate readings, track cycle progress, and take the 24-Hour Challenge for safe fishkeeping guidance — by FishKeepingLifeCo." />
-  <link rel="stylesheet" href="css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="css/style.css?v=1.0.9" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="icon" href="/favicon.ico" />
-  <script defer src="js/nav.js?v=1.0.8"></script>
+  <script defer src="js/nav.js?v=1.0.9"></script>
   <style>
     :root {
       --card-surface: rgba(14, 22, 36, 0.72);

--- a/stocking.html
+++ b/stocking.html
@@ -21,7 +21,7 @@
   <link rel="stylesheet" href="css/site.css?v=2024-07-05a" />
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="icon" href="/favicon.ico" />
-  <script defer src="js/nav.js?v=1.0.8"></script>
+  <script defer src="js/nav.js?v=1.0.9"></script>
   <style>
     :root {
       --fg: #eef3ff;

--- a/store.html
+++ b/store.html
@@ -11,7 +11,7 @@
   <link rel="canonical" href="https://thetankguide.com/store.html" />
 
   <!-- Site CSS (keep your current version number) -->
-  <link rel="stylesheet" href="/css/style.css?v=1.0.8" />
+  <link rel="stylesheet" href="/css/style.css?v=1.0.9" />
 
   <!-- Page-scoped styles (do not affect other pages) -->
   <style>

--- a/tests/nav.spec.mjs
+++ b/tests/nav.spec.mjs
@@ -90,7 +90,7 @@ async function gotoAndVerify(page, route, theme) {
   });
 
   const cssResponsePromise = page.waitForResponse((response) =>
-    response.url().includes('css/style.css?v=1.0.8')
+    response.url().includes('css/style.css?v=1.0.9')
   );
 
   await page.goto(`${baseURL}${route}`);
@@ -157,7 +157,7 @@ test('stocking, gear, and media share the nav layout', async ({ page }) => {
 
 test('index page remains free of the global nav', async ({ page }) => {
   const cssResponsePromise = page.waitForResponse((response) =>
-    response.url().includes('css/style.css?v=1.0.8')
+    response.url().includes('css/style.css?v=1.0.9')
   );
   await page.goto(`${baseURL}/index.html`);
   const cssResponse = await cssResponsePromise;


### PR DESCRIPTION
## Summary
- add a Store menu item to the shared header navigation and mobile drawer
- update the nav styling to support list markup and include cache-busting version bumps
- refresh HTML entry points so they load the updated stylesheet and navigation script

## Testing
- npm test *(fails: Playwright browsers are not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd53a7c238833284b1181086cc5915