### PR TITLE
Fix species picker to include canonical freshwater species

### DIFF
--- a/js/fish-data.js
+++ b/js/fish-data.js
@@ -48,7 +48,7 @@ export const FISH_DB = [
     adult_size_in:0.8, min_tank_length_in:18, temperature:{min_f:72,max_f:80}, ph:{min:5.0,max:7.0},
     gH:{min_dGH:0,max_dGH:8}, kH:{min_dKH:0,max_dKH:4}, salinity:"fresh", flow:"low", blackwater:"prefers",
     aggression:0, tags:["shoaler","nano"], group:{type:"shoal",min:8}, invert_safe:true, mouth_size_in:0.05, ph_sensitive:true, bioloadGE:0.3 },
-  { id:"tigerbarb", common_name:"Tiger Barb", scientific_name:"Puntigrus tetrazona", category:"fish",
+  { id:"tiger_barb", common_name:"Tiger Barb", scientific_name:"Puntigrus tetrazona", category:"fish",
     adult_size_in:3.0, min_tank_length_in:36, temperature:{min_f:72,max_f:82}, ph:{min:6.0,max:8.0},
     gH:{min_dGH:5,max_dGH:19}, kH:{min_dKH:4,max_dKH:15}, salinity:"fresh", flow:"high", blackwater:"neutral",
     aggression:55, tags:["shoaler","schooling_shoaler","fast_swimmer","fin_nipper","semi_aggressive"], behavior:[

--- a/js/logic/compute.js
+++ b/js/logic/compute.js
@@ -1044,7 +1044,7 @@ export function runSanitySuite(baseState) {
       { id: 'cardinal', qty: 12 },
       { id: 'cory_panda', qty: 6 },
     ],
-    candidate: { id: 'tigerbarb', qty: 2 },
+    candidate: { id: 'tiger_barb', qty: 2 },
   });
   results.push(`4) +2 tiger barbs → ${scenario4.status.label}`);
 

--- a/js/logic/conflicts.js
+++ b/js/logic/conflicts.js
@@ -2,7 +2,7 @@
 export const HARD_CONFLICTS = new Set([
   'betta_male|betta_male',
   'betta_male|guppy_male',
-  'betta_male|tigerbarb',
+  'betta_male|tiger_barb',
 ]);
 
 // helper to build symmetric keys: a|b in alpha order


### PR DESCRIPTION
## Summary
- rename the Tiger Barb species id to the canonical `tiger_barb` and update references in the compute diagnostics and conflict map
- rework the Plan Your Stock species selector to rebuild from the canonical freshwater list, limiting filters to salinity/search and exposing `window.advisor.rebuildSpecies`
- reset species filters on init/tank change and wire optional search input handling while keeping add button state in sync

## Testing
- npm test *(fails: Playwright suite requires external environment access in this sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e03655b8788332b123d3bf163bbca7