### PR TITLE
Configure Playwright tests and scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "npx playwright test",
+    "pw:install": "playwright install --with-deps",
+    "test": "playwright test",
+    "test:consent": "playwright test tests/consent-ads.spec.ts --project=chromium",
+    "serve:static": "npx http-server -p 8080 -c-1 .",
     "test:headed": "npx playwright test --headed",
     "test:debug": "npx playwright test --debug",
     "test:report": "npx playwright show-report"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: 'tests',
+  timeout: 60000,
+  expect: { timeout: 10000 },
+  reporter: [
+    ['list'],
+    ['html', { outputFolder: 'playwright-report', open: 'never' }]
+  ],
+  use: {
+    baseURL: process.env.TTG_BASE_URL ?? 'http://localhost:8080',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'off'
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'firefox',  use: { ...devices['Desktop Firefox'] } },
+    { name: 'webkit',   use: { ...devices['Desktop Safari'] } }
+  ]
+});


### PR DESCRIPTION
## Summary
- add a TypeScript Playwright configuration with chromium/firefox/webkit projects and shared test settings
- update package scripts to support installing Playwright deps, running the consent audit, and serving static content

## Testing
- npm i -D @playwright/test http-server *(fails: registry access returns 403 Forbidden)*
- npm run pw:install *(fails: apt repositories blocked by proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68df2b06e4308332991eaefaeb958264