### PR TITLE
Relocate stocking bottom ad unit

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -1,4 +1,5 @@
 /* unified header with right-aligned toggle */
+.adsbygoogle { margin: 20px auto; display: block; }
 .card__hd--split { display:flex; align-items:center; justify-content:space-between; gap:12px; }
 .linklike { background:none; border:0; padding:0; color:var(--link, #87b4ff); font:inherit; cursor:pointer; }
 .linklike:focus { outline:2px solid rgba(255,255,255,.35); outline-offset:2px; border-radius:6px; }

--- a/stocking.html
+++ b/stocking.html
@@ -1301,19 +1301,6 @@
         </div>
       </section>
 
-      <!-- === TTG_StockingBottom (post-results, before final blurb) === -->
-      <div class="ttg-adunit ttg-adunit--bottom" id="ad-bottom-1" aria-label="Advertisement">
-        <ins class="adsbygoogle"
-             style="display:block"
-             data-ad-client="ca-pub-9905718149811880"
-             data-ad-slot="8979116676"
-             data-ad-format="auto"
-             data-full-width-responsive="true"></ins>
-        <script>
-             (adsbygoogle = window.adsbygoogle || []).push({});
-        </script>
-      </div>
-
       <section class="panel" aria-labelledby="stock-title">
         <h2 id="stock-title">Plan Your Stock</h2>
         <div class="stock-grid">
@@ -1355,13 +1342,26 @@
         </div>
       </section>
 
-      <button class="see-gear" id="btn-gear" type="button" data-testid="btn-gear">See Gear Suggestions</button>
-
       <div id="bioload-tip" class="ui-tip" data-role="info-tip" role="tooltip" hidden>
         Approximate stocking level for your tank size. Stay in green for better stability.
       </div>
       <div id="aggression-tip" class="ui-tip" data-role="info-tip" role="tooltip" hidden>
         Estimated compatibility risk. Adding aggressive or territorial species will raise this.
+      </div>
+
+      <button class="see-gear" id="btn-gear" type="button" data-testid="btn-gear">See Gear Suggestions</button>
+
+      <!-- === TTG_StockingBottom (post-results, before footer) === -->
+      <div class="ttg-adunit ttg-adunit--bottom" id="ad-bottom-1" aria-label="Advertisement">
+        <ins class="adsbygoogle"
+             style="display:block"
+             data-ad-client="ca-pub-9905718149811880"
+             data-ad-slot="8979116676"
+             data-ad-format="auto"
+             data-full-width-responsive="true"></ins>
+        <script>
+             (adsbygoogle = window.adsbygoogle || []).push({});
+        </script>
       </div>
 
     </div>


### PR DESCRIPTION
## Summary
- move the TTG_StockingBottom AdSense unit below the See Gear Suggestions button so it sits above the footer include
- add a shared .adsbygoogle rule to space and center AdSense blocks across the site

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df1457385c8332ba1ab91e87993840