### PR TITLE
Add AdSense unit below Stocking Advisor hero

### DIFF
--- a/stocking.html
+++ b/stocking.html
@@ -944,12 +944,18 @@
     </header>
 
     <div class="wrap page-content">
-      <!-- === TTG AD: TOP START === -->
-      <div class="ttg-adunit ttg-adunit--top" id="ad-top-1" data-ad-slot="top-1" aria-label="Advertisement">
-        <!-- AdSense will mount here when approved -->
-        <span>Ad — Top placeholder</span>
+      <!-- === TTG_StockingTop (under hero/blurb) === -->
+      <div class="ttg-adunit ttg-adunit--top" id="ad-top-1" aria-label="Advertisement">
+        <ins class="adsbygoogle"
+             style="display:block"
+             data-ad-client="ca-pub-9905718149811880"
+             data-ad-slot="8419879326"
+             data-ad-format="auto"
+             data-full-width-responsive="true"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
       </div>
-      <!-- === TTG AD: TOP END === -->
 
       <!-- Tank Size card -->
       <div class="card ttg-card tank-size-card" id="tank-size-card">


### PR DESCRIPTION
## Summary
- replace the placeholder ad container beneath the Stocking Advisor hero with the live Google AdSense unit

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dede3457388332947f786b8e8681eb