### PR TITLE
fix: treat security header outputs as raw text

### DIFF
--- a/.github/workflows/security-headers-verify.yml
+++ b/.github/workflows/security-headers-verify.yml
@@ -31,10 +31,9 @@ jobs:
 
       - name: Combine and format JSON output
         run: |
-          jq -n \
-            --slurpfile apex apex_headers.txt \
-            --slurpfile www www_headers.txt \
-            '{timestamp: now, apex: ($apex | tostring), www: ($www | tostring)}' \
+          jq -n --rawfile apex apex_headers.txt --rawfile www www_headers.txt \
+            --arg now "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+            '{timestamp: $now, apex: $apex, www: $www}' \
             > security-headers-output.json
 
       - name: Upload verification artifact


### PR DESCRIPTION
## Summary
- load the apex and www header files as raw text when combining them with jq
- inject an explicit UTC timestamp argument so the JSON output remains valid

## Testing
- not run (workflow update)

------
https://chatgpt.com/codex/tasks/task_e_68e1f80e40008332a1d1f0af4adfb4fe