### PR TITLE
Add AdSense verification script to public HTML pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -261,6 +261,8 @@
   ]
 }
   </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body class="theme-light">
   <a class="skip-link" href="#main-content">Skip to content</a>

--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -294,6 +294,8 @@
     ]
   }
   </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body>
   <div id="site-nav"></div>

--- a/cookie-settings.html
+++ b/cookie-settings.html
@@ -19,6 +19,8 @@
     .cookie-actions button { border-radius: 12px; border: 1px solid rgba(255,255,255,.2); background: rgba(255,255,255,.08); color: #fff; padding: 12px 18px; font-weight: 600; cursor: pointer; }
     .cookie-actions button:hover { background: rgba(255,255,255,.16); }
   </style>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body class="theme-light">
   <div id="site-nav"></div>

--- a/copyright-dmca.html
+++ b/copyright-dmca.html
@@ -38,6 +38,8 @@
       .dmca-table{display:block;overflow-x:auto;}
     }
   </style>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body>
   <div id="site-nav"></div>

--- a/copyright.html
+++ b/copyright.html
@@ -8,6 +8,8 @@
   <script>
     window.location.replace('/copyright-dmca.html');
   </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body>
   <p>If you are not redirected, <a href="/copyright-dmca.html">view our Copyright &amp; DMCA page</a>.</p>

--- a/docs/screens/curl-index.html
+++ b/docs/screens/curl-index.html
@@ -8,6 +8,8 @@ body{background:#0b1020;color:#e0e6ff;font-family:SFMono-Regular,Consolas,Monaco
 pre{background:#05070f;padding:20px;border-radius:12px;box-shadow:0 12px 32px rgba(0,0,0,0.45);}
 strong{color:#7cd6ff;}
 </style>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body>
 <h1>curl -I http://127.0.0.1:4173/index.html</h1>

--- a/feature-your-tank.html
+++ b/feature-your-tank.html
@@ -287,6 +287,8 @@
       }
     }
   </style>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body class="page-gradient">
   <div id="site-nav"></div>

--- a/gear.html
+++ b/gear.html
@@ -5,6 +5,8 @@
   <meta http-equiv="refresh" content="0; url=/gear/" />
   <title>Redirecting to Gear Guide</title>
   <link rel="canonical" href="https://thetankguide.com/gear/">
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body>
   <p>Redirecting to the updated Gear Guide… <a href="/gear/">Continue</a></p>

--- a/gear/index.html
+++ b/gear/index.html
@@ -12,6 +12,8 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="icon" href="/favicon.ico" />
   <script defer src="/js/nav.js?v=1.1.0"></script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body class="theme-light">
   <!-- GLOBAL NAV -->

--- a/index.html
+++ b/index.html
@@ -141,6 +141,8 @@
   ]
 }
   </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body class="page-background">
   <div id="site-nav"></div>

--- a/media.html
+++ b/media.html
@@ -328,6 +328,8 @@
   }
 }
   </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body class="theme-light">
   <div id="site-nav"></div>

--- a/params.html
+++ b/params.html
@@ -528,6 +528,8 @@
   ]
 }
   </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body class="theme-dark cycling-coach">
   <div id="site-nav"></div>

--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -314,6 +314,8 @@
   ]
 }
   </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to content</a>

--- a/stocking.html
+++ b/stocking.html
@@ -904,6 +904,8 @@
       display: none !important;
     }
   </style>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body class="theme-dark">
   <div id="site-nav"></div>

--- a/store.html
+++ b/store.html
@@ -90,6 +90,8 @@
       }
     }
   </script>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 
 <body class="store-page">

--- a/terms.html
+++ b/terms.html
@@ -36,6 +36,8 @@
       h1{font-size:2rem;}
     }
   </style>
+  <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
+    crossorigin="anonymous"></script>
 </head>
 <body>
   <div id="site-nav"></div>


### PR DESCRIPTION
## Summary
- add the Google AdSense verification script to every public HTML document to support site verification
- ensure the script is placed just before the closing head tag without altering other metadata or assets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded67f8a8c8332ac2acb95f2ced013