### PR TITLE
Add Store link to footer quick links

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -28,6 +28,8 @@
     <span class="dot">·</span>
     <a href="/terms.html">Terms of Use</a>
     <span class="dot">·</span>
+    <a href="/store.html">Store</a>
+    <span class="dot">·</span>
     <a href="/copyright-dmca.html">Copyright &amp; DMCA</a>
   </nav>
 

--- a/footer.v1.2.2.html
+++ b/footer.v1.2.2.html
@@ -28,6 +28,8 @@
     <span class="dot">·</span>
     <a href="/terms.html">Terms of Use</a>
     <span class="dot">·</span>
+    <a href="/store.html">Store</a>
+    <span class="dot">·</span>
     <a href="/copyright-dmca.html">Copyright &amp; DMCA</a>
   </nav>
 


### PR DESCRIPTION
## Summary
- add the Store page link to the footer quick-links navigation while preserving existing separators
- keep the social icons and Amazon disclaimer untouched

## Testing
- not run (HTML change only)


------
https://chatgpt.com/codex/tasks/task_e_68dd5d344e308332a2b236c2485fb5d1