### PR TITLE
Implement Google Consent Mode v2 consent handling

### DIFF
--- a/about.html
+++ b/about.html
@@ -469,7 +469,7 @@
     })();
   </script>
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -507,184 +507,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -697,6 +524,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -709,7 +537,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -747,7 +575,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();

--- a/assets/js/consent-banner.js
+++ b/assets/js/consent-banner.js
@@ -1,0 +1,215 @@
+(function(){
+  var STORE_KEY = 'ttgConsentV2';
+  var EXP_DAYS = 365;
+  var MS_PER_DAY = 24*60*60*1000;
+
+  function now(){ return Date.now(); }
+  function persist(consent){
+    try {
+      localStorage.setItem(STORE_KEY, JSON.stringify(consent));
+      document.cookie = STORE_KEY + '=1; Max-Age=' + (EXP_DAYS*24*3600) + '; Path=/; SameSite=Lax';
+    } catch (e) {}
+  }
+  function erase(){
+    try {
+      localStorage.removeItem(STORE_KEY);
+      document.cookie = STORE_KEY + '=; Max-Age=0; Path=/; SameSite=Lax';
+    } catch (e) {}
+  }
+  function load(){
+    try {
+      var raw = localStorage.getItem(STORE_KEY);
+      if (!raw) return null;
+      var parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object') return null;
+      if ((now() - (parsed.ts || 0)) > EXP_DAYS * MS_PER_DAY) return null;
+      return parsed;
+    } catch (e) {
+      return null;
+    }
+  }
+
+  var regionParam = new URLSearchParams(location.search).get('region');
+  var tz = (Intl.DateTimeFormat().resolvedOptions().timeZone || '').toLowerCase();
+  var tzHintsEU = /(europe\/|gmt|bst|cet|cest)/.test(tz);
+  var inEEA = regionParam ? ['AT','BE','BG','HR','CY','CZ','DK','EE','FI','FR','DE','GR','HU','IE','IT','LV','LT','LU','MT','NL','PL','PT','RO','SK','SI','ES','SE','IS','LI','NO','GB','CH'].indexOf(regionParam.toUpperCase()) !== -1 : tzHintsEU;
+  var defaultGranted = !inEEA;
+
+  var banner = document.querySelector('[data-consent-banner]');
+  var modal = document.getElementById('ttg-consent-modal');
+  var manageBtn = document.getElementById('ttg-consent-manage');
+  var cancelBtn = document.getElementById('ttg-consent-cancel');
+  var form = document.getElementById('ttg-consent-form');
+  var rows = form ? Array.from(form.querySelectorAll('.ttg-row')) : [];
+  var ckAnalytics = document.getElementById('ttg-c-analytics');
+  var ckAds = document.getElementById('ttg-c-ads');
+  var status = form ? form.querySelector('.ttg-consent-status') : null;
+  if (form && !status){
+    status = document.createElement('p');
+    status.className = 'ttg-consent-status';
+    form.appendChild(status);
+  }
+
+  function toggleBanner(open){
+    if (!banner) return;
+    banner.classList.toggle('is-open', !!open);
+  }
+  function openBanner(){ toggleBanner(true); }
+  function closeBanner(){ toggleBanner(false); }
+
+  function openModal(){
+    if (!modal) return;
+    modal.hidden = false;
+    applyFormFromConsent();
+  }
+  function closeModal(){ if (modal) modal.hidden = true; }
+
+  function consentToForm(consent){
+    if (!consent){
+      return { analytics: false, ads: false };
+    }
+    return {
+      analytics: consent.analytics_storage === 'granted',
+      ads: consent.ad_personalization === 'granted'
+    };
+  }
+
+  function updateStatus(){
+    if (!status) return;
+    var analytics = ckAnalytics ? !!ckAnalytics.checked : false;
+    var ads = ckAds ? !!ckAds.checked : false;
+    status.hidden = false;
+    status.textContent = 'Current: Analytics ' + (analytics ? 'ON' : 'OFF') + ' • Personalized Ads ' + (ads ? 'ON' : 'OFF');
+  }
+
+  function applyFormFromConsent(){
+    var consent = load();
+    var formState = consentToForm(consent);
+    if (ckAnalytics) ckAnalytics.checked = !!formState.analytics;
+    if (ckAds) ckAds.checked = !!formState.ads;
+    updateStatus();
+  }
+
+  function consentFromForm(){
+    var analytics = ckAnalytics ? !!ckAnalytics.checked : false;
+    var ads = ckAds ? !!ckAds.checked : false;
+    return {
+      ad_storage: 'granted',
+      analytics_storage: analytics ? 'granted' : 'denied',
+      ad_user_data: ads ? 'granted' : 'denied',
+      ad_personalization: ads ? 'granted' : 'denied',
+      ts: now()
+    };
+  }
+
+  function dispatchConsent(granted, consent){
+    try {
+      window.dispatchEvent(new CustomEvent('ttg:consent-change', { detail: { granted: granted, consent: consent || null } }));
+    } catch (e) {}
+  }
+
+  function applyDocumentConsent(consent){
+    var granted = false;
+    if (consent){
+      granted = consent.ad_storage === 'granted';
+    } else {
+      granted = defaultGranted;
+    }
+    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
+    document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
+    dispatchConsent(granted, consent);
+  }
+
+  rows.forEach(function(row){
+    row.addEventListener('click', function(evt){
+      var target = evt.target;
+      var cb = row.querySelector('input[type="checkbox"]');
+      if (!cb || cb.disabled) return;
+      if (target && target.tagName && target.tagName.toLowerCase() !== 'input'){
+        cb.checked = !cb.checked;
+      }
+      updateStatus();
+    });
+  });
+
+  if (ckAnalytics) ckAnalytics.addEventListener('change', updateStatus);
+  if (ckAds) ckAds.addEventListener('change', updateStatus);
+
+  if (manageBtn) manageBtn.addEventListener('click', function(){ openModal(); });
+  if (cancelBtn) cancelBtn.addEventListener('click', function(){ closeModal(); });
+
+  if (modal) modal.addEventListener('click', function(evt){
+    if (evt.target === modal) closeModal();
+  });
+
+  document.addEventListener('keydown', function(evt){
+    if (evt.key === 'Escape' && modal && !modal.hidden){
+      closeModal();
+    }
+  });
+
+  if (form) form.addEventListener('submit', function(evt){
+    evt.preventDefault();
+    var consent = consentFromForm();
+    if (typeof window.gtag === 'function'){
+      window.gtag('consent', 'update', consent);
+    }
+    persist(consent);
+    applyDocumentConsent(consent);
+    closeModal();
+    closeBanner();
+  });
+
+  function syncFromStorage(){
+    var consent = load();
+    applyDocumentConsent(consent);
+    applyFormFromConsent();
+  }
+
+  function afterChoice(){
+    setTimeout(syncFromStorage, 0);
+  }
+
+  document.querySelectorAll('.js-consent-accept').forEach(function(btn){
+    btn.addEventListener('click', function(){
+      afterChoice();
+    });
+  });
+  document.querySelectorAll('.js-consent-reject').forEach(function(btn){
+    btn.addEventListener('click', function(){
+      afterChoice();
+    });
+  });
+
+  window.addEventListener('storage', function(evt){
+    if (evt.key === STORE_KEY){
+      syncFromStorage();
+    }
+  });
+
+  window.cookieConsent = {
+    open: function(){
+      openBanner();
+      openModal();
+    },
+    reset: function(){
+      erase();
+      var deniedState = {
+        ad_storage: 'denied',
+        analytics_storage: 'denied',
+        ad_user_data: 'denied',
+        ad_personalization: 'denied',
+        ts: now()
+      };
+      if (typeof window.gtag === 'function'){
+        window.gtag('consent', 'update', deniedState);
+      }
+      applyDocumentConsent(null);
+      closeModal();
+      openBanner();
+    }
+  };
+
+  syncFromStorage();
+})();

