### PR TITLE
Adjust ad slot visibility handling

### DIFF
--- a/assets/css/ads.css
+++ b/assets/css/ads.css
@@ -1,8 +1,14 @@
 /* TEMP: debug placeholder for AdSense slots */
-ins.adsbygoogle{
+ins.adsbygoogle,
+.ttg-adunit {
+  display:block;
   min-height:250px;             /* CLS guard & visible space */
-  display:block !important;     /* ensure it doesn’t collapse */
   outline:1px dashed rgba(255,255,255,.25);
   background:rgba(255,255,255,.04);
   border-radius:10px;
+}
+
+.is-ads-disabled ins.adsbygoogle,
+.is-ads-disabled .ttg-adunit {
+  display:none !important;
 }


### PR DESCRIPTION
## Summary
- ensure ad units are visible by default with reserved height
- hide ad units only when the ads-disabled state is active

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0254bd08883329dc769e800b99f98