### PR TITLE
Lock consent defaults to denied until acceptance

### DIFF
--- a/assets/js/consent-banner.js
+++ b/assets/js/consent-banner.js
@@ -33,7 +33,8 @@
   var tz = (Intl.DateTimeFormat().resolvedOptions().timeZone || '').toLowerCase();
   var tzHintsEU = /(europe\/|gmt|bst|cet|cest)/.test(tz);
   var inEEA = regionParam ? ['AT','BE','BG','HR','CY','CZ','DK','EE','FI','FR','DE','GR','HU','IE','IT','LV','LT','LU','MT','NL','PL','PT','RO','SK','SI','ES','SE','IS','LI','NO','GB','CH'].indexOf(regionParam.toUpperCase()) !== -1 : tzHintsEU;
-  var defaultGranted = !inEEA;
+  // Mirror consent-mode.js: default = DENIED until accepted
+  var defaultGranted = false;
 
   var banner = document.querySelector('[data-consent-banner]');
   var modal = document.getElementById('ttg-consent-modal');

--- a/assets/js/consent-mode.js
+++ b/assets/js/consent-mode.js
@@ -74,7 +74,8 @@
   })();
 
   var saved = ON_LEGAL_PAGE ? null : loadConsent();
-  var defaultGranted = !inEEA && !ON_LEGAL_PAGE;
+  // Default = DENIED for everyone until explicit accept
+  var defaultGranted = false;
 
   gtag('consent', 'default', {
     ad_storage:         (saved ? saved.ad_storage         : (defaultGranted ? 'granted' : 'denied')),


### PR DESCRIPTION
## Summary
- set consent-mode default to denied for all visitors until they explicitly accept
- mirror the denied default inside the consent banner logic so the UI reflects the new baseline

## Testing
- not run (manual QA outlined in request)

## Notes
- Before: consent defaults outside the EEA resulted in ad/analytics storage being granted immediately.
- After: all storage remains denied until the user accepts, keeping ads disabled until consent is given.


------
https://chatgpt.com/codex/tasks/task_e_68e051c66cac833285691058b54336bb