### PR TITLE
Add responsive ad placeholders to aquarium tools

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1603,3 +1603,16 @@ body.planted-active #cycling-coach .cc-title__leaf {
 .ttg-row span{ user-select: none; }
 /* === TTG Cookie Consent: forced visible checkboxes END === */
 /* === TTG Cookie Consent END === */
+/* === TTG Ads v2 (Top + Post-Results) START === */
+.ttg-adunit{min-height:250px;border:1px dashed rgba(255,255,255,.18);border-radius:12px;display:flex;align-items:center;justify-content:center;opacity:.7;margin:16px 0;}
+.ttg-adunit--top{margin-top:12px;margin-bottom:20px;}
+.ttg-adunit--bottom{margin-top:24px;margin-bottom:16px;}
+/* keep ads out of sight until allowed */
+html[data-ad-consent="denied"] .ttg-adunit,
+html:not([data-ad-consent]) .ttg-adunit,
+.is-ads-disabled .ttg-adunit{display:none !important;}
+/* Small screens: full width; Large screens: constrain for balance */
+@media (min-width: 900px){
+  .ttg-adunit{max-width:900px;margin-left:auto;margin-right:auto;}
+}
+/* === TTG Ads v2 END === */

--- a/params.html
+++ b/params.html
@@ -544,6 +544,13 @@
         <p class="cc-title__subline">Enter today’s readings for a clear snapshot.</p>
       </section>
 
+      <!-- === TTG AD: TOP START === -->
+      <div class="ttg-adunit ttg-adunit--top" id="ad-top-1" data-ad-slot="top-1" aria-label="Advertisement">
+        <!-- AdSense will mount here when approved -->
+        <span>Ad — Top placeholder</span>
+      </div>
+      <!-- === TTG AD: TOP END === -->
+
       <section class="card" aria-labelledby="inputs-heading">
         <div class="card__header">
           <h2 class="card__title" id="inputs-heading">Inputs</h2>
@@ -618,6 +625,13 @@
           <ul class="actions-list" id="actions-list"></ul>
         </div>
       </section>
+
+      <!-- === TTG AD: POST-RESULTS START === -->
+      <div class="ttg-adunit ttg-adunit--bottom" id="ad-bottom-1" data-ad-slot="post-results-1" aria-label="Advertisement">
+        <!-- AdSense will mount here when approved -->
+        <span>Ad — Post-results placeholder</span>
+      </div>
+      <!-- === TTG AD: POST-RESULTS END === -->
 
       <section class="card" id="challengeCard" aria-labelledby="challenge-heading" hidden>
         <div class="card__header">
@@ -871,6 +885,15 @@
 })();
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
+<script>
+(function(){
+  var denied = document.documentElement.getAttribute('data-ad-consent') !== 'granted';
+  if (window.__TTG_ADS_DISABLED__ || denied){
+    document.documentElement.classList.add('is-ads-disabled');
+  }
+})();
+</script>
 
 <!-- === TTG Cookie Consent END === -->
 

--- a/stocking.html
+++ b/stocking.html
@@ -921,6 +921,13 @@
     </header>
 
     <div class="wrap page-content">
+      <!-- === TTG AD: TOP START === -->
+      <div class="ttg-adunit ttg-adunit--top" id="ad-top-1" data-ad-slot="top-1" aria-label="Advertisement">
+        <!-- AdSense will mount here when approved -->
+        <span>Ad — Top placeholder</span>
+      </div>
+      <!-- === TTG AD: TOP END === -->
+
       <!-- Tank Size card -->
       <div class="card ttg-card tank-size-card" id="tank-size-card">
         <div class="card-header">
@@ -1306,6 +1313,13 @@
         </div>
       </section>
 
+      <!-- === TTG AD: POST-RESULTS START === -->
+      <div class="ttg-adunit ttg-adunit--bottom" id="ad-bottom-1" data-ad-slot="post-results-1" aria-label="Advertisement">
+        <!-- AdSense will mount here when approved -->
+        <span>Ad — Post-results placeholder</span>
+      </div>
+      <!-- === TTG AD: POST-RESULTS END === -->
+
       <button class="see-gear" id="btn-gear" type="button" data-testid="btn-gear">See Gear Suggestions</button>
 
       <div id="bioload-tip" class="ui-tip" data-role="info-tip" role="tooltip" hidden>
@@ -1508,6 +1522,15 @@
 })();
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
+<script>
+(function(){
+  var denied = document.documentElement.getAttribute('data-ad-consent') !== 'granted';
+  if (window.__TTG_ADS_DISABLED__ || denied){
+    document.documentElement.classList.add('is-ads-disabled');
+  }
+})();
+</script>
 
 <!-- === TTG Cookie Consent END === -->
 


### PR DESCRIPTION
## Summary
- add shared styling for new top and post-results ad placeholders
- insert consent-gated ad placeholders on the Stocking Advisor and Cycling Coach pages
- ensure the `is-ads-disabled` class mirrors consent for the placeholder units

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de8e175e488332bd9fa5e3e1196412