### PR TITLE
Fix cookie consent checkbox UI and status updates

### DIFF
--- a/about.html
+++ b/about.html
@@ -479,25 +479,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -508,30 +523,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -554,18 +589,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -576,7 +611,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -545,25 +545,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -574,30 +589,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -620,18 +655,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -642,7 +677,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/copyright-dmca.html
+++ b/copyright-dmca.html
@@ -177,25 +177,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -206,30 +221,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -252,18 +287,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -274,7 +309,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/copyright.html
+++ b/copyright.html
@@ -50,25 +50,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -79,30 +94,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -125,18 +160,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -147,7 +182,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/css/style.css
+++ b/css/style.css
@@ -1511,4 +1511,23 @@ body.planted-active #cycling-coach .cc-title__leaf {
   flex-shrink: 0;
 }
 /* === TTG Cookie Consent: visibility & sizing PATCH END === */
+/* === TTG Cookie Consent: checkbox visibility PATCH START === */
+/* Force native checkbox UI (some resets hide it) */
+.ttg-row input[type="checkbox"]{
+  -webkit-appearance: checkbox;
+  appearance: checkbox;
+  width:16px;
+  height:16px;
+  margin-top:3px;
+  flex-shrink:0;
+  cursor:pointer;
+  accent-color:#ffffff; /* uses your light theme; change if you want */
+}
+/* Make the whole row clickable */
+.ttg-row{ cursor:pointer; }
+/* Prevent text-selection when tapping labels on mobile */
+.ttg-row span{ user-select:none; }
+/* Small, subtle status text */
+.ttg-consent-status{ margin-top:8px; opacity:.8; font-size:.9rem; }
+/* === TTG Cookie Consent: checkbox visibility PATCH END === */
 /* === TTG Cookie Consent END === */

--- a/feature-your-tank.html
+++ b/feature-your-tank.html
@@ -907,25 +907,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -936,30 +951,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -982,18 +1017,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -1004,7 +1039,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/gear.html
+++ b/gear.html
@@ -316,25 +316,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -345,30 +360,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -391,18 +426,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -413,7 +448,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/index.html
+++ b/index.html
@@ -541,25 +541,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -570,30 +585,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -616,18 +651,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -638,7 +673,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 </body>
 </html>

--- a/media.html
+++ b/media.html
@@ -521,25 +521,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -550,30 +565,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -596,18 +631,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -618,7 +653,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/params.html
+++ b/params.html
@@ -738,25 +738,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -767,30 +782,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -813,18 +848,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -835,7 +870,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -634,25 +634,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -663,30 +678,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -709,18 +744,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -731,7 +766,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/stocking.html
+++ b/stocking.html
@@ -1355,25 +1355,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -1384,30 +1399,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -1430,18 +1465,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -1452,7 +1487,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/store.html
+++ b/store.html
@@ -231,25 +231,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -260,30 +275,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -306,18 +341,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -328,7 +363,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/terms.html
+++ b/terms.html
@@ -156,25 +156,40 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (stable) START === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
 <script>
 (function(){
   const KEY = 'ttg.consent.v1';
 
   const $banner = document.getElementById('ttg-consent');
   const $modal  = document.getElementById('ttg-consent-modal');
-  const $panel  = $modal ? $modal.querySelector('.ttg-consent-modal__panel') : null;
-
   const $btnAccept = document.getElementById('ttg-consent-accept');
   const $btnReject = document.getElementById('ttg-consent-reject');
   const $btnManage = document.getElementById('ttg-consent-manage');
   const $btnCancel = document.getElementById('ttg-consent-cancel');
+  const $form = document.getElementById('ttg-consent-form');
 
-  const $form        = document.getElementById('ttg-consent-form');
+  // Checkboxes
+  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
+  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
   const $ckAnalytics = document.getElementById('ttg-c-analytics');
   const $ckAds       = document.getElementById('ttg-c-ads');
 
-  // --- helpers ---
+  // Add a small status line so you can verify state visually
+  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
+  if ($form && !$status){
+    $status = document.createElement('p');
+    $status.className = 'ttg-consent-status';
+    $form.appendChild($status);
+  }
+
+  function updateStatus(){
+    if(!$status) return;
+    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
+    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
+    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
+  }
+
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
@@ -185,30 +200,50 @@
   function openBanner(){ if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
-    if ($modal) {
-      $modal.hidden = false;
-      const s = load() || {analytics:false, ads:false};
-      if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-      if ($ckAds)       $ckAds.checked = !!s.ads;
-    }
-  }
-  function closeModal(){ if ($modal) $modal.hidden = true; }
+    if(!$modal) return;
+    $modal.hidden = false;
 
-  // --- hard safety on initial state: modal should NEVER auto-open ---
-  closeModal(); // ensure hidden even before any logic runs
+    // Essential MUST be checked & disabled
+    if ($ckEssential){
+      $ckEssential.checked = true;
+      $ckEssential.disabled = true;
+    }
+
+    const s = load() || {analytics:false, ads:false};
+    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
+    if ($ckAds)       $ckAds.checked = !!s.ads;
+    updateStatus();
+  }
+  function closeModal(){ if($modal) $modal.hidden = true; }
+
+  // Ensure modal hidden initially
+  closeModal();
 
   const state = load();
-  if (!state) {
-    // first visit => show only the banner
+  if (!state){
+    // First visit: banner only
     openBanner();
   } else {
-    // existing choice => persist flag and keep everything hidden
     save(state);
-    closeBanner();
-    closeModal();
+    closeBanner(); closeModal();
   }
 
-  // --- wire actions ---
+  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
+  $rows.forEach(function(row, idx){
+    row.addEventListener('click', function(e){
+      const cb = row.querySelector('input[type="checkbox"]');
+      if (!cb) return;
+      if (idx === 0) return; // Essential: no toggle
+      if (e.target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+        updateStatus();
+      }
+    });
+  });
+  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
+  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
+
+  // Buttons
   if ($btnAccept) $btnAccept.addEventListener('click', function(){
     save({ essential:true, analytics:true, ads:true, ts:Date.now() });
     closeModal(); closeBanner();
@@ -231,18 +266,18 @@
     closeModal(); closeBanner();
   });
 
-  // close modal on outside click
+  // Close modal on outside click
   if ($modal) $modal.addEventListener('click', function(e){
     if (e.target === $modal) closeModal();
   });
 
-  // close modal on Escape key
+  // Close on Escape
   document.addEventListener('keydown', function(e){
     if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
   });
 
-  // Guard: don’t load ads if not consented
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted') {
+  // Guard for ad scripts
+  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
     window.__TTG_ADS_DISABLED__ = true;
   }
 
@@ -253,7 +288,8 @@
   };
 })();
 </script>
-<!-- === TTG Cookie Consent SCRIPT (stable) END === -->
+<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>


### PR DESCRIPTION
## Summary
- ensure cookie consent checkboxes display their native UI and add a status line for quick verification
- update the consent script across pages so Essential is always enforced, choices persist, and live status reflects Analytics/Advertising selections

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de103b54c883328aa026805789d651