--- a/assets/js/consent-mode.js
+++ b/assets/js/consent-mode.js
@@ -1,67 +1,86 @@
-// ---------- Google Consent Mode v2: defaults + handlers ----------
 (function () {
-  // Create dataLayer/gtag stub early
+  var STORE_KEY = 'ttgConsentV2';
+  var EXP_DAYS  = 365;
+  function now(){ return Date.now(); }
+  function saveConsent(obj){
+    try {
+      localStorage.setItem(STORE_KEY, JSON.stringify(obj));
+      document.cookie = STORE_KEY + '=1; Max-Age=' + (EXP_DAYS*24*3600) + '; Path=/; SameSite=Lax';
+    } catch(e){}
+  }
+  function loadConsent(){
+    try {
+      var v = JSON.parse(localStorage.getItem(STORE_KEY) || 'null');
+      if (!v) return null;
+      if ((now() - (v.ts||0)) > EXP_DAYS*24*3600*1000) return null;
+      return v;
+    } catch(e){ return null; }
+  }
+  function setBannerOpen(open){
+    var el = document.querySelector('[data-consent-banner]');
+    if (el) el.classList.toggle('is-open', !!open);
+  }
+  var EEA_UK_CH = ["AT","BE","BG","HR","CY","CZ","DK","EE","FI","FR","DE","GR","HU","IE","IT","LV","LT","LU","MT","NL","PL","PT","RO","SK","SI","ES","SE","IS","LI","NO","GB","CH"];
+  var regionParam = new URLSearchParams(location.search).get('region');
+  var tz = (Intl.DateTimeFormat().resolvedOptions().timeZone || '').toLowerCase();
+  var tzHintsEU = /(europe\/|gmt|bst|cet|cest)/.test(tz);
+  var inEEA = regionParam ? EEA_UK_CH.indexOf(regionParam.toUpperCase()) !== -1 : tzHintsEU;
+
   window.dataLayer = window.dataLayer || [];
   function gtag(){ dataLayer.push(arguments); }
   window.gtag = window.gtag || gtag;
 
-  // EEA + UK + Switzerland ISO codes
-  var EEA_UK_CH = ["AT","BE","BG","HR","CY","CZ","DK","EE","FI","FR","DE","GR","HU","IE","IT","LV","LT","LU","MT","NL","PL","PT","RO","SK","SI","ES","SE","IS","LI","NO","GB","CH"];
+  var saved = loadConsent();
+  var defaultGranted = !inEEA;
 
-  // Dev override: ?region=GB forces EEA behavior for testing
-  var regionParam = new URLSearchParams(location.search).get('region');
-  var inEEA = regionParam ? EEA_UK_CH.indexOf(regionParam.toUpperCase()) !== -1 : false;
-
-  // Default states: granted outside EEA, denied inside
   gtag('consent', 'default', {
-    ad_storage:         inEEA ? 'denied' : 'granted',
-    analytics_storage:  inEEA ? 'denied' : 'granted',
-    ad_user_data:       inEEA ? 'denied' : 'granted',
-    ad_personalization: inEEA ? 'denied' : 'granted'
+    ad_storage:         (saved ? saved.ad_storage         : (defaultGranted ? 'granted' : 'denied')),
+    analytics_storage:  (saved ? saved.analytics_storage  : (defaultGranted ? 'granted' : 'denied')),
+    ad_user_data:       (saved ? saved.ad_user_data       : (defaultGranted ? 'granted' : 'denied')),
+    ad_personalization: (saved ? saved.ad_personalization : (defaultGranted ? 'granted' : 'denied'))
   });
 
-  // Privacy-preserving defaults
   gtag('set', 'ads_data_redaction', true);
   gtag('set', 'url_passthrough', true);
 
-  function setAdsDisabled(disabled) {
+  function setAdsDisabled(disabled){
     document.documentElement.classList.toggle('is-ads-disabled', !!disabled);
   }
+  if (saved) setAdsDisabled(false);
+  setBannerOpen(inEEA && !saved);
 
-  // Public handlers
-  function acceptAll() {
-    gtag('consent', 'update', {
-      ad_storage: 'granted',
-      analytics_storage: 'granted',
-      ad_user_data: 'granted',
-      ad_personalization: 'granted'
-    });
+  function acceptAll(){
+    var state = {
+      ad_storage:'granted',
+      analytics_storage:'granted',
+      ad_user_data:'granted',
+      ad_personalization:'granted',
+      ts: now()
+    };
+    gtag('consent','update',state);
+    saveConsent(state);
     setAdsDisabled(false);
+    setBannerOpen(false);
   }
-
-  function rejectPersonalized() {
-    gtag('consent', 'update', {
-      ad_storage: 'granted', // allow non-personalized ads
-      analytics_storage: 'denied',
-      ad_user_data: 'denied',
-      ad_personalization: 'denied'
-    });
+  function rejectPersonalized(){
+    var state = {
+      ad_storage:'granted',
+      analytics_storage:'denied',
+      ad_user_data:'denied',
+      ad_personalization:'denied',
+      ts: now()
+    };
+    gtag('consent','update',state);
+    saveConsent(state);
     setAdsDisabled(false);
+    setBannerOpen(false);
   }
-
   window.acceptAll = acceptAll;
   window.rejectPersonalized = rejectPersonalized;
 
-  function wireBannerButtons() {
-    var acc = document.querySelectorAll('.js-consent-accept');
-    var rej = document.querySelectorAll('.js-consent-reject');
-    acc.forEach(function(btn){ btn.addEventListener('click', acceptAll); });
-    rej.forEach(function(btn){ btn.addEventListener('click', rejectPersonalized); });
+  function wire(){
+    document.querySelectorAll('.js-consent-accept').forEach(function(b){ b.addEventListener('click', acceptAll); });
+    document.querySelectorAll('.js-consent-reject').forEach(function(b){ b.addEventListener('click', rejectPersonalized); });
   }
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', wireBannerButtons);
-  } else {
-    wireBannerButtons();
-  }
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', wire); else wire();
 })();

--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -534,7 +534,7 @@
     })();
   </script>
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -572,184 +572,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -762,6 +589,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -774,7 +602,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -812,7 +640,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();

--- a/cookie-settings.html
+++ b/cookie-settings.html
@@ -72,7 +72,7 @@
   </script>
 
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -136,171 +136,10 @@
   }
 </style>
 
