### PR TITLE
Fix navigation links and CTA targets

### DIFF
--- a/about.html
+++ b/about.html
@@ -253,10 +253,11 @@
     }
   ],
   "sameAs": [
-    "https://www.instagram.com/fishkeepinglifeco/",
-    "https://www.tiktok.com/@fishkeepinglifeco",
-    "https://www.youtube.com/@fishkeepinglifeco",
+    "https://www.instagram.com/FishKeepingLifeCo",
+    "https://www.tiktok.com/@FishKeepingLifeCo",
     "https://www.facebook.com/fishkeepinglifeco",
+    "https://x.com/fishkeepinglife?s=21",
+    "https://www.youtube.com/@fishkeepinglifeco",
     "https://www.amazon.com/author/fishkeepinglifeco"
   ]
 }
@@ -371,7 +372,7 @@
           </div>
         </div>
       </section>
-      <p class="about-feedback"><a href="contact-feedback.html">Send feedback</a></p>
+      <p class="about-feedback"><a href="/contact-feedback.html">Contact &amp; Feedback</a></p>
     </div>
   </main>
 

--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -285,10 +285,10 @@
       }
     ],
     "sameAs": [
-      "https://www.instagram.com/fishkeepinglifeco/",
-      "https://www.tiktok.com/@fishkeepinglifeco",
+      "https://www.instagram.com/FishKeepingLifeCo",
+      "https://www.tiktok.com/@FishKeepingLifeCo",
       "https://www.facebook.com/fishkeepinglifeco",
-      "https://x.com/fishkeepinglife",
+      "https://x.com/fishkeepinglife?s=21",
       "https://www.youtube.com/@fishkeepinglifeco",
       "https://www.amazon.com/author/fishkeepinglifeco"
     ]

--- a/gear.html
+++ b/gear.html
@@ -30,7 +30,10 @@
   <!-- --- Google CMP (Funding Choices) END --- -->
 </head>
 <body>
-  <p>Redirecting to the updated Gear Guide… <a href="/gear/">Continue</a></p>
+  <main>
+    <h1>Build Your Perfect Setup</h1>
+    <p>Redirecting to the updated Gear Guide… <a href="/gear/">Continue</a></p>
+  </main>
   <script>window.location.replace('/gear/');</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -133,10 +133,11 @@
     }
   ],
   "sameAs": [
-    "https://www.instagram.com/fishkeepinglifeco/",
-    "https://www.tiktok.com/@fishkeepinglifeco",
-    "https://www.youtube.com/@fishkeepinglifeco",
+    "https://www.instagram.com/FishKeepingLifeCo",
+    "https://www.tiktok.com/@FishKeepingLifeCo",
     "https://www.facebook.com/fishkeepinglifeco",
+    "https://x.com/fishkeepinglife?s=21",
+    "https://www.youtube.com/@fishkeepinglifeco",
     "https://www.amazon.com/author/fishkeepinglifeco"
   ]
 }
@@ -223,7 +224,7 @@
               Questions, ideas, or spot a logic issue? Reach out with feedback, recommend fish or gear to review, or share your insights.
             </p>
             <div class="actions">
-              <a class="btn" href="/contact-feedback.html" aria-label="Open Contact form">Contact Us</a>
+              <a class="btn" href="/contact-feedback.html" aria-label="Open Contact form">Contact &amp; Feedback</a>
             </div>
           </article>
         </div>

--- a/media.html
+++ b/media.html
@@ -300,10 +300,11 @@
     }
   ],
   "sameAs": [
-    "https://www.instagram.com/fishkeepinglifeco/",
-    "https://www.tiktok.com/@fishkeepinglifeco",
-    "https://www.youtube.com/@fishkeepinglifeco",
+    "https://www.instagram.com/FishKeepingLifeCo",
+    "https://www.tiktok.com/@FishKeepingLifeCo",
     "https://www.facebook.com/fishkeepinglifeco",
+    "https://x.com/fishkeepinglife?s=21",
+    "https://www.youtube.com/@fishkeepinglifeco",
     "https://www.amazon.com/author/fishkeepinglifeco"
   ]
 }
@@ -389,7 +390,7 @@
             Our official intro — The Tank Guide, a product of FishKeepingLifeCo. Explore aquarium tools like the Stocking Advisor, along with setup tips, care guides, and resources to help every aquarist, from beginner tanks to advanced planted aquariums.
           </p>
           <div class="video-actions">
