### PR TITLE
Add nginx rule to serve ads.txt directly

### DIFF
--- a/hardening/nginx.conf
+++ b/hardening/nginx.conf
@@ -34,6 +34,11 @@ server {
     add_header Cache-Control "public, max-age=600";
   }
 
+  location = /ads.txt {
+    try_files /ads.txt =404;
+    access_log off;
+  }
+
   location /assets/ {
     add_header Cache-Control "public, max-age=31536000, immutable";
   }


### PR DESCRIPTION
## Summary
- add an explicit nginx location block for /ads.txt so the static file is served without being blocked

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e052c16a888332bb44dfe74f9f4af3