### PR TITLE
Add Params page top AdSense unit

### DIFF
--- a/params.html
+++ b/params.html
@@ -567,12 +567,18 @@
         <p class="cc-title__subline">Enter today’s readings for a clear snapshot.</p>
       </section>
 
-      <!-- === TTG AD: TOP START === -->
-      <div class="ttg-adunit ttg-adunit--top" id="ad-top-1" data-ad-slot="top-1" aria-label="Advertisement">
-        <!-- AdSense will mount here when approved -->
-        <span>Ad — Top placeholder</span>
+      <!-- === TTG_ParamsTop (under hero/blurb) === -->
+      <div class="ttg-adunit ttg-adunit--top" id="ad-top-params" aria-label="Advertisement">
+        <ins class="adsbygoogle"
+          style="display:block"
+          data-ad-client="ca-pub-9905718149811880"
+          data-ad-slot="8136808291"
+          data-ad-format="auto"
+          data-full-width-responsive="true"></ins>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
       </div>
-      <!-- === TTG AD: TOP END === -->
 
       <section class="card" aria-labelledby="inputs-heading">
         <div class="card__header">


### PR DESCRIPTION
## Summary
- replace the placeholder top advertisement slot on `params.html` with the TTG_ParamsTop AdSense unit
- mount the new unit immediately beneath the Cycling Coach hero blurb before the inputs begin

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deead378e88332bfa01c0ae80404c9