### PR TITLE
Integrate Google CMP and sync consent state

### DIFF
--- a/about.html
+++ b/about.html
@@ -263,6 +263,27 @@
   </script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body class="theme-light">
   <a class="skip-link" href="#main-content">Skip to content</a>
@@ -523,7 +544,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -659,6 +680,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -296,6 +296,27 @@
   </script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body>
   <div id="site-nav"></div>
@@ -589,7 +610,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -725,6 +746,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/cookie-settings.html
+++ b/cookie-settings.html
@@ -21,6 +21,27 @@
   </style>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body class="theme-light">
   <div id="site-nav"></div>
@@ -150,7 +171,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -276,6 +297,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 <script>

--- a/copyright-dmca.html
+++ b/copyright-dmca.html
@@ -40,6 +40,27 @@
   </style>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body>
   <div id="site-nav"></div>
@@ -221,7 +242,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -357,6 +378,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/copyright.html
+++ b/copyright.html
@@ -10,6 +10,27 @@
   </script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body>
   <p>If you are not redirected, <a href="/copyright-dmca.html">view our Copyright &amp; DMCA page</a>.</p>
@@ -94,7 +115,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -230,6 +251,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/feature-your-tank.html
+++ b/feature-your-tank.html
@@ -289,6 +289,27 @@
   </style>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body class="page-gradient">
   <div id="site-nav"></div>
@@ -951,7 +972,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -1087,6 +1108,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/gear.html
+++ b/gear.html
@@ -7,6 +7,27 @@
   <link rel="canonical" href="https://thetankguide.com/gear/">
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body>
   <p>Redirecting to the updated Gear Guide… <a href="/gear/">Continue</a></p>

--- a/gear/index.html
+++ b/gear/index.html
@@ -14,6 +14,27 @@
   <script defer src="/js/nav.js?v=1.1.0"></script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body class="theme-light">
   <!-- GLOBAL NAV -->
@@ -103,7 +124,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -239,6 +260,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 <script>
   try {

--- a/index.html
+++ b/index.html
@@ -143,6 +143,27 @@
   </script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body class="page-background">
   <div id="site-nav"></div>
@@ -585,7 +606,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -721,6 +742,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 </body>
 </html>

--- a/media.html
+++ b/media.html
@@ -330,6 +330,27 @@
   </script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body class="theme-light">
   <div id="site-nav"></div>
@@ -572,7 +593,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -708,6 +729,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/params.html
+++ b/params.html
@@ -530,6 +530,27 @@
   </script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body class="theme-dark cycling-coach">
   <div id="site-nav"></div>
@@ -796,7 +817,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -932,6 +953,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -316,6 +316,27 @@
   </script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to content</a>
@@ -693,7 +714,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -829,6 +850,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/stocking.html
+++ b/stocking.html
@@ -906,6 +906,27 @@
   </style>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body class="theme-dark">
   <div id="site-nav"></div>
@@ -1433,7 +1454,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -1569,6 +1590,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/store.html
+++ b/store.html
@@ -92,6 +92,27 @@
   </script>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 
 <body class="store-page">
@@ -238,7 +259,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -374,6 +395,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>

--- a/terms.html
+++ b/terms.html
@@ -38,6 +38,27 @@
   </style>
   <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9905718149811880"
     crossorigin="anonymous"></script>
+  <!-- --- Google CMP (Funding Choices) START --- -->
+  <script async src="https://fundingchoicesmessages.google.com/i/pub-9905718149811880?ers=1"></script>
+  <script>
+    // Required bootstrap per Google; signals CMP presence
+    (function() {
+      function signalGooglefcPresent() {
+        if (!window.frames['googlefcPresent']) {
+          if (document.body) {
+            const iframe = document.createElement('iframe');
+            iframe.style.cssText = 'display:none';
+            iframe.name = 'googlefcPresent';
+            document.body.appendChild(iframe);
+          } else {
+            setTimeout(signalGooglefcPresent, 0);
+          }
+        }
+      }
+      signalGooglefcPresent();
+    })();
+  </script>
+  <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body>
   <div id="site-nav"></div>
@@ -200,7 +221,7 @@
   function load(){
     try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
   }
-  function openBanner(){ if ($banner) $banner.hidden = false; }
+  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
   function closeBanner(){ if ($banner) $banner.hidden = true; }
   function openModal(){
     if(!$modal) return;
@@ -336,6 +357,75 @@
 })();
 </script>
 <!-- === TTG Consent → Ad Visibility Controller END === -->
+<!-- === TTG CMP Consent Bridge START === -->
+<script>
+(function(){
+  // Helper: map TCF consent to our single "ads granted" flag.
+  // We consider "granted" only when Purpose 1 (storage) AND Purpose 4 (select personalised ads)
+  // are consented. If you want to allow NON-personalised ads when only Purpose 1 is granted,
+  // set allowNPA=true below.
+  var allowNPA = true; // if true, we’ll treat Purpose 1 only as "granted" for showing slots (Google will serve NPA ads).
+
+  function setAdConsent(granted){
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    // Inform any listeners (our ad loader later)
+    window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
+  }
+
+  // If Google CMP is present, it defines __tcfapi.
+  function hookTCF(){
+    if (typeof window.__tcfapi !== 'function') return false;
+
+    // Hide our local cookie banner when Google CMP is running (EEA users).
+    try{
+      var banner = document.getElementById('ttg-consent');
+      var modal  = document.getElementById('ttg-consent-modal');
+      if (banner) banner.hidden = true;
+      if (modal)  modal.hidden  = true;
+    }catch(e){}
+
+    // Listen for consent changes
+    window.__tcfapi('addEventListener', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      // Purpose 1 = storage; Purpose 4 = personalised ads
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    // Also fetch current state once
+    window.__tcfapi('getTCData', 2, function(tcData, ok){
+      if(!ok || !tcData) return;
+      var p = (tcData.purpose && tcData.purpose.consents) || {};
+      var hasP1 = !!p[1];
+      var hasP4 = !!p[4];
+      var granted = allowNPA ? hasP1 : (hasP1 && hasP4);
+      setAdConsent(granted);
+    });
+
+    return true;
+  }
+
+  // Try to hook immediately; if CMP loads a bit later, poll briefly
+  if (!hookTCF()){
+    var tries = 0, t = setInterval(function(){
+      tries++;
+      if (hookTCF() || tries > 40) clearInterval(t); // up to ~4s
+    }, 100);
+  }
+
+  // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
+  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // If CMP absent, keep existing behavior (do not force-show anything here).
+
+})();
+</script>
+<!-- === TTG CMP Consent Bridge END === -->
+
 <!-- === TTG Cookie Consent END === -->
 
 </body>


### PR DESCRIPTION
## Summary
- load the Google Funding Choices CMP bootstrap across the shared head markup so EEA/UK/CH visitors receive the certified experience.
- add the CMP consent bridge to mirror TCF signals into the existing `data-ad-consent` controller and suppress the local banner when CMP runs.
- guard the legacy banner logic so it stays hidden whenever the Google CMP provides consent handling.

## Testing
- not run (static content changes only)


------
https://chatgpt.com/codex/tasks/task_e_68dedb0c73fc8332b9e876e318778931