### PR TITLE
chore(security): add external security headers verification and finalize 2025-10-05 audit

### DIFF
--- a/.github/workflows/security-headers-verify.yml
+++ b/.github/workflows/security-headers-verify.yml
@@ -1,0 +1,117 @@
+name: Security Headers Verify
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 1 */3 *"  # quarterly at 06:00 UTC on the 1st
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fetch headers (apex)
+        id: apex
+        run: |
+          curl -sSI https://thetankguide.com > apex.headers || true
+          cat apex.headers
+
+      - name: Fetch headers (www)
+        id: www
+        run: |
+          curl -sSI https://www.thetankguide.com > www.headers || true
+          cat www.headers
+
+      - name: Prepare required headers
+        id: requirements
+        run: |
+          cat <<'JSON' > required.json
+          {
+            "strict-transport-security": "max-age=63072000; includeSubDomains; preload",
+            "x-frame-options": "SAMEORIGIN",
+            "x-content-type-options": "nosniff",
+            "referrer-policy": "strict-origin-when-cross-origin",
+            "permissions-policy": "geolocation=(), microphone=(), camera=()"
+          }
+          JSON
+          cat required.json
+
+      - name: Validate headers with Python
+        run: |
+          python3 - <<'PY'
+import json, sys
+
+def parse(path):
+    headers = {}
+    with open(path, 'r', encoding='utf-8', errors='ignore') as fh:
+        for line in fh:
+            if ':' in line:
+                key, value = line.split(':', 1)
+                headers[key.strip().lower()] = value.strip()
+    return headers
+
+with open('required.json', 'r', encoding='utf-8') as fh:
+    required = json.load(fh)
+
+apex = parse('apex.headers')
+www = parse('www.headers')
+
+missing = {}
+mismatch = {}
+
+for name, expected in required.items():
+    for label, headers in {'https://thetankguide.com': apex, 'https://www.thetankguide.com': www}.items():
+        target_missing = missing.setdefault(label, [])
+        target_mismatch = mismatch.setdefault(label, [])
+        if name not in headers:
+            target_missing.append(name)
+        elif headers[name] != expected:
+            target_mismatch.append({"header": name, "actual": headers[name], "expected": expected})
+
+status = 'verified'
+if any(missing.values()) or any(mismatch.values()):
+    status = 'failed'
+
+result = {
+    "status": status,
+    "verified_at_utc": __import__('datetime').datetime.utcnow().isoformat() + 'Z',
+    "method": "github-actions-curl",
+    "endpoints": {
+        "https://thetankguide.com": {
+            "headers": apex,
+            "missing": missing["https://thetankguide.com"],
+            "mismatch": mismatch["https://thetankguide.com"]
+        },
+        "https://www.thetankguide.com": {
+            "headers": www,
+            "missing": missing["https://www.thetankguide.com"],
+            "mismatch": mismatch["https://www.thetankguide.com"]
+        }
+    },
+    "requirements": required
+}
+
+with open('gha-security-headers-result.json', 'w', encoding='utf-8') as fh:
+    json.dump(result, fh, indent=2)
+
+print(json.dumps(result, indent=2))
+
+if status != 'verified':
+    sys.exit(1)
+PY
+
+      - name: Upload artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-headers-result
+          path: gha-security-headers-result.json
+
+      - name: Commit report back to repo (even on failure)
+        if: always()
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore(security): add GitHub Actions security headers verification report"
+          file_pattern: gha-security-headers-result.json
+          branch: ${{ github.ref_name }}

--- a/docs/CHANNEL_LOG.md
+++ b/docs/CHANNEL_LOG.md
@@ -88,3 +88,6 @@ Footer v1.2.2 (Sept 30, 2025)
 **Owner:** FishKeepingLifeCo (CXLXC LLC)
 
 **Summary:** Compliance line added to footer on all pages: “As an Amazon Associate, I earn from qualifying purchases.”
+## [2025-10-05] — Security Headers Verification (External Runner Added)
+Outbound HTTPS blocked in this environment. Added GitHub Action to verify headers at edge and commit report.
+

--- a/scripts/finalize-security-headers.py
+++ b/scripts/finalize-security-headers.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Finalize security headers verification audit data."""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SOURCE_FILE = REPO_ROOT / "gha-security-headers-result.json"
+DOCS_DIR = REPO_ROOT / "docs" / "security"
+CHANNEL_LOG = REPO_ROOT / "docs" / "CHANNEL_LOG.md"
+
+
+def load_result() -> dict:
+    if not SOURCE_FILE.exists():
+        print(
+            "gha-security-headers-result.json not found. Run the GitHub Actions workflow first.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    with SOURCE_FILE.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def write_audit_file(result: dict, today_utc: str) -> Path:
+    DOCS_DIR.mkdir(parents=True, exist_ok=True)
+    target = DOCS_DIR / f"security-audit-{today_utc}-gha.json"
+    with target.open("w", encoding="utf-8") as handle:
+        json.dump(result, handle, indent=2)
+        handle.write("\n")
+    return target
+
+
+def append_channel_log(result: dict, today_utc: str) -> None:
+    status = result.get("status", "unknown").lower()
+    verified_at = result.get("verified_at_utc", "unknown")
+    icon = "✅" if status == "verified" else "❌"
+    outcome = "succeeded" if status == "verified" else "failed"
+
+    heading = f"## [{today_utc}] — Security Headers Verification (External Runner Added)"
+    message_lines = [
+        heading,
+        f"{icon} GitHub Actions verification {outcome} at {verified_at}.",
+        "Outbound HTTPS blocked in this environment. Added GitHub Action to verify headers at edge and commit report.",
+        "",
+    ]
+    block = "\n".join(message_lines)
+
+    existing = CHANNEL_LOG.read_text(encoding="utf-8") if CHANNEL_LOG.exists() else ""
+
+    pattern = re.compile(
+        rf"{re.escape(heading)}(?:\n.*?)(?:\n\n|\Z)",
+        flags=re.DOTALL,
+    )
+
+    if pattern.search(existing):
+        updated = pattern.sub(block + ("\n" if not block.endswith("\n") else ""), existing)
+    else:
+        updated = existing
+        if updated and not updated.endswith("\n"):
+            updated += "\n"
+        updated += block
+
+    if not updated.endswith("\n"):
+        updated += "\n"
+
+    CHANNEL_LOG.write_text(updated, encoding="utf-8")
+
+
+def main() -> None:
+    result = load_result()
+    today_utc = datetime.now(timezone.utc).date().isoformat()
+    audit_path = write_audit_file(result, today_utc)
+    append_channel_log(result, today_utc)
+    print(f"Wrote {audit_path} and appended CHANNEL_LOG entry.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a scheduled and on-demand workflow that fetches Cloudflare response headers for apex and www, validates the required policies, and stores the JSON result
- provide a finalize-security-headers helper script to persist the workflow output into the docs tree and update the channel log
- log that direct verification is blocked in this environment so the external GitHub Actions runner closes the previously stalled audit loop

## Testing
- not run (workflow only)

------
https://chatgpt.com/codex/tasks/task_e_68e1e76bb4a88332afacbb8a4201c830