### PR TITLE
Align store header and remove breadcrumbs

### DIFF
--- a/store.html
+++ b/store.html
@@ -20,14 +20,10 @@
     .store-page { --gap: 1.25rem; --radius: 14px; --wrap: 1040px; }
     .store-wrap { max-width: var(--wrap); margin: 0 auto; padding: 24px 16px 64px; }
 
-    /* Breadcrumbs */
-    .breadcrumbs { font-size: 13px; color: #8a94a3; margin-bottom: 8px; }
-    .breadcrumbs a { color: inherit; text-decoration: none; border-bottom: 1px solid rgba(138,148,163,.3); }
-    .breadcrumbs a:hover { border-bottom-color: currentColor; }
-
     /* Header */
-    .store-hero .title { font-size: clamp(26px, 3.2vw, 40px); line-height: 1.1; margin: 6px 0; }
-    .store-hero .sub { color: #7a8390; font-size: clamp(14px, 1.6vw, 16px); margin: 0 0 18px; }
+    .store-hero { text-align: left; margin: 0 0 24px; display: grid; gap: 6px; }
+    .store-hero .title { font-size: clamp(26px, 3.2vw, 40px); line-height: 1.1; margin: 0; }
+    .store-hero .sub { color: #7a8390; font-size: clamp(14px, 1.6vw, 16px); margin: 0; }
 
     /* Shelf + Product card */
     .shelf { display: grid; gap: var(--gap); }
@@ -99,15 +95,10 @@
 <body class="store-page">
   <div id="site-nav"></div>
   <div class="store-wrap">
-    <!-- Breadcrumbs -->
-    <nav class="breadcrumbs" aria-label="Breadcrumb">
-      <a href="/">Home</a> › <span aria-current="page">Store</span>
-    </nav>
-
     <!-- Header -->
     <header class="store-hero">
       <h1 class="title">Store</h1>
-      <p class="sub">Books by FishKeepingLifeCo</p>
+      <p class="sub">The official store of FishKeepingLifeCo.</p>
     </header>
 
     <!-- Shelf -->


### PR DESCRIPTION
## Summary
- remove the breadcrumb navigation from the store page and associated styles
- left-align the store hero block with tighter spacing and the updated subheading copy

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68dde360b2bc8332b2dea7141f628d72