-<script>
-(() => {
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+<script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
-
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  closeModal();
-
-  const state = load();
-  if (!state){
-    openBanner();
-  } else {
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-  }
-
-  if ($btnAccept){
-    $btnAccept.addEventListener('click', () => {
-      save({ analytics: true, ads: true });
-      closeModal();
-      closeBanner();
-    });
-  }
-  if ($btnReject){
-    $btnReject.addEventListener('click', () => {
-      save({ analytics: false, ads: false });
-      closeModal();
-      closeBanner();
-    });
-  }
-  if ($btnManage){
-    $btnManage.addEventListener('click', () => {
-      closeBanner();
-      openModal();
-    });
-  }
-  if ($btnCancel){
-    $btnCancel.addEventListener('click', () => {
-      closeModal();
-    });
-  }
-  if ($form){
-    $form.addEventListener('submit', (event) => {
-      event.preventDefault();
-      save({
-        analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-        ads: $ckAds ? !!$ckAds.checked : false,
-      });
-      closeModal();
-    });
-  }
-  if ($modal){
-    $modal.addEventListener('click', (event) => {
-      if (event.target === $modal){
-        closeModal();
-      }
-    });
-  }
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -313,6 +152,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -325,7 +165,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -363,7 +203,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();
@@ -380,7 +220,7 @@
     window.cookieConsent && window.cookieConsent.reset();
   });
   window.addEventListener('load', () => {
-    if (window.cookieConsent && localStorage.getItem('ttg.consent.v1')) {
+    if (window.cookieConsent && localStorage.getItem('ttgConsentV2')) {
       window.cookieConsent.open();
     }
   });

--- a/copyright-dmca.html
+++ b/copyright-dmca.html
@@ -166,7 +166,7 @@
   })();
   </script>
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -204,184 +204,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -394,6 +221,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -406,7 +234,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -444,7 +272,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();

