### PR TITLE
Add Codex experiments log document

### DIFF
--- a/Codex-Experiments.md
+++ b/Codex-Experiments.md
@@ -1,0 +1,39 @@
+# Codex Experiments Log — Observation & Behavior Record (October 4, 2025)
+This file complements the **AI-Learning-Journal.md**.  
+While that file captures insights about *how the user learns*, this one captures *what Codex does* — every test, behavior, and unexpected reaction.
+
+## Purpose
+To create a running experimental log that documents:
+- What prompts were given to Codex  
+- What Codex produced in response  
+- How accurate or successful the outcome was  
+- Any anomalies, errors, or “ghost moments” that occurred  
+- Lessons learned about how Codex interprets human instructions
+
+Each entry should be dated and include these four sections:
+1. **Prompt Summary** – the task or instruction sent to Codex.  
+2. **Result** – what Codex actually did (file created, lines changed, errors, etc.).  
+3. **Analysis** – observations about why Codex might have acted that way.  
+4. **Next Adjustment** – what to change in the next iteration or how to refine future prompts.
+
+## Initial Context (from current conversation)
+- The user recently discovered that Codex can create and edit files directly inside ChatGPT’s Code Lab environment.  
+- We are using Codex to generate two “journal-type” markdown files (`AI-Learning-Journal.md` and this one).  
+- The goal is to study both human prompting patterns and AI execution reliability over time.  
+- The user plans to log ghost moments, partial outputs, or unusual behavior as part of this study.
+
+## Template Example
+### [Date: YYYY-MM-DD]
+**Prompt Summary:**  
+_Describe the Codex instruction or audit you ran._
+
+**Result:**  
+_Summarize what Codex did — file created, edited, error message, or unexpected output._
+
+**Analysis:**  
+_Why might Codex have done that? Was the prompt clear? Did it need more structure?_
+
+**Next Adjustment:**  
+_What to test or refine next time._
+
+Append all future experiment entries in chronological order below this header.


### PR DESCRIPTION
## Summary
- add the Codex experiments log markdown template for tracking prompts and outcomes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e16f45bee88332a5f7dd19f10b0a65