### PR TITLE
Remove duplicate Community video card from media page

### DIFF
--- a/media.html
+++ b/media.html
@@ -436,34 +436,6 @@
           </article>
         </div>
 
-        <article class="card community-video-recommendation">
-          <h3><strong>Make a Freshwater Aquarium Sump</strong></h3>
-          <p class="muted" style="margin: 0;">
-            by
-            <a href="https://youtube.com/@serpadesign?si=h0wnMcQW4FY2Xqmj" target="_blank" rel="noopener">@SerpaDesign</a>
-          </p>
-          <hr class="media-divider" />
-          <div class="video-meta">
-            <p class="video-blurb">
-              Recommended by a community member:<br />
-              I chose this video because I used it as a bible to create my sump. I watched it for hours, section by section, and copied the baffle design for my 5-gallon sump. The creator explains things simply and clearly, making it easy to follow. This video gave me the direction to start more DIY projects.
-            </p>
-            <p class="video-blurb">
-              If you’re looking for DIY aquarium builds, sump setup tutorials, or beginner-friendly fishkeeping tips, this video is a fantastic place to start.
-            </p>
-            <div class="video-actions">
-              <a class="yt-cta" href="https://youtu.be/zX3wGQpC4eE?si=sN-QVwV8mJZt-9NB" target="_blank" rel="noopener" title="Watch Make a Freshwater Aquarium Sump on YouTube" aria-label="Watch Make a Freshwater Aquarium Sump on YouTube">
-                <span class="yt-icon" aria-hidden="true">
-                  <svg class="yt-cta-svg" viewBox="0 0 24 24" width="20" height="20" focusable="false" aria-hidden="true">
-                    <path d="M9 7v10l8-5z" fill="#fff"></path>
-                  </svg>
-                </span>
-                <span class="yt-label">Watch on YouTube</span>
-              </a>
-            </div>
-          </div>
-        </article>
-
         <!-- Aquarium Library Card -->
         <article class="card aquarium-library-card">
           <h2 id="articles">Aquarium Library</h2>


### PR DESCRIPTION
## Summary
- remove the redundant Community video recommendation card so only the featured embed remains
- ensure the Aquarium Library card follows the Community section with the expected spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd84508dec83329cd5ca184741e7a2