-            <a class="yt-cta" href="https://www.youtube.com/@FishKeepingLifeCo" target="_blank" rel="noopener" title="Visit FishKeepingLifeCo on YouTube" aria-label="Visit FishKeepingLifeCo on YouTube">
+            <a class="yt-cta" href="https://www.youtube.com/@FishKeepingLifeCo" target="_blank" rel="noopener noreferrer" title="Visit FishKeepingLifeCo on YouTube" aria-label="Visit FishKeepingLifeCo on YouTube">
               <span class="yt-icon" aria-hidden="true">
                 <svg class="yt-cta-svg" viewBox="0 0 24 24" width="20" height="20" focusable="false" aria-hidden="true">
                   <path d="M9 7v10l8-5z" fill="#fff"></path>
@@ -417,8 +418,8 @@
             </p>
             <div class="media-thumb" aria-label="Featured tank placeholder">Featured tank thumbnail (placeholder)</div>
             <div class="row" style="justify-content:space-between; align-items:center; gap:10px;">
-              <a class="btn" href="/featured-tanks.html">See More Tanks</a>
-              <a class="btn" href="/submit-tank.html">Submit Your Tank</a>
+              <a class="btn" href="/media.html">Explore Media</a>
+              <a class="btn" href="/feature-your-tank.html">Submit Your Tank</a>
             </div>
           </article>
 
@@ -440,7 +441,7 @@
               ></iframe>
             </div>
             <h3 class="card-subtitle community-video-title">Make a Freshwater Aquarium Sump</h3>
-            <p class="muted community-video-attribution">by <a href="https://youtube.com/@serpadesign" target="_blank" rel="noopener">@SerpaDesign</a></p>
+            <p class="muted community-video-attribution">by <a href="https://youtube.com/@serpadesign" target="_blank" rel="noopener noreferrer">@SerpaDesign</a></p>
             <hr class="media-divider" />
             <p>
               Recommended by a community member: I chose this video because I used it as a bible to create my sump. I watched it
@@ -452,7 +453,7 @@
               a fantastic place to start.
             </p>
             <div class="community-video-cta">
-              <a class="yt-cta" href="https://www.youtube.com/watch?v=zX3wGQpC4eE" target="_blank" rel="noopener" title="Watch Make a Freshwater Aquarium Sump on YouTube" aria-label="Watch Make a Freshwater Aquarium Sump on YouTube">
+              <a class="yt-cta" href="https://www.youtube.com/watch?v=zX3wGQpC4eE" target="_blank" rel="noopener noreferrer" title="Watch Make a Freshwater Aquarium Sump on YouTube" aria-label="Watch Make a Freshwater Aquarium Sump on YouTube">
                 <span class="yt-icon" aria-hidden="true">
                   <svg class="yt-cta-svg" viewBox="0 0 24 24" width="20" height="20" focusable="false" aria-hidden="true">
                     <path d="M9 7v10l8-5z" fill="#fff"></path>
@@ -472,7 +473,7 @@
           <div class="library-item">
             <h3>Mission &amp; Values</h3>
             <p class="muted">Explore the values behind FishKeepingLifeCo: clear guidance, hands-on learning, responsible care, and a supportive fishkeeping community.</p>
-            <p><a class="btn" href="/about.html#mission">Read Our Mission</a></p>
+            <p><a class="btn" href="/about.html#sec-mission">Read Our Mission</a></p>
           </div>
         </article>
       </div>

--- a/nav.html
+++ b/nav.html
@@ -12,21 +12,23 @@
       <span class="hamburger__bars" aria-hidden="true"></span>
       <span class="visually-hidden">Open menu</span>
     </button>
-    <a class="site-brand brand" href="/" aria-label="The Tank Guide — Home">
+    <a class="site-brand brand" href="/index.html" aria-label="The Tank Guide — Home">
       <span class="site-brand__title">The Tank Guide</span>
       <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
     </a>
     <nav class="site-links links" aria-label="Primary">
       <ul class="nav__list">
-        <li class="nav__item"><a href="/" class="nav__link">Home</a></li>
-        <li class="nav__item"><a href="/stocking-advisor" class="nav__link">Stocking Advisor</a></li>
-        <li class="nav__item"><a href="/gear/" class="nav__link">Gear</a></li>
-        <li class="nav__item"><a href="/cycling-coach" class="nav__link">Cycling Coach</a></li>
+        <li class="nav__item"><a href="/index.html" class="nav__link">Home</a></li>
+        <li class="nav__item"><a href="/stocking.html" class="nav__link">Stocking Advisor</a></li>
+        <li class="nav__item"><a href="/gear.html" class="nav__link">Gear</a></li>
+        <li class="nav__item"><a href="/cycling-coach.html" class="nav__link">Cycling Coach</a></li>
         <li class="nav__item"><a href="/media.html" class="nav__link">Media</a></li>
