### PR TITLE
Add TTG StockingBottom ad unit to stocking page

### DIFF
--- a/stocking.html
+++ b/stocking.html
@@ -1301,6 +1301,19 @@
         </div>
       </section>
 
+      <!-- === TTG_StockingBottom (post-results, before final blurb) === -->
+      <div class="ttg-adunit ttg-adunit--bottom" id="ad-bottom-1" aria-label="Advertisement">
+        <ins class="adsbygoogle"
+             style="display:block"
+             data-ad-client="ca-pub-9905718149811880"
+             data-ad-slot="8979116676"
+             data-ad-format="auto"
+             data-full-width-responsive="true"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
+      </div>
+
       <section class="panel" aria-labelledby="stock-title">
         <h2 id="stock-title">Plan Your Stock</h2>
         <div class="stock-grid">
@@ -1341,13 +1354,6 @@
           </div>
         </div>
       </section>
-
-      <!-- === TTG AD: POST-RESULTS START === -->
-      <div class="ttg-adunit ttg-adunit--bottom" id="ad-bottom-1" data-ad-slot="post-results-1" aria-label="Advertisement">
-        <!-- AdSense will mount here when approved -->
-        <span>Ad — Post-results placeholder</span>
-      </div>
-      <!-- === TTG AD: POST-RESULTS END === -->
 
       <button class="see-gear" id="btn-gear" type="button" data-testid="btn-gear">See Gear Suggestions</button>
 


### PR DESCRIPTION
## Summary
- insert the TTG_StockingBottom AdSense unit immediately after the results container on stocking.html and remove the placeholder block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee57b36408332be1ad44dace2b209