### PR TITLE
Add Amazon image link audit tooling

### DIFF
--- a/media.html
+++ b/media.html
@@ -180,6 +180,12 @@
       color: #0b1020;
     }
 
+    .affiliate-note {
+      font-size: .9rem;
+      opacity: .8;
+      margin: .25rem 0 .5rem;
+    }
+
     .resource-cover-link {
       display: inline-block;
       line-height: 0;
@@ -493,6 +499,7 @@
         <div class="resource-content">
           <p class="resource-title">The Tank Guide: Cycling &amp; Stocking Companion</p>
           <p class="resource-desc">“Life in Balance: The Hidden Magic of Aquariums” takes the confusion out of aquarium care, turning the nitrogen cycle into a simple, engaging story. Accurate yet easy to understand, it sparks curiosity in young readers while giving parents, teachers, and new aquarists the confidence to start their own aquarium journey.</p>
+          <p class="affiliate-note">As an Amazon Associate, we earn from qualifying purchases.</p>
           <a class="btn btn-amazon" href="https://amzn.to/3IRKvK0" target="_blank" rel="sponsored noopener noreferrer">Buy Book On Amazon</a>
         </div>
       </div>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "serve:static": "npx http-server -p 8080 -c-1 .",
     "test:headed": "npx playwright test --headed",
     "test:debug": "npx playwright test --debug",
-    "test:report": "npx playwright show-report"
+    "test:report": "npx playwright show-report",
+    "audit:amazon:img": "node tests/verify-amazon-image-links.cjs"
   },
   "devDependencies": {
     "@playwright/test": "^1.42.0"

--- a/tests/amazon-image-link-audit.md
+++ b/tests/amazon-image-link-audit.md
@@ -1,0 +1,28 @@
+# Amazon Image Link Audit
+
+## Totals
+- Files scanned: 63
+- Image-affiliate anchors found: 1
+- Patched: 1
+- Already compliant: 0
+
+## Updated Anchors
+| file | ~line | hostname | rel merged | target set | disclosure action |
+| --- | --- | --- | --- | --- | --- |
+| media.html | ~496 | amzn.to | already had `sponsored noopener noreferrer` | already `_blank` | added |
+
+## Potential cloaking – manual review
+- None
+
+## Short link – verify tag
+- media.html – https://amzn.to/3IRKvK0
+
+## Diff Summary
+- media.html: +7 −0
+- package.json: +2 −1
+- tests/verify-amazon-image-links.cjs: +118 −0
+- tests/amazon-image-link-summary.json: +23 −0
+- tests/amazon-image-link-audit.md: +28 −0
+
+## Verification
+- PASS – [amazon-image-links] files=63 anchors=1 ok=1 violations=0 shortLinks=1

--- a/tests/amazon-image-link-summary.json
+++ b/tests/amazon-image-link-summary.json
@@ -1,0 +1,23 @@
+{
+  "scannedFiles": 63,
+  "anchorsChecked": 1,
+  "violations": [],
+  "compliant": 1,
+  "shortLinks": [
+    {
+      "file": "/workspace/website-fish-keeper/media.html",
+      "href": "https://amzn.to/3IRKvK0"
+    }
+  ],
+  "report": [
+    {
+      "file": "/workspace/website-fish-keeper/media.html",
+      "href": "https://amzn.to/3IRKvK0",
+      "hasImg": true,
+      "rel": "sponsored noopener noreferrer",
+      "target": "_blank",
+      "shortLink": true,
+      "ok": true
+    }
+  ]
+}

--- a/tests/verify-amazon-image-links.cjs
+++ b/tests/verify-amazon-image-links.cjs
@@ -1,0 +1,118 @@
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+const INCLUDE_EXT = new Set(['.html', '.htm', '.js', '.jsx', '.ts', '.tsx']);
+const EXCLUDE_DIRS = new Set(['node_modules', 'dist', 'build', '.next', '.vercel', 'backups', '.git']);
+
+const amazonHostRe = /https?:\/\/(?:www\.)?amazon\.[a-z.]+\/\S*/i;
+const amznShortRe = /https?:\/\/amzn\.to\/\S*/i;
+
+// crude but effective anchor-with-image detector (handles nested tags)
+const anchorRe = /<a\b[^>]*href\s*=\s*(['\"])(.*?)\1[^>]*>([\s\S]*?)<\/a>/gi;
+const hasImgRe = /<img\b[^>]*>/i;
+
+// helper to check rel contains required tokens
+const needsTokens = (rel) => {
+  const want = ['sponsored', 'noopener', 'noreferrer'];
+  const have = (rel || '').toLowerCase().split(/\s+/).filter(Boolean);
+  const miss = want.filter(t => !have.includes(t));
+  return { have, miss, ok: miss.length === 0 };
+};
+
+const results = {
+  scannedFiles: 0,
+  anchorsChecked: 0,
+  violations: [],
+  compliant: 0,
+  shortLinks: [],
+  report: [],
+};
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (!EXCLUDE_DIRS.has(e.name)) walk(path.join(dir, e.name));
+      continue;
+    }
+    const ext = path.extname(e.name).toLowerCase();
+    if (!INCLUDE_EXT.has(ext)) continue;
+    const file = path.join(dir, e.name);
+    verifyFile(file);
+  }
+}
+
+function verifyFile(file) {
+  let text;
+  try { text = fs.readFileSync(file, 'utf8'); }
+  catch { return; }
+  results.scannedFiles++;
+
+  let m;
+  while ((m = anchorRe.exec(text))) {
+    const raw = m[0]; const href = m[2]; const inner = m[3];
+    const isAmazon = amazonHostRe.test(href) || amznShortRe.test(href);
+    if (!isAmazon) continue;
+
+    // image-based?
+    if (!hasImgRe.test(inner)) continue;
+
+    results.anchorsChecked++;
+
+    // Pull rel/target quickly (best-effort; AST in real patcher)
+    const relMatch = raw.match(/\brel\s*=\s*(['\"])(.*?)\1/i);
+    const targetMatch = raw.match(/\btarget\s*=\s*(['\"])(.*?)\1/i);
+    const relVal = relMatch ? relMatch[2] : '';
+    const targetVal = targetMatch ? targetMatch[2] : '';
+
+    const tcheck = targetVal === '_blank';
+    const rcheck = needsTokens(relVal);
+
+    const short = amznShortRe.test(href);
+    if (short) results.shortLinks.push({ file, href });
+
+    if (tcheck && rcheck.ok) {
+      results.compliant++;
+    } else {
+      results.violations.push({
+        file,
+        href,
+        missingRelTokens: rcheck.miss,
+        targetOk: tcheck,
+      });
+    }
+
+    results.report.push({
+      file,
+      href,
+      hasImg: true,
+      rel: relVal,
+      target: targetVal || '(none)',
+      shortLink: short,
+      ok: tcheck && rcheck.ok,
+    });
+  }
+}
+
+walk(ROOT);
+
+const summaryPath = path.join(ROOT, 'tests', 'amazon-image-link-summary.json');
+fs.mkdirSync(path.dirname(summaryPath), { recursive: true });
+fs.writeFileSync(summaryPath, JSON.stringify(results, null, 2));
+
+const violations = results.violations.length;
+const msg = `[amazon-image-links] files=${results.scannedFiles} anchors=${results.anchorsChecked} ok=${results.compliant} violations=${violations} shortLinks=${results.shortLinks.length}`;
+console.log(msg);
+if (violations > 0) {
+  console.log('Violations:');
+  results.violations.slice(0, 25).forEach(v =>
+    console.log(`- ${v.file} :: ${v.href} :: missing rel tokens [${v.missingRelTokens.join(', ')}], targetOk=${v.targetOk}`));
+  process.exitCode = 1;
+}
+
+// --- Add to package.json "scripts" (merge safely) ---
+// "audit:amazon:img": "node tests/verify-amazon-image-links.cjs"
+
+// --- Helper CSS (only if you inserted disclosures and no style exists) ---
+// .affiliate-note{font-size:.9rem;opacity:.8;margin:.25rem 0 .5rem}


### PR DESCRIPTION
## Summary
- add affiliate disclosure and supporting styling around the Amazon-linked image CTA on media.html
- add a Node-based verifier script and npm script for auditing Amazon image links
- capture the audit results in markdown and JSON reports for compliance tracking

## Testing
- npm run audit:amazon:img

------
https://chatgpt.com/codex/tasks/task_e_68e11fc079d48332912ce35f4f4c0454