### PR TITLE
Add offline fallback for link audit and capture report

### DIFF
--- a/reports/link_audit.csv
+++ b/reports/link_audit.csv
@@ -1,0 +1,117 @@
+Category,Product_Name,Amazon_Link,Resolved_URL,Domain,Page_Title,Match_Status,Notes
+Filtration,AQUANEAT Sponge,https://amzn.to/3KwArqb,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Tetra Whisper 10i,https://amzn.to/42XwEZi,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,AquaClear 20,https://amzn.to/4o1y7WN,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,AquaClear 30,https://amzn.to/4nYav5l,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,AquaClear 50,https://amzn.to/4nXVh05,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,AquaClear 70,https://amzn.to/4nTTyZK,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,AquaClear 110,https://amzn.to/4312pke,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Fluval 107,https://amzn.to/4879D9S,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Fluval 207,https://amzn.to/3KtrYEh,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Fluval 307,https://amzn.to/47bRUfx,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Fluval 407,https://amzn.to/4nvN57p,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Fluval FX4,https://amzn.to/3ITUYVf,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Fluval FX6,https://amzn.to/4q8CiCb,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Seachem Tidal 35,https://amzn.to/3ITWKWp,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Seachem Tidal 55,https://amzn.to/4pMD2g5,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Seachem Tidal 75,https://amzn.to/4pW7Gni,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Seachem Tidal 110,https://amzn.to/431O6Mj,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Cascade 500,https://amzn.to/4757LgP,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Cascade 700,https://amzn.to/48HSBzg,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Cascade 1000,https://amzn.to/48h3oAx,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Cascade 1500,https://amzn.to/46P5pBk,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Cascade 2000,https://amzn.to/4ntRKqp,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Penguin 100,https://amzn.to/46Q2rg6,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Penguin 150,https://amzn.to/46P5qFo,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Penguin 200,https://amzn.to/3VNMUs3,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Penguin 350,https://amzn.to/3VLNaHZ,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Penguin 400,https://amzn.to/4mGG6az,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,QuietFlow 10,https://amzn.to/3VHCESa,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,QuietFlow 20,https://amzn.to/3VNjcn3,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,QuietFlow 30,https://amzn.to/4nZf2Ew,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,QuietFlow 50,https://amzn.to/42XxbKM,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,QuietFlow 75,https://amzn.to/4o4vnbk,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,QuietFlow 90,https://amzn.to/42mFBLB,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,SunSun HW-302,https://amzn.to/4nZRkbk,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,SunSun HW-303B,https://amzn.to/3Whsbgi,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,SunSun HW-304B,https://amzn.to/4mIPPgE,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Eheim Classic 150,https://amzn.to/46A7h24,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Eheim Classic 250,https://amzn.to/4mGGkyr,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Eheim Classic 350,https://amzn.to/46vTNo2,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Eheim Classic 600,https://amzn.to/3IAUO57,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Eheim Pro 4+ 250,https://amzn.to/3KoJ7z5,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Eheim Pro 4+ 350,https://amzn.to/4o36KLX,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Eheim Pro 4+ 600,https://amzn.to/4gRAgC5,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Biomaster Thermo 250,https://amzn.to/3VLjfQo,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Biomaster Thermo 350,https://amzn.to/4gNOVhw,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Biomaster Thermo 600,https://amzn.to/3KuIlR0,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Biomaster Thermo 850,https://amzn.to/4gUDYuE,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Hygger Sponge Double,https://amzn.to/46NTAeW,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Hygger Internal Power,https://amzn.to/42W1YHZ,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Hygger Canister HG-915,https://amzn.to/46SU6s4,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Filtration,Hygger Canister HG-918,https://amzn.to/46LTvrZ,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,NICREW ClassicLED Plus 18in,https://amzn.to/46Oetq2,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,NICREW ClassicLED Plus 24in,https://amzn.to/3IRfhTd,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,NICREW ClassicLED Plus 30in,https://amzn.to/4n4x9Z7,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,NICREW ClassicLED Plus 36in,https://amzn.to/46WyHOO,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,NICREW ClassicLED Plus 48in,https://amzn.to/4nq2Exu,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,NICREW SkyLED Plus 24in,https://amzn.to/48LB1dN,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,NICREW SkyLED Plus 36in,https://amzn.to/3ITYtuR,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,NICREW SkyLED Plus 48in,https://amzn.to/48ceAOH,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,NICREW Reef LED 30in,https://amzn.to/47bTqOL,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Fluval Aquasky 24-36in,https://amzn.to/3WhthIW,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Fluval Aquasky 36-48in,https://amzn.to/46LULvd,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Fluval Plant 3.0 24-34in,https://amzn.to/4mK1I5Q,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Fluval Plant 3.0 36-48in,https://amzn.to/3VLtFzq,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Fluval Plant 3.0 Nano 15in,https://amzn.to/46Oex9g,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Hygger Clip-On 18in,https://amzn.to/48bCV7f,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Hygger 24in Full-Spectrum LED,https://amzn.to/42my2Vn,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Hygger 36in Full-Spectrum LED,https://amzn.to/4nwtLXR,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Hygger 48in Full-Spectrum LED,https://amzn.to/4ntyOYX,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Aqueon Clip-On Planted 20in,https://amzn.to/42kSTbs,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Aqueon Planted 30in,https://amzn.to/42p2OwO,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Aqueon Planted 48in,https://amzn.to/4pS0CYI,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Beamswork DA 36in,https://amzn.to/4nx2TXy,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Beamswork DA 48in,https://amzn.to/4nHYXDm,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Beamswork DA 72in,https://amzn.to/4q8DXaT,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Beamswork EA 24in,https://amzn.to/3WhtsnA,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Beamswork EA 36in,https://amzn.to/3KwJck7,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Beamswork EA 48in,https://amzn.to/4pOqHHY,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Beamswork Vivio 24in,https://amzn.to/4pRESMy,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Beamswork Vivio 36in,https://amzn.to/4pWeBNk,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Beamswork Vivio 48in,https://amzn.to/4mGHBWf,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Hygger Advanced LED 24in,https://amzn.to/4pQHz0J,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Hygger Advanced LED 36in,https://amzn.to/4mNWPIZ,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Hygger Advanced LED 48in,https://amzn.to/4pOqEfg,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Hygger Advanced LED 72in,https://amzn.to/4pS5uNg,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Chihiros WRGB II 30in,https://amzn.to/4mKTtGP,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Chihiros WRGB II 36in,https://amzn.to/474piWp,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Chihiros WRGB II 48in,https://amzn.to/3WjlH0w,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Lighting,Chihiros WRGB II 72in,https://amzn.to/4gUd06z,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,hygger Aquarium Heater 500W,https://amzn.to/4o1C1ip,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,hygger Aquarium Heater 800W,https://amzn.to/4o1C1ip,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,hygger Aquarium Heater 1000W,https://amzn.to/4o1C1ip,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,hygger Small Aquarium Heater 10W,https://amzn.to/4nxu199,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,hygger Small Aquarium Heater 25W,https://amzn.to/3KwEIdd,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,hygger Small Aquarium Heater 50W,https://amzn.to/4nxu199,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,hygger Small Aquarium Heater 100W,https://amzn.to/3KwEIdd,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,hygger ETL Certified Heater 50W,https://amzn.to/46ylbSr,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,hygger ETL Certified Heater 100W,https://amzn.to/46ymD7l,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,hygger ETL Certified Heater 200W,https://amzn.to/46ylbSr,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,hygger ETL Certified Heater 300W,https://amzn.to/46ymD7l,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,Marineland Precision Heater 200W,https://amzn.to/4pPMBuv,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,Marineland Precision Heater 250W,https://amzn.to/48GqKPZ,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,Marineland Precision Heater (assorted watts),https://amzn.to/3VIySYP,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,Inkbird Aquarium Temperature Controller,https://amzn.to/46IMpEB,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,Cobalt Neo-Therm Pro 100W,https://www.cobaltaquatics.com/products/neo-therm-pro-heater,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,Cobalt Neo-Therm Pro 200W,https://www.cobaltaquatics.com/products/neo-therm-pro-heater,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,TBD (enter product + watt),https://amzn.to/476spgs,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,TBD (enter product + watt),https://amzn.to/3INi6Vh,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,TBD (enter product + watt),https://amzn.to/42U1jGT,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,TBD (enter product + watt),https://amzn.to/4pSi4fx,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,TBD (enter product + watt),https://amzn.to/46N20TL,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,TBD (enter product + watt),https://amzn.to/4nZjenK,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,TBD (enter product + watt),https://amzn.to/3WfXoAC,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,TBD (enter product + watt),https://amzn.to/42l2Q8X,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,TBD (enter product + watt),https://amzn.to/4nVrEwl,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+Heating,TBD (enter product + watt),https://amzn.to/48J1wjW,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL

--- a/reports/link_audit.txt
+++ b/reports/link_audit.txt
@@ -1,0 +1,1 @@
+Link Audit Source: master:gear_master.csv\nTotal audited: 116\n  Filtration: 51\n  Heating: 27\n  Lighting: 38\n\nMISMATCH rows: 0\n\nNO_TITLE rows: 116\n\nUNKNOWN rows: 0\n\nNotes: EXPAND_ERR = redirect/resolve failed; TITLE_ERR = fetch or parse title failed.\n


### PR DESCRIPTION
## Summary
- add a urllib-based fallback path to `scripts/link_audit.py` so the link audit can run without `requests`/`bs4`
- tighten timeouts and skip inter-request sleeping when using the fallback session
- capture the latest audit outputs under `reports/` (no mismatches found because external requests are blocked)

## Testing
- python scripts/link_audit.py --sleep 0.7

------
https://chatgpt.com/codex/tasks/task_e_68de6accca408332a015cc207f6b3e09