--- a/copyright.html
+++ b/copyright.html
@@ -39,7 +39,7 @@
 <body>
   <p>If you are not redirected, <a href="/copyright-dmca.html">view our Copyright &amp; DMCA page</a>.</p>
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -77,184 +77,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -267,6 +94,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -279,7 +107,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -317,7 +145,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();

--- a/css/style.css
+++ b/css/style.css
@@ -1508,6 +1508,8 @@ body.planted-active #cycling-coach .cc-title__leaf {
 #cc-bottom:where(*) { scroll-margin-top: 24px; }
 
 /* === TTG Cookie Consent START === */
+[data-consent-banner]{display:none !important;}
+[data-consent-banner].is-open{display:block !important;}
 .ttg-consent{position:fixed;left:0;right:0;bottom:0;z-index:9999;display:block;background:rgba(10,14,22,.96);backdrop-filter:saturate(120%) blur(6px);border-top:1px solid rgba(255,255,255,.08);}
 .ttg-consent__inner{max-width:1100px;margin:0 auto;padding:14px 16px;display:flex;flex-direction:column;gap:10px;color:#e8edf3;}
 .ttg-consent__inner h3{margin:0 0 4px 0;font-size:1rem;line-height:1.2}

--- a/feature-your-tank.html
+++ b/feature-your-tank.html
@@ -896,7 +896,7 @@
 </script>
   <script src="https://www.google.com/recaptcha/api.js" async defer></script>
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -934,184 +934,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -1124,6 +951,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -1136,7 +964,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -1174,7 +1002,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();

--- a/gear/index.html
+++ b/gear/index.html
@@ -60,7 +60,7 @@
   </main>
   <script type="module" src="/src/pages/GearPage.js"></script>
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -98,184 +98,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -288,6 +115,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -300,7 +128,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -338,7 +166,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();

--- a/index.html
+++ b/index.html
@@ -531,7 +531,7 @@
 })();
 </script>
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -569,184 +569,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -759,6 +586,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -771,7 +599,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -809,7 +637,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();

