### PR TITLE
Implement contact form submission, expand privacy disclosures, and refine drawer a11y

### DIFF
--- a/contact-feedback.html
+++ b/contact-feedback.html
@@ -335,7 +335,7 @@
   <main class="page-wrapper">
     <section class="contact-card" aria-labelledby="page-title">
       <div class="status-stack">
-        <div role="status" class="success" data-testid="contact-success" tabindex="-1">Message captured locally. TODO: wire submission endpoint.</div>
+        <div role="status" class="success" data-testid="contact-success" tabindex="-1">Thanks! Your message was sent to the team.</div>
         <div role="alert" class="error-summary" data-testid="contact-errors">
           <strong>There’s a bit more to complete:</strong>
           <ul></ul>
@@ -345,7 +345,6 @@
       <p class="intro">Use this form to share feedback, report logic issues, or highlight anything that seems off in our tools.</p>
       <p class="intro">We also welcome aquarium questions so we can point you toward the right resources for your next build.</p>
       <p class="tiny" aria-live="polite">We usually reply within 1–2 business days.</p>
-      <p class="todo-note" role="note">TODO: Wire the external submission endpoint so these messages send to the team automatically.</p>
       <form data-testid="contact-form" novalidate>
         <fieldset>
           <legend class="visually-hidden">Contact &amp; Feedback form</legend>
@@ -437,7 +436,11 @@
       const successBanner = document.querySelector('[data-testid="contact-success"]');
       const errorSummary = document.querySelector('[data-testid="contact-errors"]');
       const summaryList = errorSummary ? errorSummary.querySelector('ul') : null;
+      const errorHeading = errorSummary ? errorSummary.querySelector('strong') : null;
+      const defaultErrorHeading = errorHeading?.textContent ?? '';
+      const submitButton = form.querySelector('[data-testid="contact-submit"]');
       const LOCAL_STORAGE_KEY = 'ttg.contact.localQueue';
+      const FORM_ENDPOINT = 'https://formspree.io/f/xnngnwld';
 
       const fields = [
         {
@@ -482,6 +485,10 @@
           summaryList.innerHTML = '';
         }
         errorSummary?.classList.remove('visible');
+        errorSummary?.setAttribute('tabindex', '-1');
+        if (errorHeading) {
+          errorHeading.textContent = defaultErrorHeading;
+        }
       }
 
       function captureSubmission(entry) {
@@ -513,6 +520,22 @@
         window.__ttgContactQueue = queue;
       }
 
+      function showSubmissionError() {
+        if (errorHeading) {
+          errorHeading.textContent = "We couldn’t send your message right now.";
+        }
+        if (summaryList) {
+          summaryList.innerHTML = '';
+          const item = document.createElement('li');
+          item.textContent = 'Your message was saved locally. Please try again shortly or email info@thetankguide.com.';
+          summaryList.appendChild(item);
+        }
+        if (errorSummary) {
+          errorSummary.classList.add('visible');
+          errorSummary.focus({ preventScroll: true });
+        }
+      }
+
       fields.forEach((field) => {
         if (!field.input) return;
         const eventName = field.input.tagName === 'SELECT' ? 'change' : 'input';
@@ -525,11 +548,12 @@
         });
       });
 
-      form.addEventListener('submit', (event) => {
+      form.addEventListener('submit', async (event) => {
         event.preventDefault();
         hideStatus();
 
         const invalidFields = [];
+        const payload = {};
 
         fields.forEach((field) => {
           if (!field.input) return;
@@ -539,6 +563,8 @@
           if (!isValid) {
             invalidFields.push(field);
           }
+          const key = field.input.name || field.input.id || 'field';
+          payload[key] = value.trim();
         });
 
         if (invalidFields.length > 0) {
@@ -557,24 +583,51 @@
           return;
         }
 
-        const submission = { submittedAt: new Date().toISOString(), source: 'contact-feedback.html', data: {} };
+        const submission = {
+          submittedAt: new Date().toISOString(),
+          source: 'contact-feedback.html',
+          data: payload,
+        };
 
-        fields.forEach((field) => {
-          if (!field.input) return;
-          const key = field.input.name || field.input.id || 'field';
-          submission.data[key] = field.input.value?.trim() ?? '';
-          field.input.value = '';
-          field.helper?.classList.remove('visible');
-          field.input.removeAttribute('aria-invalid');
-        });
-
-        captureSubmission(submission);
-
-        if (successBanner) {
-          successBanner.classList.add('visible');
-          successBanner.focus({ preventScroll: true });
+        if (submitButton instanceof HTMLButtonElement) {
+          submitButton.setAttribute('aria-disabled', 'true');
+          submitButton.disabled = true;
         }
-        form.reset();
+
+        try {
+          const response = await fetch(FORM_ENDPOINT, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Accept: 'application/json',
+            },
+            body: JSON.stringify(payload),
+          });
+
+          if (!response.ok) {
+            throw new Error(`Contact submit failed with status ${response.status}`);
+          }
+
+          if (successBanner) {
+            successBanner.classList.add('visible');
+            successBanner.focus({ preventScroll: true });
+          }
+          form.reset();
+          fields.forEach((field) => {
+            if (!field.input) return;
+            field.helper?.classList.remove('visible');
+            field.input.removeAttribute('aria-invalid');
+          });
+        } catch (error) {
+          console.error('Contact submission failed', error);
+          captureSubmission(submission);
+          showSubmissionError();
+        } finally {
+          if (submitButton instanceof HTMLButtonElement) {
+            submitButton.disabled = false;
+            submitButton.removeAttribute('aria-disabled');
+          }
+        }
       });
     })();
   </script>

