### PR TITLE
Fix gear page to use global navigation and footer

### DIFF
--- a/gear/index.html
+++ b/gear/index.html
@@ -16,14 +16,6 @@
 <body class="theme-light">
   <!-- GLOBAL NAV -->
   <div id="site-nav"></div>
-  <script>
-    (function(){
-      fetch('/nav.html')
-        .then(r => r.text())
-        .then(html => { document.getElementById('site-nav').innerHTML = html; })
-        .catch(console.error);
-    })();
-  </script>
   <main id="gear-main">
     <div id="gear-root" data-testid="gear-root"></div>
   </main>
@@ -213,12 +205,14 @@
 <!-- GLOBAL FOOTER v1.3.0 -->
 <div id="site-footer"></div>
 <script>
-  (function(){
-    fetch('/footer.v1.3.0.html')
-      .then(r => r.text())
-      .then(html => { document.getElementById('site-footer').innerHTML = html; })
-      .catch(console.error);
-  })();
+(async () => {
+  try {
+    const res = await fetch('/footer.v1.3.0.html?v=1.3.0', { cache: 'no-cache' });
+    const html = await res.text();
+    const host = document.getElementById('site-footer');
+    if (host) host.outerHTML = html;
+  } catch (e) { console.error('[Footer] load failed:', e); }
+})();
 </script>
 </body>
 </html>

--- a/nav.html
+++ b/nav.html
@@ -12,21 +12,21 @@
       <span class="hamburger__bars" aria-hidden="true"></span>
       <span class="visually-hidden">Open menu</span>
     </button>
-    <a class="site-brand brand" href="index.html" aria-label="The Tank Guide — Home">
+    <a class="site-brand brand" href="/" aria-label="The Tank Guide — Home">
       <span class="site-brand__title">The Tank Guide</span>
       <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
     </a>
     <nav class="site-links links" aria-label="Primary">
       <ul class="nav__list">
         <li class="nav__item"><a href="/" class="nav__link">Home</a></li>
-        <li class="nav__item"><a href="/stocking.html" class="nav__link">Stocking Advisor</a></li>
+        <li class="nav__item"><a href="/stocking-advisor" class="nav__link">Stocking Advisor</a></li>
         <li class="nav__item"><a href="/gear/" class="nav__link">Gear</a></li>
-        <li class="nav__item"><a href="/params.html" class="nav__link">Cycling Coach</a></li>
+        <li class="nav__item"><a href="/cycling-coach" class="nav__link">Cycling Coach</a></li>
         <li class="nav__item"><a href="/media.html" class="nav__link">Media</a></li>
-        <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link">Feature Your Tank</a></li>
-        <li class="nav__item"><a href="/store.html" class="nav__link">Store</a></li>
-        <li class="nav__item"><a href="/contact-feedback.html" class="nav__link">Contact &amp; Feedback</a></li>
-        <li class="nav__item"><a href="/about.html" class="nav__link">About</a></li>
+        <li class="nav__item"><a href="/feature-your-tank" class="nav__link">Feature Your Tank</a></li>
+        <li class="nav__item"><a href="/store" class="nav__link">Store</a></li>
+        <li class="nav__item"><a href="/contact" class="nav__link">Contact &amp; Feedback</a></li>
+        <li class="nav__item"><a href="/about" class="nav__link">About</a></li>
       </ul>
     </nav>
   </div>
@@ -40,14 +40,14 @@
     <nav class="drawer-links" aria-label="Mobile">
       <ul class="nav__list nav__list--drawer">
         <li class="nav__item"><a href="/" class="nav__link">Home</a></li>
-        <li class="nav__item"><a href="/stocking.html" class="nav__link">Stocking Advisor</a></li>
+        <li class="nav__item"><a href="/stocking-advisor" class="nav__link">Stocking Advisor</a></li>
         <li class="nav__item"><a href="/gear/" class="nav__link">Gear</a></li>
-        <li class="nav__item"><a href="/params.html" class="nav__link">Cycling Coach</a></li>
+        <li class="nav__item"><a href="/cycling-coach" class="nav__link">Cycling Coach</a></li>
         <li class="nav__item"><a href="/media.html" class="nav__link">Media</a></li>
-        <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link">Feature Your Tank</a></li>
-        <li class="nav__item"><a href="/store.html" class="nav__link">Store</a></li>
-        <li class="nav__item"><a href="/contact-feedback.html" class="nav__link">Contact &amp; Feedback</a></li>
-        <li class="nav__item"><a href="/about.html" class="nav__link">About</a></li>
+        <li class="nav__item"><a href="/feature-your-tank" class="nav__link">Feature Your Tank</a></li>
+        <li class="nav__item"><a href="/store" class="nav__link">Store</a></li>
+        <li class="nav__item"><a href="/contact" class="nav__link">Contact &amp; Feedback</a></li>
+        <li class="nav__item"><a href="/about" class="nav__link">About</a></li>
       </ul>
     </nav>
   </aside>


### PR DESCRIPTION
## Summary
- update navigation links to match the canonical internal routes
- load the gear page header/footer through the shared includes and drop the duplicate inline loader

## Testing
- Manual verification of /gear/ in browser_container (mobile + desktop views)


------
https://chatgpt.com/codex/tasks/task_e_68ded1f649d483329fd3f143c0e0875e