### PR TITLE
Fix gear navigation link and update nav routes

### DIFF
--- a/js/nav.js
+++ b/js/nav.js
@@ -181,7 +181,7 @@
       return;
     }
     try {
-      const response = await fetch(`/nav.html?v=${NAV_VERSION}`, { cache: 'no-cache' });
+      const response = await fetch(`/nav.html?v=${NAV_VERSION}`, { cache: 'no-store' });
       if (!response.ok) {
         throw new Error(`Failed to fetch nav: ${response.status}`);
       }

--- a/nav.html
+++ b/nav.html
@@ -12,23 +12,21 @@
       <span class="hamburger__bars" aria-hidden="true"></span>
       <span class="visually-hidden">Open menu</span>
     </button>
-    <a class="site-brand brand" href="/index.html" aria-label="The Tank Guide — Home">
+    <a class="site-brand brand" href="/" aria-label="The Tank Guide — Home">
       <span class="site-brand__title">The Tank Guide</span>
       <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
     </a>
     <nav class="site-links links" aria-label="Primary">
       <ul class="nav__list">
-        <li class="nav__item"><a href="/index.html" class="nav__link">Home</a></li>
-        <li class="nav__item"><a href="/stocking.html" class="nav__link">Stocking Advisor</a></li>
-        <li class="nav__item"><a href="/gear.html" class="nav__link">Gear</a></li>
-        <li class="nav__item"><a href="/cycling-coach.html" class="nav__link">Cycling Coach</a></li>
+        <li class="nav__item"><a href="/" class="nav__link">Home</a></li>
+        <li class="nav__item"><a href="/stocking-advisor" class="nav__link">Stocking Advisor</a></li>
+        <li class="nav__item"><a href="/gear/" class="nav__link">Gear</a></li>
+        <li class="nav__item"><a href="/cycling-coach" class="nav__link">Cycling Coach</a></li>
         <li class="nav__item"><a href="/media.html" class="nav__link">Media</a></li>
-        <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link">Feature Your Tank</a></li>
-        <li class="nav__item"><a href="/contact-feedback.html" class="nav__link">Contact &amp; Feedback</a></li>
-        <li class="nav__item"><a href="/about.html" class="nav__link">About</a></li>
-        <li class="nav__item"><a href="/privacy-legal.html" class="nav__link">Privacy &amp; Legal</a></li>
-        <li class="nav__item"><a href="/terms.html" class="nav__link">Terms of Use</a></li>
-        <li class="nav__item"><a href="/copyright-dmca.html" class="nav__link">Copyright &amp; DMCA</a></li>
+        <li class="nav__item"><a href="/feature-your-tank" class="nav__link">Feature Your Tank</a></li>
+        <li class="nav__item"><a href="/store" class="nav__link">Store</a></li>
+        <li class="nav__item"><a href="/contact" class="nav__link">Contact</a></li>
+        <li class="nav__item"><a href="/about" class="nav__link">About</a></li>
       </ul>
     </nav>
   </div>
@@ -41,17 +39,15 @@
     </div>
     <nav class="drawer-links" aria-label="Mobile">
       <ul class="nav__list nav__list--drawer">
-        <li class="nav__item"><a href="/index.html" class="nav__link">Home</a></li>
-        <li class="nav__item"><a href="/stocking.html" class="nav__link">Stocking Advisor</a></li>
-        <li class="nav__item"><a href="/gear.html" class="nav__link">Gear</a></li>
-        <li class="nav__item"><a href="/cycling-coach.html" class="nav__link">Cycling Coach</a></li>
+        <li class="nav__item"><a href="/" class="nav__link">Home</a></li>
+        <li class="nav__item"><a href="/stocking-advisor" class="nav__link">Stocking Advisor</a></li>
+        <li class="nav__item"><a href="/gear/" class="nav__link">Gear</a></li>
+        <li class="nav__item"><a href="/cycling-coach" class="nav__link">Cycling Coach</a></li>
         <li class="nav__item"><a href="/media.html" class="nav__link">Media</a></li>
-        <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link">Feature Your Tank</a></li>
-        <li class="nav__item"><a href="/contact-feedback.html" class="nav__link">Contact &amp; Feedback</a></li>
-        <li class="nav__item"><a href="/about.html" class="nav__link">About</a></li>
-        <li class="nav__item"><a href="/privacy-legal.html" class="nav__link">Privacy &amp; Legal</a></li>
-        <li class="nav__item"><a href="/terms.html" class="nav__link">Terms of Use</a></li>
-        <li class="nav__item"><a href="/copyright-dmca.html" class="nav__link">Copyright &amp; DMCA</a></li>
+        <li class="nav__item"><a href="/feature-your-tank" class="nav__link">Feature Your Tank</a></li>
+        <li class="nav__item"><a href="/store" class="nav__link">Store</a></li>
+        <li class="nav__item"><a href="/contact" class="nav__link">Contact</a></li>
+        <li class="nav__item"><a href="/about" class="nav__link">About</a></li>
       </ul>
     </nav>
   </aside>


### PR DESCRIPTION
## Summary
- point the global nav brand and Gear links at the canonical routes, including the trailing slash for /gear/
- align both desktop and drawer menus with the updated navigation destinations
- force the nav include fetch to bypass caches so pages pick up the refreshed markup immediately

## Testing
- Manual verification in local browser (desktop & mobile nav)

------
https://chatgpt.com/codex/tasks/task_e_68e01396f35883329655ab19e104d3ff