### PR TITLE
Enable AdSense test ads across site

### DIFF
--- a/gear/index.html
+++ b/gear/index.html
@@ -52,7 +52,7 @@
            data-ad-client="ca-pub-9905718149811880"
            data-ad-slot="1762971638"
            data-ad-format="auto"
-           data-full-width-responsive="true"></ins>
+           data-full-width-responsive="true" data-adtest="on"></ins>
       <script>
            (adsbygoogle = window.adsbygoogle || []).push({});
       </script>

--- a/media.html
+++ b/media.html
@@ -506,7 +506,7 @@
          data-ad-client="ca-pub-9905718149811880"
          data-ad-slot="9522042154"
          data-ad-format="auto"
-         data-full-width-responsive="true"></ins>
+         data-full-width-responsive="true" data-adtest="on"></ins>
     <script>
       (adsbygoogle = window.adsbygoogle || []).push({});
     </script>

--- a/params.html
+++ b/params.html
@@ -579,7 +579,7 @@
           data-ad-client="ca-pub-9905718149811880"
           data-ad-slot="8136808291"
           data-ad-format="auto"
-          data-full-width-responsive="true"></ins>
+          data-full-width-responsive="true" data-adtest="on"></ins>
         <script>
           (adsbygoogle = window.adsbygoogle || []).push({});
         </script>
@@ -667,7 +667,7 @@
           data-ad-client="ca-pub-9905718149811880"
           data-ad-slot="5754828160"
           data-ad-format="auto"
-          data-full-width-responsive="true"></ins>
+          data-full-width-responsive="true" data-adtest="on"></ins>
         <script>
           (adsbygoogle = window.adsbygoogle || []).push({});
         </script>

--- a/src/pages/GearPage.js
+++ b/src/pages/GearPage.js
@@ -174,6 +174,7 @@ function GearTopAd() {
       'data-ad-slot': '7692943403',
       'data-ad-format': 'auto',
       'data-full-width-responsive': 'true',
+      'data-adtest': 'on',
     },
   });
 

--- a/stocking.html
+++ b/stocking.html
@@ -955,7 +955,7 @@
              data-ad-client="ca-pub-9905718149811880"
              data-ad-slot="8419879326"
              data-ad-format="auto"
-             data-full-width-responsive="true"></ins>
+             data-full-width-responsive="true" data-adtest="on"></ins>
         <script>
              (adsbygoogle = window.adsbygoogle || []).push({});
         </script>
@@ -1362,7 +1362,7 @@
              data-ad-client="ca-pub-9905718149811880"
              data-ad-slot="8979116676"
              data-ad-format="auto"
-             data-full-width-responsive="true"></ins>
+             data-full-width-responsive="true" data-adtest="on"></ins>
         <script>
              (adsbygoogle = window.adsbygoogle || []).push({});
         </script>


### PR DESCRIPTION
## Summary
- add the data-adtest="on" flag to each existing Google AdSense slot so units render test creatives during QA
- include the flag in the Gear SPA ad factory to keep dynamically rendered slots in test mode

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e017cc7408833291ae01eb2de3603d