### PR TITLE
Add data hooks for stocking advisor verification

### DIFF
--- a/js/logic/envRecommend.js
+++ b/js/logic/envRecommend.js
@@ -454,7 +454,7 @@ function renderBars(root, env, { isMobile = false, isEmpty = false } = {}) {
         <div class="env-bar env-bar--xl bar-row">
           <div class="env-bar__hd">
             <div class="env-bar__label metric-label">Bioload ${bioloadInfoBtn}</div>
-            <div class="env-bar__value">${bioloadDisplay}</div>
+            <div class="env-bar__value" data-role="bioload-percent" data-field="bioload-percent" data-env="bioload">${bioloadDisplay}</div>
           </div>
           <div class="env-bar__track meter-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${bioloadAria}">
             <div class="env-bar__fill" style="width:${bioloadPct}%; background:${bioloadColor};"></div>
@@ -480,7 +480,7 @@ function renderBars(root, env, { isMobile = false, isEmpty = false } = {}) {
       <div class="env-bar metric-row">
         <div class="env-bar__hd">
           <span class="env-bar__label metric-label">Bioload ${bioloadInfoBtn}</span>
-          <span>${escapeHtml(bioloadLabel)}</span>
+          <span data-role="bioload-percent" data-field="bioload-percent" data-env="bioload">${escapeHtml(bioloadLabel)}</span>
         </div>
         <div class="env-bar__track progress-track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${bioloadAria}">
           <div class="env-bar__fill" style="width:${bioloadPct}%; background:${bioloadColor};"></div>

--- a/js/logic/ui.js
+++ b/js/logic/ui.js
@@ -202,6 +202,12 @@ export function renderConditions(list, items) {
     const li = document.createElement('li');
     li.className = 'condition-item';
     li.dataset.state = item.severity;
+    const rawKey = typeof item.key === 'string' ? item.key.trim() : '';
+    const normalizedKey = rawKey.toLowerCase();
+    if (normalizedKey) {
+      const envField = `env-${normalizedKey}`;
+      li.dataset.field = envField;
+    }
 
     const label = document.createElement('div');
     label.className = 'label';
@@ -219,6 +225,12 @@ export function renderConditions(list, items) {
 
     const value = document.createElement('div');
     value.className = 'value';
+    if (normalizedKey) {
+      const envField = `env-${normalizedKey}`;
+      value.dataset.field = envField;
+      value.dataset.role = envField;
+      value.dataset.env = normalizedKey;
+    }
     const rangeText = formatRangeForKey(item.key, item.range);
     const icon = document.createElement('span');
     icon.className = 'condition-icon';
@@ -231,6 +243,12 @@ export function renderConditions(list, items) {
     bullet.style.opacity = '0.6';
     const actualSpan = document.createElement('span');
     actualSpan.textContent = item.actual ?? '—';
+    if (normalizedKey) {
+      const envField = `env-${normalizedKey}`;
+      actualSpan.dataset.field = envField;
+      actualSpan.dataset.role = envField;
+      actualSpan.dataset.env = normalizedKey;
+    }
     const hintSpan = document.createElement('span');
     hintSpan.textContent = item.hint;
     value.append(rangeSpan, bullet, actualSpan, icon, hintSpan);
@@ -298,6 +316,7 @@ export function renderStockList(list, entries, onRemove) {
   for (const entry of entries) {
     const li = document.createElement('li');
     li.className = 'stock-item';
+    li.dataset.role = 'stock-row';
     const meta = document.createElement('div');
     meta.className = 'meta';
     const name = document.createElement('span');
@@ -310,6 +329,8 @@ export function renderStockList(list, entries, onRemove) {
     const remove = document.createElement('button');
     remove.type = 'button';
     remove.textContent = 'Remove';
+    remove.dataset.action = 'remove';
+    remove.dataset.role = 'remove-stock';
     remove.addEventListener('click', () => onRemove(entry));
     li.append(meta, remove);
     list.appendChild(li);

--- a/js/stocking.js
+++ b/js/stocking.js
@@ -81,7 +81,8 @@ function createLengthValidator(container) {
     chip = document.createElement('span');
     chip.className = 'chip';
     chip.dataset.tone = 'bad';
-    chip.dataset.role = 'tank-length-warning';
+    chip.dataset.role = 'stock-warning-length';
+    chip.dataset.field = 'length-warning';
     chip.setAttribute('data-testid', 'tank-length-warning');
     return chip;
   };


### PR DESCRIPTION
## Summary
- expose tank length warnings with stable data attributes for external verification
- add environment field metadata so pH and other recommendations can be queried
- tag bioload meters and stock list controls with data-role hooks used by live scripts

## Testing
- npm test *(fails: Playwright suite requires full site environment and multiple specs errored)*

------
https://chatgpt.com/codex/tasks/task_e_68dd99f860e883329ee8d9da140457a6