### PR TITLE
Add GA4 ad slot view tracking helper

### DIFF
--- a/docs/adsense-performance-tracking.md
+++ b/docs/adsense-performance-tracking.md
@@ -1,0 +1,60 @@
+# AdSense Performance Tracking Setup
+
+This document summarizes the workflow for breaking down ad performance by placement and correlating it with analytics data.
+
+## 1. Ad unit names
+
+All ad units in AdSense already follow the naming convention below, which makes it easy to assign them to placement groups:
+
+- `TTG_StockingTop` → slot `8419879326`
+- `TTG_StockingBottom` → slot `8979116676`
+- `TTG_ParamsTop` → slot `8136808291`
+- `TTG_ParamsBottom` → slot `5754828160`
+- `TTG_GearTop` → slot `7692943403`
+- `TTG_GearBottom` → slot `1762971638`
+- `TTG_MediaBottom` → slot `9522042154`
+
+## 2. Custom channels (AdSense UI)
+
+Create a **custom channel** for each placement grouping so you can compare RPM/CTR/impressions across your layouts:
+
+1. Go to **AdSense → Brand Safety & Blocks → Manage → Custom channels** (or **Ads → By ad unit → Custom channels**).
+2. Create the channels below and add the specified ad units to each:
+   - `TTG_TopTool`: StockingTop, ParamsTop, GearTop
+   - `TTG_PostResultsTool`: StockingBottom, ParamsBottom
+   - `TTG_MediaBottom`: MediaBottom
+
+Once these channels collect data you can break down reports by placement group and optionally drill down to individual ad units as a secondary dimension.
+
+## 3. URL groups (optional)
+
+Set up URL groups if you want to filter AdSense reports by tool/page type:
+
+- `/stocking.html`
+- `/params.html`
+- `/gear.html`
+- `/media.html`
+
+## 4. Link AdSense to GA4 (recommended)
+
+Linking AdSense with GA4 unlocks page-level revenue data in Analytics:
+
+- In **AdSense**: `Account → Access and authorization → Google Analytics` and link the GA4 property.
+- In **GA4**: `Admin → Product Links → AdSense` and complete the link wizard.
+
+After the link is active you can combine AdSense revenue with GA4 events to see which tool flows correlate with higher monetization.
+
+## 5. GA4 slot view events (implemented in code)
+
+We now emit a lightweight GA4 event when ad containers become at least 25% visible in the viewport. Events are sent only when `gtag` is present on the page.
+
+File: [`/js/ad-slot-view-tracking.js`](../js/ad-slot-view-tracking.js)
+
+Covered slots:
+
+- Stocking top & bottom (`ad-top-1`, `ad-bottom-1`)
+- Params top & bottom (`ad-top-params`, `ad-bottom-params`)
+- Gear top & bottom (`ad-top-gear`, `ad-bottom-gear`)
+- Media bottom (`ad-media-bottom-1`)
+
+Use the GA4 event `ad_slot_view` with the `label` parameter to inspect viewability context alongside AdSense revenue once the integration is active.

--- a/gear/index.html
+++ b/gear/index.html
@@ -362,5 +362,8 @@
   } catch (e) { console.error('[Footer] load failed:', e); }
 })();
 </script>
+<!-- === TTG Ad Slot View Tracking START === -->
+<script src="/js/ad-slot-view-tracking.js"></script>
+<!-- === TTG Ad Slot View Tracking END === -->
 </body>
 </html>

--- a/js/ad-slot-view-tracking.js
+++ b/js/ad-slot-view-tracking.js
@@ -1,0 +1,58 @@
+(function(){
+  if (!('IntersectionObserver' in window)) {
+    return;
+  }
+
+  function initObserver(el, label) {
+    if (!el) {
+      return false;
+    }
+
+    var seen = false;
+    var observer = new IntersectionObserver(function(entries, obs){
+      entries.forEach(function(entry){
+        if (!seen && entry.isIntersecting) {
+          seen = true;
+          obs.disconnect();
+          if (typeof window.gtag === 'function') {
+            window.gtag('event', 'ad_slot_view', {
+              slot_id: el.id,
+              label: label
+            });
+          }
+        }
+      });
+    }, { threshold: 0.25 });
+
+    observer.observe(el);
+    return true;
+  }
+
+  function track(id, label) {
+    if (initObserver(document.getElementById(id), label)) {
+      return;
+    }
+
+    var attempts = 0;
+    var timer = setInterval(function(){
+      attempts += 1;
+      if (initObserver(document.getElementById(id), label) || attempts > 40) {
+        clearInterval(timer);
+      }
+    }, 250);
+  }
+
+  var slots = [
+    { id: 'ad-top-1', label: 'StockingTop' },
+    { id: 'ad-bottom-1', label: 'StockingBottom' },
+    { id: 'ad-top-params', label: 'ParamsTop' },
+    { id: 'ad-bottom-params', label: 'ParamsBottom' },
+    { id: 'ad-top-gear', label: 'GearTop' },
+    { id: 'ad-bottom-gear', label: 'GearBottom' },
+    { id: 'ad-media-bottom-1', label: 'MediaBottom' }
+  ];
+
+  slots.forEach(function(slot){
+    track(slot.id, slot.label);
+  });
+})();

--- a/media.html
+++ b/media.html
@@ -806,5 +806,9 @@
 
 <!-- === TTG Cookie Consent END === -->
 
+<!-- === TTG Ad Slot View Tracking START === -->
+<script src="/js/ad-slot-view-tracking.js"></script>
+<!-- === TTG Ad Slot View Tracking END === -->
+
 </body>
 </html>

--- a/params.html
+++ b/params.html
@@ -1036,5 +1036,9 @@
 
 <!-- === TTG Cookie Consent END === -->
 
+<!-- === TTG Ad Slot View Tracking START === -->
+<script src="/js/ad-slot-view-tracking.js"></script>
+<!-- === TTG Ad Slot View Tracking END === -->
+
 </body>
 </html>

--- a/stocking.html
+++ b/stocking.html
@@ -1673,5 +1673,9 @@
 
 <!-- === TTG Cookie Consent END === -->
 
+<!-- === TTG Ad Slot View Tracking START === -->
+<script src="/js/ad-slot-view-tracking.js"></script>
+<!-- === TTG Ad Slot View Tracking END === -->
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a shared helper to emit GA4 `ad_slot_view` events when ad placements reach 25% visibility
- load the helper on stocking, params, gear, and media pages so each slot reports its placement label
- document the AdSense custom channel and GA4 linkage workflow for future reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df049ba5e48332af748a62bb8a6bb0