--- a/media.html
+++ b/media.html
@@ -524,7 +524,7 @@
 })();
 </script>
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -562,184 +562,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -752,6 +579,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -764,7 +592,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -802,7 +630,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();

--- a/params.html
+++ b/params.html
@@ -754,7 +754,7 @@
 </script>
   <script type="module" src="js/params.js?v=2.0.0"></script>
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -792,184 +792,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -982,6 +809,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -994,7 +822,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -1032,7 +860,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();

--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -639,7 +639,7 @@
     })();
   </script>
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -677,184 +677,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -867,6 +694,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -879,7 +707,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -917,7 +745,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();

--- a/stocking.html
+++ b/stocking.html
@@ -1390,7 +1390,7 @@
   <script type="module" src="js/tank-size-card.js?v=2024-09-01"></script>
 
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -1428,184 +1428,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -1618,6 +1445,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -1630,7 +1458,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -1668,7 +1496,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();

--- a/store.html
+++ b/store.html
@@ -183,7 +183,7 @@
 })();
   </script>
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -221,184 +221,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -411,6 +238,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -423,7 +251,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -461,7 +289,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();

--- a/terms.html
+++ b/terms.html
@@ -145,7 +145,7 @@
   })();
   </script>
 <!-- === TTG Cookie Consent START === -->
-<div id="ttg-consent" class="ttg-consent" hidden>
+<div id="ttg-consent" class="ttg-consent" data-consent-banner>
   <div class="ttg-consent__inner" role="dialog" aria-labelledby="ttg-consent-title" aria-describedby="ttg-consent-desc">
     <h3 id="ttg-consent-title">Cookies & Advertising</h3>
     <p id="ttg-consent-desc">
