### PR TITLE
Use global nav/footer includes on gear page

### DIFF
--- a/assets/js/include-partials.js
+++ b/assets/js/include-partials.js
@@ -1,0 +1,20 @@
+(() => {
+  async function inject(el) {
+    const src = el.getAttribute('data-include');
+    if (!src) return;
+    try {
+      const res = await fetch(src, { cache: 'no-cache' });
+      if (!res.ok) throw new Error(`Failed include: ${src}`);
+      el.outerHTML = await res.text();
+    } catch (e) { console.error(e); }
+  }
+  function run() {
+    const nodes = document.querySelectorAll('[data-include]');
+    nodes.forEach(inject);
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', run);
+  } else {
+    run();
+  }
+})();

--- a/gear/index.html
+++ b/gear/index.html
@@ -8,8 +8,7 @@
   <link rel="stylesheet" href="/assets/css/gear.v2.css">
 </head>
 <body>
-  <!-- Global Nav Include -->
-  <div data-include="/nav.html"></div>
+  <header id="site-nav" data-include="/partials/nav.html"></header>
 
   <!-- Sticky Tank Reference -->
   <section id="tank-ref" class="tank-ref" aria-label="Tank reference">
@@ -83,11 +82,9 @@
     <div id="substrate-body" class="gear-card__body" hidden></div>
   </section>
 
-  <!-- Global Footer Include -->
-  <div data-include="/footer.v1.3.0.html"></div>
-
   <script src="/assets/js/gear.v2.data.js" defer></script>
   <script src="/assets/js/gear.v2.js" defer></script>
-  <script src="/assets/js/includes.js" defer></script>
+  <footer id="site-footer" data-include="/partials/footer.html"></footer>
+  <script src="/assets/js/include-partials.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the gear page's local navigation markup with the global nav include hook
- load the shared footer partial and new include loader script for consistency
- add the reusable include-partials loader used to inject partial HTML

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2c221cb048332b358fd13cbff466c