### PR TITLE
Add params bottom ad unit

### DIFF
--- a/params.html
+++ b/params.html
@@ -655,12 +655,18 @@
         </div>
       </section>
 
-      <!-- === TTG AD: POST-RESULTS START === -->
-      <div class="ttg-adunit ttg-adunit--bottom" id="ad-bottom-1" data-ad-slot="post-results-1" aria-label="Advertisement">
-        <!-- AdSense will mount here when approved -->
-        <span>Ad — Post-results placeholder</span>
+      <!-- === TTG_ParamsBottom (post-results, before educational blurb) === -->
+      <div class="ttg-adunit ttg-adunit--bottom" id="ad-bottom-params" aria-label="Advertisement">
+        <ins class="adsbygoogle"
+          style="display:block"
+          data-ad-client="ca-pub-9905718149811880"
+          data-ad-slot="5754828160"
+          data-ad-format="auto"
+          data-full-width-responsive="true"></ins>
+        <script>
+          (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
       </div>
-      <!-- === TTG AD: POST-RESULTS END === -->
 
       <section class="card" id="challengeCard" aria-labelledby="challenge-heading" hidden>
         <div class="card__header">


### PR DESCRIPTION
## Summary
- replace the placeholder post-results ad container with the TTG_ParamsBottom ad unit on params.html
- ensure the new ad sits after the results/status section and before the educational blurb without adding another loader script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deee8f1fdc8332a94aeb57ecc39403