### PR TITLE
Fix species schema tags to restore Betta and Tiger Barb options

### DIFF
--- a/js/logic/speciesSchema.js
+++ b/js/logic/speciesSchema.js
@@ -6,9 +6,10 @@ export const REQUIRED_FIELDS = [
 import { BEHAVIOR_TAG_VALUES } from "./behaviorTags.js";
 
 const ALLOWED_TAGS = new Set([
-  "betta","livebearer","labyrinth","algae_specialist","nano",
-  "shoaler","bottom_dweller","fast_swimmer","nocturnal","territorial",
-  "fin_nipper","fin_sensitive","predator_shrimp","predator_snail","invert_safe","cichlid"
+  "betta","betta_male","livebearer","labyrinth","algae_specialist","nano",
+  "shoaler","schooling_shoaler","bottom_dweller","fast_swimmer","nocturnal","territorial",
+  "fin_nipper","fin_sensitive","predator_shrimp","predator_snail","invert_safe","cichlid",
+  "long_fins","slow_long_fins","aggressive","semi_aggressive"
 ]);
 
 const ALLOWED_BEHAVIOR_TAGS = new Set(BEHAVIOR_TAG_VALUES);


### PR DESCRIPTION
## Summary
- allow planner schema to accept the betta_male and schooling_shoaler tag variants used by the catalog
- include the long-fins and aggression related tags so Betta (Male) and Tiger Barb records validate again

## Testing
- node - <<'NODE'
import { SPECIES } from './js/logic/compute.js';
console.log('count', SPECIES.length);
console.log('betta_male', SPECIES.some(s=>s.id==='betta_male'));
console.log('tiger_barb', SPECIES.some(s=>s.id==='tiger_barb'));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e09a569f588332a1a43b88a729a020