### PR TITLE
Add TTG gear bottom ad unit

### DIFF
--- a/gear/index.html
+++ b/gear/index.html
@@ -41,6 +41,18 @@
   <div id="site-nav"></div>
   <main id="gear-main">
     <div id="gear-root" data-testid="gear-root"></div>
+    <!-- === TTG_GearBottom (before footer) === -->
+    <div class="ttg-adunit ttg-adunit--bottom" id="ad-bottom-gear" aria-label="Advertisement">
+      <ins class="adsbygoogle"
+           style="display:block"
+           data-ad-client="ca-pub-9905718149811880"
+           data-ad-slot="1762971638"
+           data-ad-format="auto"
+           data-full-width-responsive="true"></ins>
+      <script>
+           (adsbygoogle = window.adsbygoogle || []).push({});
+      </script>
+    </div>
   </main>
   <script type="module" src="/src/pages/GearPage.js"></script>
 <!-- === TTG Cookie Consent START === -->


### PR DESCRIPTION
## Summary
- insert the TTG_GearBottom AdSense unit after the gear listings container so it renders before the footer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee9a1972483328f22ca1018950ecc