### PR TITLE
Add temporary AdSense slot debug styles

### DIFF
--- a/assets/css/ads.css
+++ b/assets/css/ads.css
@@ -1,0 +1,8 @@
+/* TEMP: debug placeholder for AdSense slots */
+ins.adsbygoogle{
+  min-height:250px;             /* CLS guard & visible space */
+  display:block !important;     /* ensure it doesn’t collapse */
+  outline:1px dashed rgba(255,255,255,.25);
+  background:rgba(255,255,255,.04);
+  border-radius:10px;
+}

--- a/css/site.css
+++ b/css/site.css
@@ -1,4 +1,5 @@
 /* unified header with right-aligned toggle */
+@import url("/assets/css/ads.css");
 .adsbygoogle { margin: 20px auto; display: block; }
 .card__hd--split { display:flex; align-items:center; justify-content:space-between; gap:12px; }
 .linklike { background:none; border:0; padding:0; color:var(--link, #87b4ff); font:inherit; cursor:pointer; }


### PR DESCRIPTION
## Summary
- add a temporary debug stylesheet for AdSense slots to keep their layout space visible
- import the new debug stylesheet globally so ad placeholders are outlined consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e015a895008332b3044b44bd9c14ab