### PR TITLE
Add consent-gated media bottom ad placeholder

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1616,3 +1616,14 @@ html:not([data-ad-consent]) .ttg-adunit,
   .ttg-adunit{max-width:900px;margin-left:auto;margin-right:auto;}
 }
 /* === TTG Ads v2 END === */
+/* === TTG Ads: Media Bottom START === */
+.ttg-adunit{min-height:250px;border:1px dashed rgba(255,255,255,.18);border-radius:12px;display:flex;align-items:center;justify-content:center;opacity:.7;margin:16px 0;}
+.ttg-adunit--media-bottom{margin-top:28px;margin-bottom:20px;}
+/* hide until consent explicitly granted */
+html[data-ad-consent="denied"] .ttg-adunit,
+html:not([data-ad-consent]) .ttg-adunit,
+.is-ads-disabled .ttg-adunit{display:none !important;}
+@media (min-width: 900px){
+  .ttg-adunit{max-width: 1000px;margin-left:auto;margin-right:auto;}
+}
+/* === TTG Ads: Media Bottom END === */

--- a/media.html
+++ b/media.html
@@ -471,6 +471,13 @@
     </section>
   </main>
 
+  <!-- === TTG AD: MEDIA BOTTOM START === -->
+  <div class="ttg-adunit ttg-adunit--media-bottom" id="ad-media-bottom-1" data-ad-slot="media-bottom-1" aria-label="Advertisement">
+    <!-- AdSense will mount here when approved -->
+    <span>Ad — Media bottom placeholder</span>
+  </div>
+  <!-- === TTG AD: MEDIA BOTTOM END === -->
+
   <div id="site-footer"></div>
   <script>
 (async () => {
@@ -654,6 +661,15 @@
 })();
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
+
+<script>
+(function(){
+  var denied = document.documentElement.getAttribute('data-ad-consent') !== 'granted';
+  if (window.__TTG_ADS_DISABLED__ || denied){
+    document.documentElement.classList.add('is-ads-disabled');
+  }
+})();
+</script>
 
 <!-- === TTG Cookie Consent END === -->
 


### PR DESCRIPTION
## Summary
- add a bottom ad placeholder to the media page before the footer
- append ad styling that keeps the media bottom slot hidden until consent is granted
- ensure the shared consent guard toggles the ads-disabled class on the media layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ded39ae2a4833280f3bb24576cb8ca