### PR TITLE
Improve consent-aware ad placeholders

### DIFF
--- a/about.html
+++ b/about.html
@@ -518,6 +518,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -615,6 +616,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
+<script>
+(function(){
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
+  }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
+})();
+</script>
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -584,6 +584,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -681,6 +682,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
+<script>
+(function(){
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
+  }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
+})();
+</script>
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/cookie-settings.html
+++ b/cookie-settings.html
@@ -145,6 +145,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -232,6 +233,49 @@
   };
 })();
 </script>
+<!-- === TTG Consent → Ad Visibility Controller START === -->
+<script>
+(function(){
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
+  }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
+})();
+</script>
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 
 <script>

--- a/copyright-dmca.html
+++ b/copyright-dmca.html
@@ -216,6 +216,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -313,6 +314,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
+<script>
+(function(){
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
+  }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
+})();
+</script>
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/copyright.html
+++ b/copyright.html
@@ -89,6 +89,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -186,6 +187,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
+<script>
+(function(){
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
+  }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
+})();
+</script>
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/css/style.css
+++ b/css/style.css
@@ -1603,27 +1603,35 @@ body.planted-active #cycling-coach .cc-title__leaf {
 .ttg-row span{ user-select: none; }
 /* === TTG Cookie Consent: forced visible checkboxes END === */
 /* === TTG Cookie Consent END === */
-/* === TTG Ads v2 (Top + Post-Results) START === */
-.ttg-adunit{min-height:250px;border:1px dashed rgba(255,255,255,.18);border-radius:12px;display:flex;align-items:center;justify-content:center;opacity:.7;margin:16px 0;}
-.ttg-adunit--top{margin-top:12px;margin-bottom:20px;}
-.ttg-adunit--bottom{margin-top:24px;margin-bottom:16px;}
-/* keep ads out of sight until allowed */
+/* === TTG Ads (behavior fix) START === */
+.ttg-adunit{
+  /* Reserve a smaller safe area; will expand when a real ad renders */
+  min-height: 96px;
+  border: 1px dashed rgba(255,255,255,.18);
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: .7;
+  margin: 16px 0;
+}
+.ttg-adunit--top{ margin-top: 12px; margin-bottom: 20px; }
+.ttg-adunit--bottom{ margin-top: 24px; margin-bottom: 16px; }
+.ttg-adunit--media-bottom{ margin-top: 28px; margin-bottom: 20px; }
+
+/* Hide ad placeholders until consent is expressly granted */
 html[data-ad-consent="denied"] .ttg-adunit,
 html:not([data-ad-consent]) .ttg-adunit,
-.is-ads-disabled .ttg-adunit{display:none !important;}
-/* Small screens: full width; Large screens: constrain for balance */
-@media (min-width: 900px){
-  .ttg-adunit{max-width:900px;margin-left:auto;margin-right:auto;}
+.is-ads-disabled .ttg-adunit{
+  display: none !important;
 }
-/* === TTG Ads v2 END === */
-/* === TTG Ads: Media Bottom START === */
-.ttg-adunit{min-height:250px;border:1px dashed rgba(255,255,255,.18);border-radius:12px;display:flex;align-items:center;justify-content:center;opacity:.7;margin:16px 0;}
-.ttg-adunit--media-bottom{margin-top:28px;margin-bottom:20px;}
-/* hide until consent explicitly granted */
-html[data-ad-consent="denied"] .ttg-adunit,
-html:not([data-ad-consent]) .ttg-adunit,
-.is-ads-disabled .ttg-adunit{display:none !important;}
+
+/* Large screens: center and constrain */
 @media (min-width: 900px){
-  .ttg-adunit{max-width: 1000px;margin-left:auto;margin-right:auto;}
+  .ttg-adunit{
+    max-width: 1000px;
+    margin-left: auto;
+    margin-right: auto;
+  }
 }
-/* === TTG Ads: Media Bottom END === */
+/* === TTG Ads (behavior fix) END === */

--- a/feature-your-tank.html
+++ b/feature-your-tank.html
@@ -946,6 +946,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -1043,6 +1044,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
+<script>
+(function(){
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
+  }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
+})();
+</script>
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/gear/index.html
+++ b/gear/index.html
@@ -98,6 +98,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -195,6 +196,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
+<script>
+(function(){
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
+  }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
+})();
+</script>
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 <script>
   try {

--- a/index.html
+++ b/index.html
@@ -580,6 +580,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -677,6 +678,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
+<script>
+(function(){
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
+  }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
+})();
+</script>
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 </body>
 </html>