--- a/css/style.css
+++ b/css/style.css
@@ -57,6 +57,18 @@ body.theme-light {
   border: 0;
 }
 
+.ttg-visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
 .page-background {
   background:
     radial-gradient(1200px 800px at 75% -10%, #36c2cc 0%, rgba(54, 194, 204, 0) 60%),

--- a/js/nav.js
+++ b/js/nav.js
@@ -155,6 +155,7 @@
         target.focus({ preventScroll: true });
       }
       previousFocus = null;
+      drawerFocusables = [];
     };
 
     const openDrawer = () => {

--- a/nav.html
+++ b/nav.html
@@ -41,7 +41,7 @@
     aria-modal="true"
     aria-labelledby="drawer-title"
   >
-    <h2 id="drawer-title" class="visually-hidden">Site navigation</h2>
+    <h2 id="drawer-title" class="ttg-visually-hidden">Site navigation</h2>
     <div class="drawer-head">
       <span class="drawer-title">The Tank Guide</span>
       <button id="drawer-close" class="drawer-close" type="button" aria-label="Close menu" data-nav="drawer-close">

--- a/privacy-legal.html
+++ b/privacy-legal.html
@@ -374,6 +374,14 @@
             <p>We keep personal data only as long as necessary to fulfill the purposes described above, unless a longer retention period is required by law. Contact form submissions are deleted upon request.</p>
             <h3>Sharing &amp; Disclosure</h3>
             <p>We do <strong>not sell</strong> your personal information. We only share limited information with service providers (such as hosting or email providers) who help us operate this site.</p>
+            <p>When you use specific features, we rely on trusted third-party partners who process limited data to deliver those services:</p>
+            <ul>
+              <li><strong>Google AdSense</strong> serves on-site advertising and may collect device identifiers, IP address, and cookie data to deliver personalized or non-personalized ads. See the <a href="https://policies.google.com/technologies/ads" rel="noopener">Google Advertising Privacy &amp; Terms</a>.</li>
+              <li><strong>Google Funding Choices</strong> powers our consent banner for EEA/UK visitors and records your consent selections along with basic device information. Learn more at <a href="https://privacy.google.com/businesses/fundingchoices/" rel="noopener">Google Funding Choices</a>.</li>
+              <li><strong>Google reCAPTCHA</strong> protects the Feature Your Tank submission form from spam by evaluating interaction, device, and IP data per <a href="https://policies.google.com/privacy" rel="noopener">Google’s Privacy Policy</a>.</li>
+              <li><strong>Cloudinary Upload Widget</strong> handles optional photo and video uploads on the Feature Your Tank page and receives the media you provide plus related metadata. Review the <a href="https://cloudinary.com/privacy" rel="noopener">Cloudinary Privacy Policy</a>.</li>
+              <li><strong>Formspree</strong> securely processes our contact and feature form submissions, passing along your message, email, and any other form fields so we can respond. See the <a href="https://formspree.io/legal/privacy-policy" rel="noopener">Formspree Privacy Policy</a>.</li>
+            </ul>
             <h3>Security</h3>
             <p>We use reasonable safeguards to protect information, but no method of storage or transmission is 100% secure.</p>
             <h3>Your Rights</h3>


### PR DESCRIPTION
## Summary
- wire the contact form to the Formspree endpoint with success and failure handling instead of the temporary local queue copy
- document Google AdSense, Funding Choices, reCAPTCHA, Cloudinary, and Formspree participation in the privacy policy
- align the drawer markup/styles with the required visually hidden heading class and tidy focus bookkeeping

## Testing
- npm i
- npx playwright install --with-deps *(fails: blocked fetching apt packages via proxy)*
- npx playwright test tests/nav.spec.* --project=chromium *(fails: browsers not installed in container)*
- npx playwright test tests/consent-ads.spec.* --project=chromium *(fails: browsers not installed in container)*
- npx playwright test tests/forms.spec.* --project=chromium *(fails: no matching tests)*

------
https://chatgpt.com/codex/tasks/task_e_68e085e72e948332bf1902806753d28f