### PR TITLE
Remove diagnostics UI from stocking advisor

### DIFF
--- a/js/stocking.js
+++ b/js/stocking.js
@@ -182,8 +182,6 @@ function bootstrapStocking() {
     addBtn: document.getElementById('plan-add'),
     stockList: document.getElementById('stock-list'),
     seeGear: document.getElementById('btn-gear'),
-    diagnostics: document.getElementById('diagnostics'),
-    diagnosticsContent: document.getElementById('diagnostics-content'),
     envReco: document.getElementById('env-reco'),
     envTips: document.querySelector('#env-legend, #env-more-tips, [data-role="env-legend"]'),
   };
@@ -670,31 +668,21 @@ function renderCandidateState() {
 }
 
 function renderDiagnostics() {
-  if (!debugMode || !refs.diagnostics) return;
+  if (!debugMode) return;
+  const groupLabel = computed ? '[Stocking] Diagnostics' : '[Stocking] Diagnostics (inactive)';
+  console.groupCollapsed(groupLabel);
   if (!computed) {
-    refs.diagnostics.hidden = true;
-    if (refs.diagnosticsContent) {
-      refs.diagnosticsContent.innerHTML = '';
-    }
+    console.log('Diagnostics unavailable: select a tank to generate state.');
+    console.groupEnd();
     return;
   }
-  refs.diagnostics.hidden = false;
   const sanity = runSanitySuite(state);
   const stress = runStressSuite(state);
-  const lines = [
-    '<strong>Live Snapshot</strong>',
-    ...computed.diagnostics.map((line) => `<span>${line}</span>`),
-    '<strong>Sanity Tests</strong>',
-    ...sanity.map((line) => `<span>${line}</span>`),
-    '<strong>Stress Tests</strong>',
-    ...stress.map((line) => `<span>${line}</span>`),
-  ];
-  if (refs.diagnosticsContent) {
-    refs.diagnosticsContent.innerHTML = `<ul>${lines.map((line) => `<li>${line}</li>`).join('')}</ul>`;
-  }
-  console.groupCollapsed('[Stocking] Diagnostics');
+  console.log('Live Snapshot');
   computed.diagnostics.forEach((line) => console.log(line));
+  console.log('Sanity Tests');
   sanity.forEach((line) => console.log(line));
+  console.log('Stress Tests');
   stress.forEach((line) => console.log(line));
   console.groupEnd();
 }

--- a/stocking.html
+++ b/stocking.html
@@ -1293,10 +1293,6 @@
 
       <button class="see-gear" id="btn-gear" type="button" data-testid="btn-gear">See Gear Suggestions</button>
 
-      <section class="diagnostics" id="diagnostics" hidden>
-        <h3>Diagnostics</h3>
-        <div id="diagnostics-content"></div>
-      </section>
     </div>
   </main>
 


### PR DESCRIPTION
## Summary
- remove the Diagnostics card markup from the stocking advisor page
- keep diagnostics logging available for debug mode without rendering UI content

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68dd88fbefc88332980805f6f2d6e195