### PR TITLE
Fix cookie consent modal interactions and checkbox sizing

### DIFF
--- a/about.html
+++ b/about.html
@@ -479,11 +479,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -509,19 +511,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -539,12 +536,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -545,11 +545,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -575,19 +577,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -605,12 +602,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/copyright-dmca.html
+++ b/copyright-dmca.html
@@ -177,11 +177,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -207,19 +209,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -237,12 +234,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/copyright.html
+++ b/copyright.html
@@ -50,11 +50,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -80,19 +82,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -110,12 +107,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/css/style.css
+++ b/css/style.css
@@ -1499,4 +1499,13 @@ body.planted-active #cycling-coach .cc-title__leaf {
 .ttg-consent-modal__panel h3{margin:0 0 8px 0}
 .ttg-row{display:flex;gap:10px;align-items:flex-start;margin:8px 0}
 .ttg-consent-modal__actions{display:flex;justify-content:flex-end;gap:8px;margin-top:12px}
+/* === TTG Cookie Consent PATCH START === */
+/* Smaller checkboxes and alignment */
+.ttg-row input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  margin-top: 3px;
+  flex-shrink: 0;
+}
+/* === TTG Cookie Consent PATCH END === */
 /* === TTG Cookie Consent END === */

--- a/feature-your-tank.html
+++ b/feature-your-tank.html
@@ -907,11 +907,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -937,19 +939,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -967,12 +964,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/gear.html
+++ b/gear.html
@@ -316,11 +316,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -346,19 +348,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -376,12 +373,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/index.html
+++ b/index.html
@@ -541,11 +541,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -571,19 +573,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -601,12 +598,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 </body>
 </html>

--- a/media.html
+++ b/media.html
@@ -521,11 +521,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -551,19 +553,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -581,12 +578,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/params.html
+++ b/params.html
@@ -738,11 +738,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -768,19 +770,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -798,12 +795,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -634,11 +634,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -664,19 +666,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -694,12 +691,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/stocking.html
+++ b/stocking.html
@@ -1355,11 +1355,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -1385,19 +1387,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -1415,12 +1412,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/store.html
+++ b/store.html
@@ -231,11 +231,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -261,19 +263,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -291,12 +288,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/terms.html
+++ b/terms.html
@@ -156,11 +156,13 @@
   </div>
 </div>
 
+<!-- === TTG Cookie Consent SCRIPT START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
   const $banner = document.getElementById('ttg-consent');
   const $modal = document.getElementById('ttg-consent-modal');
+  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
@@ -186,19 +188,14 @@
   }
   function closeModal(){ $modal.hidden = true; }
 
-  // public API for footer link
+  // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
     reset: function(){ localStorage.removeItem(KEY); openBanner(); }
   };
 
   const state = load();
-  if(!state){
-    document.documentElement.setAttribute('data-ad-consent', 'denied');
-    openBanner();
-  } else {
-    save(state);
-  }
+  if(!state){ openBanner(); } else { save(state); }
 
   $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
@@ -216,12 +213,23 @@
     closeModal(); closeBanner();
   });
 
-  // If consent not granted, set guard flag so ad code can check before loading.
+  // Close on outside click
+  $modal.addEventListener('click', function(e){
+    if(e.target === $modal) closeModal();
+  });
+
+  // Close on Escape key
+  document.addEventListener('keydown', function(e){
+    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
+  });
+
+  // Guard: don’t load ads if not consented
   if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 })();
 </script>
+<!-- === TTG Cookie Consent SCRIPT END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>


### PR DESCRIPTION
## Summary
- shrink the cookie consent modal checkboxes for better alignment
- replace the consent script so choices persist while supporting Escape/outside-click dismissal and ad guard updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de0b3c5be48332b328813ac9a21c83