### PR TITLE
Add weekly security headers verification schedule

### DIFF
--- a/.github/workflows/security-headers-verify.yml
+++ b/.github/workflows/security-headers-verify.yml
@@ -1,9 +1,9 @@
 name: Security Headers Verify
 
 on:
-  workflow_dispatch:
   schedule:
-    - cron: "0 3 * * *"  # daily at 03:00 UTC
+    - cron: "15 9 * * 0"   # Sundays 09:15 UTC
+  workflow_dispatch: {}
 
 jobs:
   verify:
@@ -42,12 +42,18 @@ jobs:
           name: security-headers-verify
           path: security-headers-output.json
 
+      - name: Append scheduled run entry to channel log
+        if: github.event_name == 'schedule'
+        run: |
+          timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+          echo "✅ ${timestamp} — Scheduled security headers verification completed. Artifact: security-headers-verify" >> docs/CHANNEL_LOG.md
+
       - name: Commit latest report into docs/security
         run: |
           mkdir -p docs/security
           mv security-headers-output.json docs/security/security-headers-verify-latest.json
           git config user.name "github-actions"
           git config user.email "actions@github.com"
-          git add docs/security/security-headers-verify-latest.json
+          git add docs/security/security-headers-verify-latest.json docs/CHANNEL_LOG.md
           git commit -m "chore(security): update security headers verification report" || echo "No changes to commit"
           git push || echo "Push skipped (PR flow or no changes)"

--- a/README.MD
+++ b/README.MD
@@ -30,17 +30,22 @@ This repository powers **The Tank Guide**, a static website with aquarium tools 
 
 ---
 
-## 📌 Release Management  
-All production changes are logged:  
-1. **Channel Log** — `/docs/CHANNEL_LOG.md` (source of truth, reverse-chronological)  
-2. **GitHub Releases** — synced with Channel Log entries, tagged for versioning  
+## 📌 Release Management
+All production changes are logged:
+1. **Channel Log** — `/docs/CHANNEL_LOG.md` (source of truth, reverse-chronological)
+2. **GitHub Releases** — synced with Channel Log entries, tagged for versioning
 
 ---
 
-## 🚦 Status  
-- ✅ Core pages live  
-- ✅ SEO metadata updated (Sept 2025)  
-- ✅ Headings + keyword alignment  
+## 🔐 Security
+[![Security Headers Verify](https://github.com/FishKeepingLifeCo/website-fish-keeper/actions/workflows/security-headers-verify.yml/badge.svg)](https://github.com/FishKeepingLifeCo/website-fish-keeper/actions/workflows/security-headers-verify.yml)
+
+---
+
+## 🚦 Status
+- ✅ Core pages live
+- ✅ SEO metadata updated (Sept 2025)
+- ✅ Headings + keyword alignment
 - ✅ Contact form v1.1 with reCAPTCHA secret key  
 - 🔄 Ongoing: bi-weekly release/channel log reviews  
 


### PR DESCRIPTION
## Summary
- schedule the Security Headers Verify workflow weekly while preserving manual dispatch support
- append scheduled run entries to docs/CHANNEL_LOG.md and continue committing the latest report artifact
- surface a Security section in the README with the workflow status badge

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1fc2858dc83328687c5f297ac4549