### PR TITLE
Convert Amazon export to gear master dataset

### DIFF
--- a/data/gear_master.csv
+++ b/data/gear_master.csv
@@ -1,0 +1,13 @@
+Category,Item_Name,Tank_Size_Range,Price_Range,Notes,Amazon_Link,Chewy_Link,Status
+Filtration,Fluval 107 Performance Canister Filter,,Mid,Great for 30-gallon setups,https://www.amazon.com/dp/B07KXJGDLT/?tag=fishkeepinglife-20,,Active
+Filtration,AquaClear 50 Power Filter,,Budget,,https://www.amazon.com/dp/B0002566WY/?tag=fishkeepinglife-20,,Active
+Filtration,Seachem Tidal 55 Hang On Back Filter,,Mid,Quiet motor,https://www.amazon.com/dp/B01M0N8FPT/?tag=fishkeepinglife-20,,Active
+Filtration,Tetra Whisper IQ Power Filter 45,,Budget,Budget-friendly option,https://www.amazon.com/dp/B0B3QFMG6M/?tag=fishkeepinglife-20,,Active
+Filtration,Hygger Quiet Aquarium Power Filter,,Budget,,https://www.amazon.com/dp/B08F2Z4M6W/?tag=fishkeepinglife-20,,Active
+Filtration,MarineLand Penguin 350 BIO-Wheel Filter,,Budget,,https://www.amazon.com/dp/B07PHLZYRZ/?tag=fishkeepinglife-20,,Active
+Filtration,Aqueon QuietFlow Canister Filter 200,,Premium,Includes media baskets,https://www.amazon.com/dp/B08N4G6GRH/?tag=fishkeepinglife-20,,Active
+Filtration,Fluval FX4 High Performance Canister Filter,,Premium,For large tanks,https://www.amazon.com/dp/B09R7MDG8M/?tag=fishkeepinglife-20,,Active
+Filtration,SunSun HW-3000 Canister Filter,,Premium,,https://www.amazon.com/dp/B081V6B7LN/?tag=fishkeepinglife-20,,Active
+Filtration,Polar Aurora External Canister Filter,,Mid,,https://www.amazon.com/dp/B0834K1LXB/?tag=fishkeepinglife-20,,Active
+Filtration,Cascade 1500 Canister Filter,,Premium,Easy priming,https://www.amazon.com/dp/B0BR8HH7ND/?tag=fishkeepinglife-20,,Active
+Filtration,Eheim Classic External Canister Filter 2213,,Mid,,https://www.amazon.com/dp/B005QRDCP2/?tag=fishkeepinglife-20,,Active

--- a/data/raw/exportedList_1K6C25CO6ESSX.csv
+++ b/data/raw/exportedList_1K6C25CO6ESSX.csv
@@ -1,0 +1,13 @@
+ASIN,Title,Price,Availability,Comments,Quantity
+B07KXJGDLT,Fluval 107 Performance Canister Filter,$134.99,In Stock,Great for 30-gallon setups,1
+B0002566WY,AquaClear 50 Power Filter,$59.99,In Stock,,1
+B01M0N8FPT,Seachem Tidal 55 Hang On Back Filter,$99.99,Usually ships within 3 days,Quiet motor,2
+B0B3QFMG6M,Tetra Whisper IQ Power Filter 45,$44.99,In Stock,Budget-friendly option,1
+B08F2Z4M6W,Hygger Quiet Aquarium Power Filter,$32.49,In Stock,,1
+B07PHLZYRZ,MarineLand Penguin 350 BIO-Wheel Filter,$49.99,In Stock,,1
+B08N4G6GRH,Aqueon QuietFlow Canister Filter 200,$179.99,In Stock,Includes media baskets,1
+B09R7MDG8M,Fluval FX4 High Performance Canister Filter,$329.99,Backordered 1-2 weeks,For large tanks,1
+B081V6B7LN,SunSun HW-3000 Canister Filter,$219.99,In Stock,,1
+B0834K1LXB,Polar Aurora External Canister Filter,$89.99,In Stock,,1
+B0BR8HH7ND,Cascade 1500 Canister Filter,$179.95,Low stock,Easy priming,1
+B005QRDCP2,Eheim Classic External Canister Filter 2213,$109.00,In Stock,,1

