### PR TITLE
Fix cookie consent banner visibility and modal behavior

### DIFF
--- a/about.html
+++ b/about.html
@@ -479,80 +479,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -545,80 +545,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/copyright-dmca.html
+++ b/copyright-dmca.html
@@ -177,80 +177,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/copyright.html
+++ b/copyright.html
@@ -50,80 +50,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/css/style.css
+++ b/css/style.css
@@ -1499,7 +1499,10 @@ body.planted-active #cycling-coach .cc-title__leaf {
 .ttg-consent-modal__panel h3{margin:0 0 8px 0}
 .ttg-row{display:flex;gap:10px;align-items:flex-start;margin:8px 0}
 .ttg-consent-modal__actions{display:flex;justify-content:flex-end;gap:8px;margin-top:12px}
-/* === TTG Cookie Consent PATCH START === */
+/* === TTG Cookie Consent: visibility & sizing PATCH START === */
+/* Ensure anything with [hidden] is actually not rendered (some resets override it) */
+[hidden] { display: none !important; }
+
 /* Smaller checkboxes and alignment */
 .ttg-row input[type="checkbox"] {
   width: 16px;
@@ -1507,5 +1510,5 @@ body.planted-active #cycling-coach .cc-title__leaf {
   margin-top: 3px;
   flex-shrink: 0;
 }
-/* === TTG Cookie Consent PATCH END === */
+/* === TTG Cookie Consent: visibility & sizing PATCH END === */
 /* === TTG Cookie Consent END === */

--- a/feature-your-tank.html
+++ b/feature-your-tank.html
@@ -907,80 +907,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/gear.html
+++ b/gear.html
@@ -316,80 +316,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/index.html
+++ b/index.html
@@ -541,80 +541,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 </body>
 </html>

--- a/media.html
+++ b/media.html
@@ -521,80 +521,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/params.html
+++ b/params.html
@@ -738,80 +738,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -634,80 +634,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/stocking.html
+++ b/stocking.html
@@ -1355,80 +1355,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/store.html
+++ b/store.html
@@ -231,80 +231,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/terms.html
+++ b/terms.html
@@ -156,80 +156,104 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT START === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
+
   const $banner = document.getElementById('ttg-consent');
-  const $modal = document.getElementById('ttg-consent-modal');
-  const $panel = $modal.querySelector('.ttg-consent-modal__panel');
+  const $modal  = document.getElementById('ttg-consent-modal');
+  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
+
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds = document.getElementById('ttg-c-ads');
 
+  const $form        = document.getElementById('ttg-consent-form');
+  const $ckAnalytics = document.getElementById('ttg-c-analytics');
+  const $ckAds       = document.getElementById('ttg-c-ads');
+
+  // --- helpers ---
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
   }
   function load(){
-    try { return JSON.parse(localStorage.getItem(KEY)||''); } catch(e){ return null; }
+    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ $banner.hidden = false; }
-  function closeBanner(){ $banner.hidden = true; }
+  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    $modal.hidden = false;
-    const s = load() || {analytics:false, ads:false};
-    $ckAnalytics.checked = !!s.analytics;
-    $ckAds.checked = !!s.ads;
+    if ($modal) {
+      $modal.hidden = false;
+      const s = load() || {analytics:false, ads:false};
+      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+      if ($ckAds)       $ckAds.checked = !!s.ads;
+    }
   }
-  function closeModal(){ $modal.hidden = true; }
+  function closeModal(){ if ($modal) $modal.hidden = true; }
+
+  // --- hard safety on initial state: modal should NEVER auto-open ---
+  closeModal(); // ensure hidden even before any logic runs
+
+  const state = load();
+  if (!state) {
+    // first visit => show only the banner
+    openBanner();
+  } else {
+    // existing choice => persist flag and keep everything hidden
+    save(state);
+    closeBanner();
+    closeModal();
+  }
+
+  // --- wire actions ---
+  if ($btnAccept) $btnAccept.addEventListener('click', function(){
+    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnReject) $btnReject.addEventListener('click', function(){
+    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
+    closeModal(); closeBanner();
+  });
+  if ($btnManage) $btnManage.addEventListener('click', openModal);
+  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
+
+  if ($form) $form.addEventListener('submit', function(e){
+    e.preventDefault();
+    save({
+      essential: true,
+      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
+      ads:       $ckAds ? !!$ckAds.checked : false,
+      ts: Date.now()
+    });
+    closeModal(); closeBanner();
+  });
+
+  // close modal on outside click
+  if ($modal) $modal.addEventListener('click', function(e){
+    if (e.target === $modal) closeModal();
+  });
+
+  // close modal on Escape key
+  document.addEventListener('keydown', function(e){
+    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
+  });
+
+  // Guard: don’t load ads if not consented
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+    window.__TTG_ADS_DISABLED__ = true;
+  }
 
   // Public API for footer link
   window.cookieConsent = {
     open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); openBanner(); }
+    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
   };
-
-  const state = load();
-  if(!state){ openBanner(); } else { save(state); }
-
-  $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  $btnManage.addEventListener('click', openModal);
-  $btnCancel.addEventListener('click', closeModal);
-  $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({ essential:true, analytics:$ckAnalytics.checked, ads:$ckAds.checked, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-
-  // Close on outside click
-  $modal.addEventListener('click', function(e){
-    if(e.target === $modal) closeModal();
-  });
-
-  // Close on Escape key
-  document.addEventListener('keydown', function(e){
-    if(e.key === 'Escape' && !$modal.hidden){ closeModal(); }
-  });
-
-  // Guard: don’t load ads if not consented
-  if(document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT END === -->
+<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>


### PR DESCRIPTION
## Summary
- ensure [hidden] elements stay hidden and keep consent checkboxes compact
- replace the cookie consent script to prevent auto-opening and add robust open/close handling

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de0deec74883328812fdb228368bdc