--- a/media.html
+++ b/media.html
@@ -567,6 +567,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -664,15 +665,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
 <script>
 (function(){
-  var denied = document.documentElement.getAttribute('data-ad-consent') !== 'granted';
-  if (window.__TTG_ADS_DISABLED__ || denied){
-    document.documentElement.classList.add('is-ads-disabled');
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
   }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
 })();
 </script>
-
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/params.html
+++ b/params.html
@@ -791,6 +791,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -888,15 +889,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
 <script>
 (function(){
-  var denied = document.documentElement.getAttribute('data-ad-consent') !== 'granted';
-  if (window.__TTG_ADS_DISABLED__ || denied){
-    document.documentElement.classList.add('is-ads-disabled');
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
   }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
 })();
 </script>
-
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -688,6 +688,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -785,6 +786,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
+<script>
+(function(){
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
+  }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
+})();
+</script>
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/stocking.html
+++ b/stocking.html
@@ -1428,6 +1428,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -1525,15 +1526,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
 <script>
 (function(){
-  var denied = document.documentElement.getAttribute('data-ad-consent') !== 'granted';
-  if (window.__TTG_ADS_DISABLED__ || denied){
-    document.documentElement.classList.add('is-ads-disabled');
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
   }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
 })();
 </script>
-
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/store.html
+++ b/store.html
@@ -233,6 +233,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -330,6 +331,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
+<script>
+(function(){
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
+  }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
+})();
+</script>
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/terms.html
+++ b/terms.html
@@ -195,6 +195,7 @@
   function save(state){
     localStorage.setItem(KEY, JSON.stringify(state));
     document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
+    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
   }
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
@@ -292,6 +293,49 @@
 </script>
 <!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
 
+<!-- === TTG Consent → Ad Visibility Controller START === -->
+<script>
+(function(){
+  var KEY = 'ttg.consent.v1';
+
+  function hasGranted(){
+    try {
+      var s = JSON.parse(localStorage.getItem(KEY) || '');
+      return !!(s && s.ads === true);
+    } catch(e){ return false; }
+  }
+
+  function applyConsentToDOM(){
+    var granted = hasGranted();
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+
+    // If we’re only showing placeholders (no AdSense yet),
+    // simply un-hide or keep hidden via the CSS above.
+    // (When you later enable the AdSense loader, mount units here if granted.)
+  }
+
+  // Run now
+  applyConsentToDOM();
+
+  // Listen for same-page consent changes (buttons & form), then update immediately
+  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
+    var el = document.getElementById(id);
+    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
+  });
+  var form = document.getElementById('ttg-consent-form');
+  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
+
+  // If your cookie script dispatches a custom event, react to it too
+  window.addEventListener('ttg:consent-change', applyConsentToDOM);
+
+  // Cross-tab changes (Storage event)
+  window.addEventListener('storage', function(e){
+    if (e.key === KEY) applyConsentToDOM();
+  });
+})();
+</script>
+<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG Cookie Consent END === -->
 
 </body>


### PR DESCRIPTION
## Summary
- shrink the default TTG ad placeholder height and hide it whenever ad consent is denied or unknown
- add a consent-change controller script to update ad visibility immediately when preferences change without reloading
- emit a consent-change event when saving preferences so the new controller stays in sync across all pages

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ded8d7c468833296b4e176e71d7504