### PR TITLE
Update navigation slugs and improve drawer accessibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -134,7 +134,7 @@ body.theme-light {
   text-decoration: none;
   font-weight: 600;
   font-size: 0.95rem;
-  padding: 10px 0;
+  padding: 12px 0;
   position: relative;
 }
 
@@ -145,17 +145,9 @@ body.theme-light {
 
 #global-nav .links .nav__link[aria-current="page"] {
   color: #ffffff;
-}
-
-#global-nav .links .nav__link[aria-current="page"]::after {
-  content: "";
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 6px;
-  height: 2px;
-  background: rgba(255, 255, 255, 0.9);
-  border-radius: 999px;
+  text-decoration: underline;
+  text-underline-offset: 6px;
+  text-decoration-thickness: 2px;
 }
 
 @media (max-width: 920px) {
@@ -366,8 +358,8 @@ body.theme-light {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 40px;
-  height: 40px;
+  min-width: 44px;
+  min-height: 44px;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.18);
   background: rgba(255, 255, 255, 0.08);
@@ -418,7 +410,13 @@ body.theme-light {
 
 #global-nav #ttg-drawer .drawer-links .nav__link[aria-current="page"] {
   color: #ffffff;
-  background: rgba(255, 255, 255, 0.18);
+  background: none;
+  text-decoration: underline;
+}
+
+#global-nav #ttg-drawer .drawer-links .nav__link[aria-current="page"]:hover,
+#global-nav #ttg-drawer .drawer-links .nav__link[aria-current="page"]:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
 }
 
 #global-nav a:focus-visible,

--- a/footer.v1.3.0.html
+++ b/footer.v1.3.0.html
@@ -30,7 +30,9 @@
     <span class="dot">·</span>
     <a href="/cookie-settings.html">Cookie Settings</a>
     <span class="dot">·</span>
-    <a href="/contact-feedback.html">Contact</a>
+    <a href="/cookie-settings.html">Do Not Sell or Share My Personal Information</a>
+    <span class="dot">·</span>
+    <a href="/contact-feedback.html">Contact &amp; Feedback</a>
     <span class="dot">·</span>
     <a href="/store.html">Store</a>
     <span class="dot">·</span>

--- a/gear/index.html
+++ b/gear/index.html
@@ -44,7 +44,9 @@
   <!-- GLOBAL NAV -->
   <div id="site-nav"></div>
   <main id="gear-main">
-    <div id="gear-root" data-testid="gear-root"></div>
+    <div id="gear-root" data-testid="gear-root">
+      <h1 id="gear-title" class="visually-hidden">Gear Guide</h1>
+    </div>
     <!-- === TTG_GearBottom (before footer) === -->
     <div class="ttg-adunit ttg-adunit--bottom" id="ad-bottom-gear" aria-label="Advertisement">
       <ins class="adsbygoogle"

--- a/nav.html
+++ b/nav.html
@@ -18,36 +18,49 @@
     </a>
     <nav class="site-links links" aria-label="Primary">
       <ul class="nav__list">
-        <li class="nav__item"><a href="/" class="nav__link">Home</a></li>
-        <li class="nav__item"><a href="/stocking-advisor" class="nav__link">Stocking Advisor</a></li>
-        <li class="nav__item"><a href="/gear/" class="nav__link">Gear</a></li>
-        <li class="nav__item"><a href="/cycling-coach" class="nav__link">Cycling Coach</a></li>
-        <li class="nav__item"><a href="/media.html" class="nav__link">Media</a></li>
-        <li class="nav__item"><a href="/feature-your-tank" class="nav__link">Feature Your Tank</a></li>
-        <li class="nav__item"><a href="/store" class="nav__link">Store</a></li>
-        <li class="nav__item"><a href="/contact" class="nav__link">Contact</a></li>
-        <li class="nav__item"><a href="/about" class="nav__link">About</a></li>
+        <li class="nav__item"><a href="/index.html" class="nav__link" data-nav="home">Home</a></li>
+        <li class="nav__item"><a href="/stocking.html" class="nav__link" data-nav="stocking">Stocking Advisor</a></li>
+        <li class="nav__item"><a href="/gear/index.html" class="nav__link" data-nav="gear">Gear</a></li>
+        <li class="nav__item"><a href="/media.html" class="nav__link" data-nav="media">Media</a></li>
+        <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link" data-nav="feature-your-tank">Feature Your Tank</a></li>
+        <li class="nav__item"><a href="/store.html" class="nav__link" data-nav="store">Store</a></li>
+        <li class="nav__item"><a href="/contact-feedback.html" class="nav__link" data-nav="contact-feedback">Contact &amp; Feedback</a></li>
+        <li class="nav__item"><a href="/about.html" class="nav__link" data-nav="about">About</a></li>
+        <li class="nav__item"><a href="/privacy-legal.html" class="nav__link" data-nav="privacy-legal">Privacy &amp; Legal</a></li>
+        <li class="nav__item"><a href="/terms.html" class="nav__link" data-nav="terms">Terms of Use</a></li>
+        <li class="nav__item"><a href="/copyright-dmca.html" class="nav__link" data-nav="copyright-dmca">Copyright &amp; DMCA</a></li>
       </ul>
     </nav>
   </div>
