### PR TITLE
Fix plan warning chip to show selected tank length

### DIFF
--- a/js/logic/compute.js
+++ b/js/logic/compute.js
@@ -168,9 +168,20 @@ function calcTank(state, entries, overrideVariant) {
     ?? getTankVariants({ tankId, gallons })[0]
     ?? null;
 
-  const length = Number.isFinite(tankState.lengthIn) && tankState.lengthIn > 0 ? tankState.lengthIn : variant?.length ?? 0;
-  const width = Number.isFinite(tankState.widthIn) && tankState.widthIn > 0 ? tankState.widthIn : variant?.width ?? 0;
-  const height = Number.isFinite(tankState.heightIn) && tankState.heightIn > 0 ? tankState.heightIn : variant?.height ?? 0;
+  const resolveDimension = (value, fallback) => {
+    if (Number.isFinite(value) && value > 0) {
+      return value;
+    }
+    return Number.isFinite(fallback) && fallback > 0 ? fallback : null;
+  };
+
+  const lengthIn = resolveDimension(tankState.lengthIn, variant?.length);
+  const widthIn = resolveDimension(tankState.widthIn, variant?.width);
+  const heightIn = resolveDimension(tankState.heightIn, variant?.height);
+
+  const length = Number.isFinite(lengthIn) ? lengthIn : 0;
+  const width = Number.isFinite(widthIn) ? widthIn : 0;
+  const height = Number.isFinite(heightIn) ? heightIn : 0;
   const volume = gallons + 0.7 * sump;
   const turnover = clamp(Number(state.turnover) || 5, 0.5, 20);
   const multiplier = interpolateMultiplier(turnover);
@@ -190,8 +201,11 @@ function calcTank(state, entries, overrideVariant) {
     presetId: tankState.id ?? null,
     presetLabel: tankState.label ?? '',
     length,
+    lengthIn,
     width,
+    widthIn,
     height,
+    heightIn,
     volume,
     turnover,
     multiplier,

--- a/js/stocking/validators.js
+++ b/js/stocking/validators.js
@@ -1,25 +1,31 @@
 export function formatLength(value) {
-  if (!Number.isFinite(value)) {
-    return '0';
-  }
-  if (Number.isInteger(value)) {
-    return String(value);
+  if (!Number.isFinite(value) || value <= 0) {
+    return '';
   }
   const fixed = value.toFixed(2);
-  return fixed.replace(/\.00$/, '').replace(/(\.[0-9])0$/, '$1');
+  const trimmed = fixed.replace(/\.00$/, '').replace(/(\.[0-9])0$/, '$1');
+  return `${trimmed}″`;
 }
 
 export function tankLengthStatus({ tank, species }) {
-  const required = Number(species?.min_tank_length_in);
-  const hasRequirement = Number.isFinite(required) && required > 0;
-  const actualRaw = Number(tank?.lengthIn);
-  const actual = Number.isFinite(actualRaw) && actualRaw > 0 ? actualRaw : 0;
+  const requiredValue = Number(species?.min_tank_length_in);
+  const required = Number.isFinite(requiredValue) && requiredValue > 0 ? requiredValue : null;
+  const actualValue = Number(tank?.lengthIn);
+  const actual = Number.isFinite(actualValue) && actualValue > 0 ? actualValue : null;
 
-  if (!hasRequirement) {
+  if (!required) {
     return { show: false, required: null, actual, message: '' };
   }
 
-  const show = !Number.isFinite(actualRaw) || actualRaw <= 0 || actualRaw < required;
-  const message = `Needs ${formatLength(required)}″ tank length (yours ${formatLength(actual)}″)`;
+  if (actual == null) {
+    return { show: false, required, actual: null, message: '' };
+  }
+
+  const show = actual < required;
+  if (!show) {
+    return { show: false, required, actual, message: '' };
+  }
+
+  const message = `Needs ${formatLength(required)} tank length (yours ${formatLength(actual)})`;
   return { show, required, actual, message };
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -17,6 +17,7 @@ export const TANK_SIZES = [
     lengthIn: 16.2,
     widthIn: 8.4,
     heightIn: 10.5,
+    dims: { w: 16.2, d: 8.4, h: 10.5 },
     dimensions_in: { l: 16.2, w: 8.4, h: 10.5 },
     dimensions_cm: { l: cm(16.2), w: cm(8.4), h: cm(10.5) },
     filled_weight_lbs: 62,
@@ -30,6 +31,7 @@ export const TANK_SIZES = [
     lengthIn: 20.25,
     widthIn: 10.5,
     heightIn: 12.6,
+    dims: { w: 20.25, d: 10.5, h: 12.6 },
     dimensions_in: { l: 20.25, w: 10.5, h: 12.6 },
     dimensions_cm: { l: cm(20.25), w: cm(10.5), h: cm(12.6) },
     filled_weight_lbs: 111,
@@ -43,6 +45,7 @@ export const TANK_SIZES = [
     lengthIn: 20.25,
     widthIn: 10.5,
     heightIn: 18.75,
+    dims: { w: 20.25, d: 10.5, h: 18.75 },
     dimensions_in: { l: 20.25, w: 10.5, h: 18.75 },
     dimensions_cm: { l: cm(20.25), w: cm(10.5), h: cm(18.75) },
     filled_weight_lbs: 170,
@@ -56,6 +59,7 @@ export const TANK_SIZES = [
     lengthIn: 24.25,
     widthIn: 12.5,
     heightIn: 16.75,
+    dims: { w: 24.25, d: 12.5, h: 16.75 },
     dimensions_in: { l: 24.25, w: 12.5, h: 16.75 },
     dimensions_cm: { l: cm(24.25), w: cm(12.5), h: cm(16.75) },
     filled_weight_lbs: 225,
@@ -69,6 +73,7 @@ export const TANK_SIZES = [
     lengthIn: 30.25,
     widthIn: 12.5,
     heightIn: 12.75,
+    dims: { w: 30.25, d: 12.5, h: 12.75 },
     dimensions_in: { l: 30.25, w: 12.5, h: 12.75 },
     dimensions_cm: { l: cm(30.25), w: cm(12.5), h: cm(12.75) },
     filled_weight_lbs: 225,
@@ -82,6 +87,7 @@ export const TANK_SIZES = [
     lengthIn: 30.25,
     widthIn: 12.5,
     heightIn: 18.75,
+    dims: { w: 30.25, d: 12.5, h: 18.75 },
     dimensions_in: { l: 30.25, w: 12.5, h: 18.75 },
     dimensions_cm: { l: cm(30.25), w: cm(12.5), h: cm(18.75) },
     filled_weight_lbs: 330,
@@ -95,6 +101,7 @@ export const TANK_SIZES = [
     lengthIn: 36.25,
     widthIn: 18.25,
     heightIn: 16.75,
+    dims: { w: 36.25, d: 18.25, h: 16.75 },
     dimensions_in: { l: 36.25, w: 18.25, h: 16.75 },
     dimensions_cm: { l: cm(36.25), w: cm(18.25), h: cm(16.75) },
     filled_weight_lbs: 458,
@@ -108,6 +115,7 @@ export const TANK_SIZES = [
     lengthIn: 48.25,
     widthIn: 12.75,
     heightIn: 21,
+    dims: { w: 48.25, d: 12.75, h: 21 },
     dimensions_in: { l: 48.25, w: 12.75, h: 21 },
     dimensions_cm: { l: cm(48.25), w: cm(12.75), h: cm(21) },
     filled_weight_lbs: 625,
@@ -121,6 +129,7 @@ export const TANK_SIZES = [
     lengthIn: 48.5,
     widthIn: 18.5,
     heightIn: 21.25,
+    dims: { w: 48.5, d: 18.5, h: 21.25 },
     dimensions_in: { l: 48.5, w: 18.5, h: 21.25 },
     dimensions_cm: { l: cm(48.5), w: cm(18.5), h: cm(21.25) },
     filled_weight_lbs: 850,
@@ -134,6 +143,7 @@ export const TANK_SIZES = [
     lengthIn: 72,
     widthIn: 18,
     heightIn: 21,
+    dims: { w: 72, d: 18, h: 21 },
     dimensions_in: { l: 72, w: 18, h: 21 },
     dimensions_cm: { l: cm(72), w: cm(18), h: cm(21) },
     filled_weight_lbs: 1206,
@@ -174,6 +184,13 @@ let legacyWarningShown = false;
 export function getTankById(id) {
   if (!id) return null;
   return TANK_SIZES.find((tank) => tank.id === id) ?? null;
+}
+
+export function getTankLengthIn(id) {
+  if (!id) return null;
+  const raw = getTankById(id)?.dims?.w;
+  const length = typeof raw === 'number' ? raw : Number(raw);
+  return Number.isFinite(length) && length > 0 ? length : null;
 }
 
 export function getTankLabel(id) {


### PR DESCRIPTION
## Summary
- add canonical inch dimensions and a helper for reading tank length from the tank dataset
- persist the selected tank's true dimensions in the tank store and computed tank state
- update the stocking validator to hide the length warning when no tank is selected and format the measured length correctly

## Testing
- not run (Playwright tests)


------
https://chatgpt.com/codex/tasks/task_e_68ddd3d26f8c833282794b3c336cdd25