--- a/scripts/convert_amazon_list.py
+++ b/scripts/convert_amazon_list.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Convert Amazon list export to TheTankGuide gear master schema."""
+from __future__ import annotations
+
+import csv
+import re
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+INPUT_FILE = Path("data/raw/exportedList_1K6C25CO6ESSX.csv")
+OUTPUT_FILE = Path("data/gear_master.csv")
+
+CATEGORY = "Filtration"
+AMAZON_ASSOCIATE_TAG = "fishkeepinglife-20"
+
+PRICE_BUDGET_MAX = 60.0
+PRICE_MID_MAX = 150.0
+
+
+def _normalize_keys(row: Dict[str, str]) -> Dict[str, str]:
+    """Return a dict with lower-cased keys preserving original values."""
+    return {key.lower(): value for key, value in row.items()}
+
+
+def _first_value(row: Dict[str, str], candidates: Iterable[str]) -> str:
+    for candidate in candidates:
+        value = row.get(candidate.lower(), "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _parse_price(raw_price: str) -> Optional[float]:
+    if not raw_price:
+        return None
+    cleaned = raw_price.replace(",", "")
+    match = re.search(r"(-?\d+(?:\.\d+)?)", cleaned)
+    if not match:
+        return None
+    try:
+        return float(match.group(1))
+    except ValueError:
+        return None
+
+
+def _categorize_price(price: Optional[float]) -> str:
+    if price is None:
+        return ""
+    if price < PRICE_BUDGET_MAX:
+        return "Budget"
+    if price < PRICE_MID_MAX:
+        return "Mid"
+    return "Premium"
+
+
+def build_amazon_link(asin: str) -> str:
+    return f"https://www.amazon.com/dp/{asin}/?tag={AMAZON_ASSOCIATE_TAG}"
+
+
+def transform_row(row: Dict[str, str]) -> Optional[Dict[str, str]]:
+    normalized = _normalize_keys(row)
+
+    asin = _first_value(normalized, [
+        "asin",
+        "asin/isbn",
+        "isbn",
+        "product id",
+        "productid",
+        "item id",
+    ])
+    title = _first_value(normalized, [
+        "title",
+        "item name",
+        "item",
+        "product name",
+        "description",
+    ])
+    comments = _first_value(normalized, ["comments", "comment", "notes"])
+    price_raw = _first_value(normalized, [
+        "price",
+        "our price",
+        "price (usd)",
+        "current price",
+        "listed price",
+    ])
+
+    if not asin or not title:
+        return None
+
+    price_value = _parse_price(price_raw)
+    price_range = _categorize_price(price_value)
+
+    return {
+        "Category": CATEGORY,
+        "Item_Name": title,
+        "Tank_Size_Range": "",
+        "Price_Range": price_range,
+        "Notes": comments,
+        "Amazon_Link": build_amazon_link(asin),
+        "Chewy_Link": "",
+        "Status": "Active",
+    }
+
+
+def convert() -> None:
+    if not INPUT_FILE.exists():
+        raise FileNotFoundError(f"Input file not found: {INPUT_FILE}")
+
+    with INPUT_FILE.open("r", newline="", encoding="utf-8-sig") as source:
+        reader = csv.DictReader(source)
+        rows = []
+        for raw_row in reader:
+            transformed = transform_row(raw_row)
+            if transformed is not None:
+                rows.append(transformed)
+
+    OUTPUT_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with OUTPUT_FILE.open("w", newline="", encoding="utf-8") as target:
+        fieldnames = [
+            "Category",
+            "Item_Name",
+            "Tank_Size_Range",
+            "Price_Range",
+            "Notes",
+            "Amazon_Link",
+            "Chewy_Link",
+            "Status",
+        ]
+        writer = csv.DictWriter(target, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+if __name__ == "__main__":
+    convert()


### PR DESCRIPTION
## Summary
- add the exported Amazon list under data/raw for reproducible processing
- script conversion logic that normalizes columns, builds affiliate links, and categorizes price ranges
- generate gear_master.csv in the target schema with filtration entries marked Active

## Testing
- python3 scripts/convert_amazon_list.py

------
https://chatgpt.com/codex/tasks/task_e_68e1dbb7bdbc8332bf5e2a6809574af5