-        <li class="nav__item"><a href="/feature-your-tank" class="nav__link">Feature Your Tank</a></li>
-        <li class="nav__item"><a href="/store" class="nav__link">Store</a></li>
-        <li class="nav__item"><a href="/contact" class="nav__link">Contact &amp; Feedback</a></li>
-        <li class="nav__item"><a href="/about" class="nav__link">About</a></li>
+        <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link">Feature Your Tank</a></li>
+        <li class="nav__item"><a href="/contact-feedback.html" class="nav__link">Contact &amp; Feedback</a></li>
+        <li class="nav__item"><a href="/about.html" class="nav__link">About</a></li>
+        <li class="nav__item"><a href="/privacy-legal.html" class="nav__link">Privacy &amp; Legal</a></li>
+        <li class="nav__item"><a href="/terms.html" class="nav__link">Terms of Use</a></li>
+        <li class="nav__item"><a href="/copyright-dmca.html" class="nav__link">Copyright &amp; DMCA</a></li>
       </ul>
     </nav>
   </div>
@@ -39,15 +41,17 @@
     </div>
     <nav class="drawer-links" aria-label="Mobile">
       <ul class="nav__list nav__list--drawer">
-        <li class="nav__item"><a href="/" class="nav__link">Home</a></li>
-        <li class="nav__item"><a href="/stocking-advisor" class="nav__link">Stocking Advisor</a></li>
-        <li class="nav__item"><a href="/gear/" class="nav__link">Gear</a></li>
-        <li class="nav__item"><a href="/cycling-coach" class="nav__link">Cycling Coach</a></li>
+        <li class="nav__item"><a href="/index.html" class="nav__link">Home</a></li>
+        <li class="nav__item"><a href="/stocking.html" class="nav__link">Stocking Advisor</a></li>
+        <li class="nav__item"><a href="/gear.html" class="nav__link">Gear</a></li>
+        <li class="nav__item"><a href="/cycling-coach.html" class="nav__link">Cycling Coach</a></li>
         <li class="nav__item"><a href="/media.html" class="nav__link">Media</a></li>
-        <li class="nav__item"><a href="/feature-your-tank" class="nav__link">Feature Your Tank</a></li>
-        <li class="nav__item"><a href="/store" class="nav__link">Store</a></li>
-        <li class="nav__item"><a href="/contact" class="nav__link">Contact &amp; Feedback</a></li>
-        <li class="nav__item"><a href="/about" class="nav__link">About</a></li>
+        <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link">Feature Your Tank</a></li>
+        <li class="nav__item"><a href="/contact-feedback.html" class="nav__link">Contact &amp; Feedback</a></li>
+        <li class="nav__item"><a href="/about.html" class="nav__link">About</a></li>
+        <li class="nav__item"><a href="/privacy-legal.html" class="nav__link">Privacy &amp; Legal</a></li>
+        <li class="nav__item"><a href="/terms.html" class="nav__link">Terms of Use</a></li>
+        <li class="nav__item"><a href="/copyright-dmca.html" class="nav__link">Copyright &amp; DMCA</a></li>
       </ul>
     </nav>
   </aside>

--- a/params.html
+++ b/params.html
@@ -520,10 +520,11 @@
     }
   ],
   "sameAs": [
-    "https://www.instagram.com/fishkeepinglifeco/",
-    "https://www.tiktok.com/@fishkeepinglifeco",
-    "https://www.youtube.com/@fishkeepinglifeco",
+    "https://www.instagram.com/FishKeepingLifeCo",
+    "https://www.tiktok.com/@FishKeepingLifeCo",
     "https://www.facebook.com/fishkeepinglifeco",
+    "https://x.com/fishkeepinglife?s=21",
+    "https://www.youtube.com/@fishkeepinglifeco",
     "https://www.amazon.com/author/fishkeepinglifeco"
   ]
 }

--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -306,10 +306,11 @@
   "image": "https://thetankguide.com/logo.png",
   "foundingLocation": "United States, New York",
   "sameAs": [
-    "https://www.instagram.com/fishkeepinglifeco/",
-    "https://www.tiktok.com/@fishkeepinglifeco",
-    "https://www.youtube.com/@fishkeepinglifeco",
+    "https://www.instagram.com/FishKeepingLifeCo",
+    "https://www.tiktok.com/@FishKeepingLifeCo",
     "https://www.facebook.com/fishkeepinglifeco",
+    "https://x.com/fishkeepinglife?s=21",
+    "https://www.youtube.com/@fishkeepinglifeco",
     "https://www.amazon.com/author/fishkeepinglifeco"
   ]
 }


### PR DESCRIPTION
## Summary
- update the site navigation and drawer links to use the audited .html slugs and include the legal destinations
- align CTA labels and targets across the homepage, about page, media hub, and gear redirect fallback
- normalize Organization JSON-LD sameAs profiles and external link rel attributes for consistency with the footer

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68df10ceecac8332b08016be71fd11d4