### PR TITLE
Fix privacy/legal accordion order and TOC sequence

### DIFF
--- a/js/nav.js
+++ b/js/nav.js
@@ -2,6 +2,18 @@
   const NAV_VERSION = '1.1.0';
   const NAV_PLACEHOLDER_ID = 'site-nav';
   const HOME_PATH = '/index.html';
+  const PRIVACY_SECTION_IDS = [
+    'privacy-policy',
+    'cookies-tracking',
+    'affiliate-disclosure',
+    'adsense-disclaimer',
+    'terms-of-use',
+    'disclaimer',
+    'copyright-dmca',
+    'accessibility',
+    'contact',
+    'effective-date'
+  ];
 
   if (window.__TTG_NAV_LOADER__) {
     return;
@@ -188,4 +200,5 @@
   }
 
   window.ttgInitNav = initNav;
+  window.__TTG_PRIVACY_SECTION_IDS__ = PRIVACY_SECTION_IDS;
 })();

--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -413,6 +413,24 @@
           </div>
         </details>
 
+        <details id="terms-of-use">
+          <summary><span>Terms of Use</span></summary>
+          <div class="details-body">
+            <h2>Terms of Use</h2>
+            <ul>
+              <li><strong>Informational Only:</strong> Content on TheTankGuide.com is for educational and informational purposes. It is not professional advice.</li>
+              <li><strong>No Warranties:</strong> The site is provided “as is.” We make no guarantees regarding accuracy, completeness, or availability.</li>
+              <li><strong>Limitation of Liability:</strong> To the fullest extent permitted by law, FishKeepingLifeCo is not liable for damages arising from use of this site.</li>
+              <li><strong>Indemnification:</strong> By using this site, you agree to indemnify and hold us harmless from claims related to your misuse of the content.</li>
+              <li><strong>Intellectual Property:</strong> All content is owned by FishKeepingLifeCo or our licensors. You may not copy or redistribute without permission.</li>
+              <li><strong>External Links:</strong> We may link to third-party sites. We are not responsible for their content, policies, or practices.</li>
+              <li><strong>Governing Law:</strong> This Agreement is governed by the laws of New York, USA.</li>
+              <li><strong>Termination:</strong> We may suspend or terminate access to this site at any time.</li>
+              <li><strong>Severability:</strong> If any provision is held invalid, the rest remain in effect.</li>
+            </ul>
+          </div>
+        </details>
+
         <details id="disclaimer">
           <summary><span>Disclaimer</span></summary>
           <div class="details-body">
@@ -435,24 +453,6 @@
             <p>Use of TheTankGuide.com is at your own risk. All information and services are provided “as is” without warranties of any kind, either expressed or implied. FishKeepingLifeCo disclaims all liability for damages arising from the use of this website or reliance on its content.</p>
             <h3>Contact</h3>
             <p>For questions regarding this disclaimer, please contact us at: <a href="mailto:contact@thetankguide.com">contact@thetankguide.com</a></p>
-          </div>
-        </details>
-
-        <details id="terms-of-use">
-          <summary><span>Terms of Use</span></summary>
-          <div class="details-body">
-            <h2>Terms of Use</h2>
-            <ul>
-              <li><strong>Informational Only:</strong> Content on TheTankGuide.com is for educational and informational purposes. It is not professional advice.</li>
-              <li><strong>No Warranties:</strong> The site is provided “as is.” We make no guarantees regarding accuracy, completeness, or availability.</li>
-              <li><strong>Limitation of Liability:</strong> To the fullest extent permitted by law, FishKeepingLifeCo is not liable for damages arising from use of this site.</li>
-              <li><strong>Indemnification:</strong> By using this site, you agree to indemnify and hold us harmless from claims related to your misuse of the content.</li>
-              <li><strong>Intellectual Property:</strong> All content is owned by FishKeepingLifeCo or our licensors. You may not copy or redistribute without permission.</li>
-              <li><strong>External Links:</strong> We may link to third-party sites. We are not responsible for their content, policies, or practices.</li>
-              <li><strong>Governing Law:</strong> This Agreement is governed by the laws of New York, USA.</li>
-              <li><strong>Termination:</strong> We may suspend or terminate access to this site at any time.</li>
-              <li><strong>Severability:</strong> If any provision is held invalid, the rest remain in effect.</li>
-            </ul>
           </div>
         </details>
 
@@ -523,13 +523,14 @@
           'privacy-policy',
           'cookies-tracking',
           'affiliate-disclosure',
-          'disclaimer',
+          'adsense-disclaimer',
           'terms-of-use',
+          'disclaimer',
           'copyright-dmca',
           'accessibility',
           'contact',
-        'effective-date'
-      ];
+          'effective-date'
+        ];
 
       const detailsElements = SECTION_IDS
         .map((id) => document.getElementById(id))


### PR DESCRIPTION
## Summary
- reorder the Privacy & Legal accordions so Terms of Use appears ahead of Disclaimer while preserving all content
- update the section ID list used for hash navigation to include the AdSense disclaimer and reflect the new order
- expose the section ordering via the shared nav loader for any TOC or hash-link consumers

## Testing
- Manual Playwright QA of privacy-legal.html (hash navigation, screenshots, console checks)


------
https://chatgpt.com/codex/tasks/task_e_68de889471d4833281e5c5c91e67dc0d