### PR TITLE
Add community section to media page

### DIFF
--- a/media.html
+++ b/media.html
@@ -115,6 +115,29 @@
       padding: 16px;
     }
 
+    /* Community split layout */
+    #community .split {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: 1fr;
+    }
+
+    @media (min-width: 900px) {
+      #community .split {
+        grid-template-columns: 1fr 1fr;
+      }
+    }
+
+    #community .media-thumb {
+      display: grid;
+      place-items: center;
+      min-height: 140px;
+      border-radius: 12px;
+      background: rgba(255,255,255,0.5);
+      color: #2b2b2b;
+      font-weight: 600;
+    }
+
     .resource-card {
       background: #e9f4ff;
       border-radius: 12px;
@@ -399,6 +422,38 @@
           <p><a class="btn" href="/about.html#mission">Read Our Mission</a></p>
         </div>
       </article>
+    </section>
+
+    <!-- Community -->
+    <section class="section" id="community" aria-labelledby="community-title">
+      <h2 id="community-title">Community</h2>
+
+      <div class="split">
+        <!-- Card A: Community Video Picks -->
+        <article class="card">
+          <h3><strong>Community Video Picks</strong></h3>
+          <p class="muted">
+            Curated how-to videos and inspiration from creators we trust — and from folks who use and follow The Tank Guide.
+            We rotate a featured pick regularly and keep an archive of favorites you can explore anytime.
+          </p>
+          <div class="media-thumb" aria-label="Community video placeholder">Feature video thumbnail (placeholder)</div>
+          <a class="btn" href="/community-videos.html">View More Videos</a>
+        </article>
+
+        <!-- Card B: Featured Tanks -->
+        <article class="card">
+          <h3><strong>Featured Tanks</strong></h3>
+          <p class="muted">
+            Showcasing aquariums from The Tank Guide community — real setups, honest lessons learned, and ideas to try.
+            Want to be featured? Submit your tank and we’ll highlight standout builds.
+          </p>
+          <div class="media-thumb" aria-label="Featured tank placeholder">Featured tank thumbnail (placeholder)</div>
+          <div class="row" style="justify-content:space-between; align-items:center; gap:10px;">
+            <a class="btn" href="/featured-tanks.html">See More Tanks</a>
+            <a class="btn" href="/submit-tank.html">Submit Your Tank</a>
+          </div>
+        </article>
+      </div>
     </section>
 
     <!-- Featured Resource -->


### PR DESCRIPTION
## Summary
- add a community section between the aquarium library and featured resource content
- add scoped styling to keep the new cards responsive without affecting other sections

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd6515091483328f5c507931290b77