@@ -183,184 +183,11 @@
   </div>
 </div>
 
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) START === -->
-<script>
-(function(){
-  const KEY = 'ttg.consent.v1';
+<!-- === TTG Consent Banner Controller START === -->
+  <script defer src="/assets/js/consent-banner.js"></script>
+<!-- === TTG Consent Banner Controller END === -->
 
-  const $banner = document.getElementById('ttg-consent');
-  const $modal  = document.getElementById('ttg-consent-modal');
-  const $btnAccept = document.getElementById('ttg-consent-accept');
-  const $btnReject = document.getElementById('ttg-consent-reject');
-  const $btnManage = document.getElementById('ttg-consent-manage');
-  const $btnCancel = document.getElementById('ttg-consent-cancel');
-  const $form = document.getElementById('ttg-consent-form');
 
-  // Checkboxes
-  const $rows        = $form ? $form.querySelectorAll('.ttg-row') : [];
-  const $ckEssential = $rows[0] ? $rows[0].querySelector('input[type="checkbox"]') : null;
-  const $ckAnalytics = document.getElementById('ttg-c-analytics');
-  const $ckAds       = document.getElementById('ttg-c-ads');
-
-  // Add a small status line so you can verify state visually
-  let $status = $form ? $form.querySelector('.ttg-consent-status') : null;
-  if ($form && !$status){
-    $status = document.createElement('p');
-    $status.className = 'ttg-consent-status';
-    $form.appendChild($status);
-  }
-
-  function updateStatus(){
-    if(!$status) return;
-    const a = $ckAnalytics && $ckAnalytics.checked ? 'ON' : 'OFF';
-    const d = $ckAds && $ckAds.checked ? 'ON' : 'OFF';
-    $status.textContent = `Current: Analytics ${a} • Advertising ${d}`;
-  }
-
-  function save(state){
-    localStorage.setItem(KEY, JSON.stringify(state));
-    document.documentElement.setAttribute('data-ad-consent', state.ads ? 'granted' : 'denied');
-    window.dispatchEvent(new CustomEvent('ttg:consent-change'));
-  }
-  function load(){
-    try { return JSON.parse(localStorage.getItem(KEY) || ''); } catch(e){ return null; }
-  }
-  function openBanner(){ if (typeof window.__tcfapi === 'function') { return; } if ($banner) $banner.hidden = false; }
-  function closeBanner(){ if ($banner) $banner.hidden = true; }
-  function openModal(){
-    if(!$modal) return;
-    $modal.hidden = false;
-
-    // Essential MUST be checked & disabled
-    if ($ckEssential){
-      $ckEssential.checked = true;
-      $ckEssential.disabled = true;
-    }
-
-    const s = load() || {analytics:false, ads:false};
-    if ($ckAnalytics) $ckAnalytics.checked = !!s.analytics;
-    if ($ckAds)       $ckAds.checked = !!s.ads;
-    updateStatus();
-  }
-  function closeModal(){ if($modal) $modal.hidden = true; }
-
-  // Ensure modal hidden initially
-  closeModal();
-
-  const state = load();
-  if (!state){
-    // First visit: banner only
-    openBanner();
-  } else {
-    save(state);
-    closeBanner(); closeModal();
-  }
-
-  // Wire up clicks on the whole row to toggle the checkbox (except Essential)
-  $rows.forEach(function(row, idx){
-    row.addEventListener('click', function(e){
-      const cb = row.querySelector('input[type="checkbox"]');
-      if (!cb) return;
-      if (idx === 0) return; // Essential: no toggle
-      if (e.target.tagName.toLowerCase() !== 'input'){
-        cb.checked = !cb.checked;
-        updateStatus();
-      }
-    });
-  });
-  if ($ckAnalytics) $ckAnalytics.addEventListener('change', updateStatus);
-  if ($ckAds)       $ckAds.addEventListener('change', updateStatus);
-
-  // Buttons
-  if ($btnAccept) $btnAccept.addEventListener('click', function(){
-    save({ essential:true, analytics:true, ads:true, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnReject) $btnReject.addEventListener('click', function(){
-    save({ essential:true, analytics:false, ads:false, ts:Date.now() });
-    closeModal(); closeBanner();
-  });
-  if ($btnManage) $btnManage.addEventListener('click', openModal);
-  if ($btnCancel) $btnCancel.addEventListener('click', closeModal);
-
-  if ($form) $form.addEventListener('submit', function(e){
-    e.preventDefault();
-    save({
-      essential: true,
-      analytics: $ckAnalytics ? !!$ckAnalytics.checked : false,
-      ads:       $ckAds ? !!$ckAds.checked : false,
-      ts: Date.now()
-    });
-    closeModal(); closeBanner();
-  });
-
-  // Close modal on outside click
-  if ($modal) $modal.addEventListener('click', function(e){
-    if (e.target === $modal) closeModal();
-  });
-
-  // Close on Escape
-  document.addEventListener('keydown', function(e){
-    if (e.key === 'Escape' && $modal && !$modal.hidden) closeModal();
-  });
-
-  // Guard for ad scripts
-  if (document.documentElement.getAttribute('data-ad-consent') !== 'granted'){
-    window.__TTG_ADS_DISABLED__ = true;
-  }
-
-  // Public API for footer link
-  window.cookieConsent = {
-    open: function(){ openModal(); },
-    reset: function(){ localStorage.removeItem(KEY); closeModal(); openBanner(); }
-  };
-})();
-</script>
-<!-- === TTG Cookie Consent SCRIPT (checkbox fix + status) END === -->
-
-<!-- === TTG Consent → Ad Visibility Controller START === -->
-<script>
-(function(){
-  var KEY = 'ttg.consent.v1';
-
-  function hasGranted(){
-    try {
-      var s = JSON.parse(localStorage.getItem(KEY) || '');
-      return !!(s && s.ads === true);
-    } catch(e){ return false; }
-  }
-
-  function applyConsentToDOM(){
-    var granted = hasGranted();
-    document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
-    document.documentElement.classList.toggle('is-ads-disabled', !granted);
-
-    // If we’re only showing placeholders (no AdSense yet),
-    // simply un-hide or keep hidden via the CSS above.
-    // (When you later enable the AdSense loader, mount units here if granted.)
-  }
-
-  // Run now
-  applyConsentToDOM();
-
-  // Listen for same-page consent changes (buttons & form), then update immediately
-  ['ttg-consent-accept','ttg-consent-reject'].forEach(function(id){
-    var el = document.getElementById(id);
-    if (el) el.addEventListener('click', function(){ setTimeout(applyConsentToDOM, 0); });
-  });
-  var form = document.getElementById('ttg-consent-form');
-  if (form) form.addEventListener('submit', function(){ setTimeout(applyConsentToDOM, 0); });
-
-  // If your cookie script dispatches a custom event, react to it too
-  window.addEventListener('ttg:consent-change', applyConsentToDOM);
-
-  // Cross-tab changes (Storage event)
-  window.addEventListener('storage', function(e){
-    if (e.key === KEY) applyConsentToDOM();
-  });
-})();
-</script>
-<!-- === TTG Consent → Ad Visibility Controller END === -->
 <!-- === TTG CMP Consent Bridge START === -->
 <script>
 (function(){
@@ -373,6 +200,7 @@
   function setAdConsent(granted){
     document.documentElement.setAttribute('data-ad-consent', granted ? 'granted' : 'denied');
     document.documentElement.classList.toggle('is-ads-disabled', !granted);
+    window.__TTG_ADS_DISABLED__ = !granted;
     // Inform any listeners (our ad loader later)
     window.dispatchEvent(new CustomEvent('ttg:consent-change', {detail:{granted}}));
   }
@@ -385,7 +213,7 @@
     try{
       var banner = document.getElementById('ttg-consent');
       var modal  = document.getElementById('ttg-consent-modal');
-      if (banner) banner.hidden = true;
+      if (banner){ banner.hidden = true; banner.classList.remove('is-open'); }
       if (modal)  modal.hidden  = true;
     }catch(e){}
 
@@ -423,7 +251,7 @@
   }
 
   // Fallback for non-EEA visitors (no __tcfapi): keep using our local preference
-  // Our existing local banner writes ttg.consent.v1 with {ads:true|false}.
+  // Our existing local banner writes ttgConsentV2 with {ads:true|false}.
   // If CMP absent, keep existing behavior (do not force-show anything here).
 
 })();


### PR DESCRIPTION
## Summary
- replace the consent-mode bootstrap with the provided Google Consent Mode v2 defaults so non-EEA visitors grant storage automatically
- add a reusable consent-banner controller script, wire the banner buttons to the new handlers, and refresh every page’s markup to use the shared include
- add a global visibility toggle for the banner and update the CMP bridge so external consent managers keep the banner closed while still toggling ad visibility

## Testing
- npm run test:consent *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfdce9c7e88332a7f2fc3c7c9ab606