### PR TITLE
Update store product copy and CTA

### DIFF
--- a/store.html
+++ b/store.html
@@ -122,18 +122,20 @@
         </div>
 
         <div class="details">
-          <div class="kicker">Hardcover • Ages 6–12</div>
+          <div class="kicker">Paperback • 7×10</div>
           <h2 itemprop="name">Life in Balance: The Hidden Magic of Aquariums</h2>
 
           <p class="desc" itemprop="description">
-            A friendly, science-meets-story tour of the nitrogen cycle, guided by Benny the Betta.
-            Perfect for young readers, classrooms, and new hobbyists.
+            Life in Balance: The Hidden Magic of Aquariums is a beginner-friendly aquarium book that explains the nitrogen cycle and the science of fishkeeping. Learn how clean water, beneficial bacteria, and balance keep tropical fish, plants, and shrimp healthy in any freshwater tank. Perfect for kids, families, classrooms, and new hobbyists looking for an easy aquarium guide.
           </p>
 
           <ul class="bullets">
-            <li>7×10 hardcover • educational & family-friendly</li>
-            <li>Explains water, bacteria, and balance in simple language</li>
-            <li>Pairs with our activity book (coming soon)</li>
+            <li>Paperback • 7×10 • beginner-friendly aquarium book</li>
+            <li>Explains the nitrogen cycle and freshwater tank setup</li>
+            <li>Covers tropical fish, live plants, shrimp, and snails</li>
+            <li>Teaches fish tank care, water quality, and balance</li>
+            <li>Great for families, classrooms, and homeschool science</li>
+            <li>A fun fishkeeping guide for kids and new hobbyists</li>
           </ul>
 
           <div class="meta">Category: Aquariums • Science • Family &amp; Education</div>
@@ -141,9 +143,6 @@
           <div class="cta-row">
             <a class="btn primary" href="https://amzn.to/3Kh34I1" target="_blank" rel="sponsored noopener noreferrer">
               Buy on Amazon
-            </a>
-            <a class="btn secondary" href="/media.html#books">
-              See it in action
             </a>
           </div>
 


### PR DESCRIPTION
## Summary
- update the store product kicker to indicate the paperback 7×10 format
- replace the description and feature bullets with the finalized SEO copy
- remove the secondary CTA so only the Amazon button remains

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dddcc465488332a2504ea5583b7aa2