### PR TITLE
Normalize YouTube play icon and add community card divider

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -252,9 +252,6 @@ body.theme-light {
   border-radius: 4px / 6px;
 }
 
-.video-card a.yt-cta .yt-icon .yt-cta-svg {
-  display: block;
-}
 
 .video-card a.yt-cta .yt-label {
   white-space: nowrap;
@@ -1370,15 +1367,20 @@ body.planted-active #cycling-coach .cc-title__leaf {
 .yt-cta:hover { filter: brightness(1.08); }
 .yt-cta:active { transform: translateY(1px); }
 
-/* Red play icon (SVG via CSS background) */
+/* Red play icon wrapper */
 .yt-icon {
-  width: 22px; height: 16px; flex: 0 0 22px;
-  background:
-    /* white play triangle */
-    conic-gradient(from 330deg at 9px 8px, #fff 0 60deg, transparent 0) no-repeat 7px 3px / 8px 10px,
-    /* red rounded rect */
-    #FF0033;
+  width: 28px;
+  height: 20px;
+  flex: 0 0 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #ff0033;
   border-radius: 4px / 6px;
+}
+
+.yt-cta .yt-icon .yt-cta-svg {
+  display: block;
 }
 
 .video-card > iframe,
@@ -1408,6 +1410,12 @@ body.planted-active #cycling-coach .cc-title__leaf {
   border-top:1px solid var(--border);
   width:100%;
   margin:4px 0 4px;
+}
+.card-sep {
+  border: 0;
+  height: 1px;
+  background: rgba(255,255,255,0.25);
+  margin: 12px 0 16px;
 }
 .featured-videos-card .video-meta{
   padding-top:.25rem;

--- a/media.html
+++ b/media.html
@@ -406,6 +406,7 @@
               Curated how-to videos and inspiration from creators we trust — and from folks who use and follow The Tank Guide.
               We rotate a featured pick regularly and keep an archive of favorites you can explore anytime.
             </p>
+            <hr class="card-sep" aria-hidden="true">
             <div class="video-embed">
               <iframe
                 src="https://www.youtube.com/embed/zX3wGQpC4eE"
@@ -429,7 +430,11 @@
             </p>
             <div class="community-video-cta">
               <a class="yt-cta" href="https://www.youtube.com/watch?v=zX3wGQpC4eE" target="_blank" rel="noopener" title="Watch Make a Freshwater Aquarium Sump on YouTube" aria-label="Watch Make a Freshwater Aquarium Sump on YouTube">
-                <span class="yt-icon" aria-hidden="true"></span>
+                <span class="yt-icon" aria-hidden="true">
+                  <svg class="yt-cta-svg" viewBox="0 0 24 24" width="20" height="20" focusable="false" aria-hidden="true">
+                    <path d="M9 7v10l8-5z" fill="#fff"></path>
+                  </svg>
+                </span>
                 <span class="yt-label">Watch on YouTube</span>
               </a>
             </div>


### PR DESCRIPTION
## Summary
- replace the play icon SVG in the "Watch on YouTube" CTA with the same markup used for the channel button
- insert an accessible divider element between the Community Video Picks blurb and video content and style it subtly
- update the shared `.yt-icon` wrapper styling so both CTAs render the inline SVG triangle without the old CSS-generated shape

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd872ad4f48332b8659559628967db