-  <aside id="ttg-drawer" aria-label="Site" data-nav="drawer" aria-hidden="true">
+  <aside
+    id="ttg-drawer"
+    aria-label="Site"
+    data-nav="drawer"
+    aria-hidden="true"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="drawer-title"
+  >
+    <h2 id="drawer-title" class="visually-hidden">Site navigation</h2>
     <div class="drawer-head">
       <span class="drawer-title">The Tank Guide</span>
-      <button id="ttg-nav-close" class="drawer-close" type="button" aria-label="Close menu">
+      <button id="drawer-close" class="drawer-close" type="button" aria-label="Close menu" data-nav="drawer-close">
         <span aria-hidden="true">×</span>
       </button>
     </div>
     <nav class="drawer-links" aria-label="Mobile">
       <ul class="nav__list nav__list--drawer">
-        <li class="nav__item"><a href="/" class="nav__link">Home</a></li>
-        <li class="nav__item"><a href="/stocking-advisor" class="nav__link">Stocking Advisor</a></li>
-        <li class="nav__item"><a href="/gear/" class="nav__link">Gear</a></li>
-        <li class="nav__item"><a href="/cycling-coach" class="nav__link">Cycling Coach</a></li>
-        <li class="nav__item"><a href="/media.html" class="nav__link">Media</a></li>
-        <li class="nav__item"><a href="/feature-your-tank" class="nav__link">Feature Your Tank</a></li>
-        <li class="nav__item"><a href="/store" class="nav__link">Store</a></li>
-        <li class="nav__item"><a href="/contact" class="nav__link">Contact</a></li>
-        <li class="nav__item"><a href="/about" class="nav__link">About</a></li>
+        <li class="nav__item"><a id="drawer-first" href="/index.html" class="nav__link" data-nav="home">Home</a></li>
+        <li class="nav__item"><a href="/stocking.html" class="nav__link" data-nav="stocking">Stocking Advisor</a></li>
+        <li class="nav__item"><a href="/gear/index.html" class="nav__link" data-nav="gear">Gear</a></li>
+        <li class="nav__item"><a href="/media.html" class="nav__link" data-nav="media">Media</a></li>
+        <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link" data-nav="feature-your-tank">Feature Your Tank</a></li>
+        <li class="nav__item"><a href="/store.html" class="nav__link" data-nav="store">Store</a></li>
+        <li class="nav__item"><a href="/contact-feedback.html" class="nav__link" data-nav="contact-feedback">Contact &amp; Feedback</a></li>
+        <li class="nav__item"><a href="/about.html" class="nav__link" data-nav="about">About</a></li>
+        <li class="nav__item"><a href="/privacy-legal.html" class="nav__link" data-nav="privacy-legal">Privacy &amp; Legal</a></li>
+        <li class="nav__item"><a href="/terms.html" class="nav__link" data-nav="terms">Terms of Use</a></li>
+        <li class="nav__item"><a href="/copyright-dmca.html" class="nav__link" data-nav="copyright-dmca">Copyright &amp; DMCA</a></li>
       </ul>
     </nav>
   </aside>


### PR DESCRIPTION
## Summary
- align desktop and mobile navigation to canonical .html routes, add legal links, and upgrade the drawer to dialog semantics with labeled controls
- normalize route matching in the nav script, add aria-current cleanup, and implement a focus trap while adjusting styles for underline active states and larger touch targets
- seed the gear shell with a hidden `<h1>` and update the footer labels to include the Do Not Sell or Share link

## Testing
- npx playwright test tests/nav.spec.ts tests/nav.spec.mjs tests/e2e.spec.js *(fails: Playwright browsers are not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e01b4ef73883328ef5ec3a0848e643