### PR TITLE
Add AdSense disclaimer accordion to privacy page

### DIFF
--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -399,6 +399,20 @@
           </div>
         </details>
 
+        <details id="adsense-disclaimer">
+          <summary><span>AdSense Disclaimer</span></summary>
+          <div class="details-body">
+            <h2>AdSense Disclaimer</h2>
+            <p>This site uses Google AdSense to display advertisements. Google and its partners may use cookies and similar technologies to serve ads based on your visits to this site and other websites.</p>
+            <ul>
+              <li><strong>Personalized Ads:</strong> If enabled, AdSense may show ads tailored to your interests and browsing behavior.</li>
+              <li><strong>Non-Personalized Ads:</strong> You may choose to receive ads that are contextual only, not based on your past activity.</li>
+            </ul>
+            <p>You can manage or opt out of personalized advertising at any time by visiting Google’s Ads Settings: <a href="https://www.google.com/settings/ads" rel="noopener">https://www.google.com/settings/ads</a>.</p>
+            <p>By using this site, you consent to the use of cookies and data as described in our Cookies &amp; Tracking section and in this AdSense Disclaimer.</p>
+          </div>
+        </details>
+
         <details id="disclaimer">
           <summary><span>Disclaimer</span></summary>
           <div class="details-body">


### PR DESCRIPTION
## Summary
- add an AdSense Disclaimer accordion section to the Privacy & Legal page directly after Affiliate Disclosure
- include Google advertising details, personalization options, and links to Ads Settings while matching existing accordion styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de841770dc83328a29eda0f176c0e0