### PR TITLE
Refactor gear page to rely on global layout

### DIFF
--- a/tests/gear-nav.spec.ts
+++ b/tests/gear-nav.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Gear page navigation landmarks', () => {
+  test('renders only the global navigation', async ({ page }) => {
+    await page.goto('/gear/', { waitUntil: 'networkidle' });
+    const navs = await page.getByRole('navigation').all();
+    expect(navs.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- wrap the gear experience in a simple container that keeps the banner, context bar, recommendations, accordion, drawer, and modal while dropping the local footer meta block
- ensure the rendered markup no longer mounts an inline navigation/header so the page uses only the global shell
- add a Playwright regression test that fails if the gear page exposes more than the single expected navigation landmark

## Testing
- npm test *(fails: Playwright browsers are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de7a466488833290676de98e831491