### PR TITLE
Add disclaimer accordion to privacy and legal page

### DIFF
--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -390,6 +390,31 @@
           </div>
         </details>
 
+        <details id="disclaimer">
+          <summary><span>Disclaimer</span></summary>
+          <div class="details-body">
+            <h2>Disclaimer</h2>
+            <p>TheTankGuide.com (a product of FishKeepingLifeCo) provides educational content, interactive tools, and product recommendations for aquarium hobbyists. The information on this site is offered for general guidance only and should not be considered professional or veterinary advice. Visitors are encouraged to verify any information before making purchasing or care decisions. FishKeepingLifeCo assumes no responsibility for errors, omissions, or outcomes resulting from the use of this website or the information contained herein.</p>
+            <h3>Affiliate Disclosure</h3>
+            <p>TheTankGuide.com participates in affiliate marketing programs with third-party retailers, including the Amazon Services LLC Associates Program. This means we may earn commissions on qualifying purchases made through links on this site. These commissions help support the continued operation of this website. Prices, availability, and product details are subject to change by the retailers.</p>
+            <h3>Advertising Disclosure</h3>
+            <p>This site may display third-party advertisements, including but not limited to Google AdSense. These ads may use cookies or similar technologies to deliver relevant and personalized content. By using this website, visitors acknowledge that:</p>
+            <ul>
+              <li>Third-party vendors, including Google, use cookies to serve ads based on a user’s prior visits to this site and other websites.</li>
+              <li>Google’s use of advertising cookies enables it and its partners to serve ads to users based on their visit to this site and/or other sites on the Internet.</li>
+              <li>Users may opt out of personalized advertising by visiting Google’s Ads Settings (<a href="https://www.google.com/settings/ads">https://www.google.com/settings/ads</a>).</li>
+            </ul>
+            <h3>Cookie &amp; Consent Notice</h3>
+            <p>TheTankGuide.com uses cookies to improve user experience, track analytics, and display relevant advertising. By continuing to browse this site, you consent to the use of cookies. Visitors in regions with specific privacy laws (e.g., California, EU/EEA, UK) will be presented with a cookie consent banner allowing them to manage preferences regarding data collection and ad personalization.</p>
+            <h3>External Links</h3>
+            <p>This website may contain links to external websites not operated by FishKeepingLifeCo. We are not responsible for the content, privacy practices, or accuracy of any information provided on external sites.</p>
+            <h3>Liability Disclaimer</h3>
+            <p>Use of TheTankGuide.com is at your own risk. All information and services are provided “as is” without warranties of any kind, either expressed or implied. FishKeepingLifeCo disclaims all liability for damages arising from the use of this website or reliance on its content.</p>
+            <h3>Contact</h3>
+            <p>For questions regarding this disclaimer, please contact us at: <a href="mailto:contact@thetankguide.com">contact@thetankguide.com</a></p>
+          </div>
+        </details>
+
         <details id="terms-of-use">
           <summary><span>Terms of Use</span></summary>
           <div class="details-body">
@@ -471,14 +496,15 @@
 
   <script>
     (() => {
-      const SECTION_IDS = [
-        'privacy-policy',
-        'cookies-tracking',
-        'affiliate-disclosure',
-        'terms-of-use',
-        'copyright-dmca',
-        'accessibility',
-        'contact',
+        const SECTION_IDS = [
+          'privacy-policy',
+          'cookies-tracking',
+          'affiliate-disclosure',
+          'disclaimer',
+          'terms-of-use',
+          'copyright-dmca',
+          'accessibility',
+          'contact',
         'effective-date'
       ];
 


### PR DESCRIPTION
## Summary
- add a new Disclaimer accordion section beneath the Affiliate Disclosure entry on the Privacy & Legal page
- include the provided disclaimer content with matching typography, links, and contact information
- register the new accordion in the client-side section list so hash navigation continues to work

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68ddf4c48cb48332b852e581bebe26e2