### PR TITLE
Update gear page tank selector and highlighting

### DIFF
--- a/assets/css/gear.v2.css
+++ b/assets/css/gear.v2.css
@@ -1,28 +1,231 @@
-:root{ --bg:#0f172a; --card:#111827; --ink:#e5e7eb; --muted:#9ca3af; --accent:#60a5fa; --line:#1f2937; --active:#22c55e; }
-body{ background:var(--bg); color:var(--ink); font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Arial; margin:0; }
-[data-include]{ display:block; }
-.tank-ref{ position:sticky; top:0; z-index:50; backdrop-filter:saturate(160%) blur(6px); background:rgba(15,23,42,.9); border-bottom:1px solid var(--line); }
-.tank-ref__row{ max-width:1000px; margin:0 auto; padding:10px 16px; display:grid; grid-template-columns: 1fr 1fr 1fr auto; gap:12px; align-items:end; }
-.tank-ref__field label{ display:block; font-size:12px; color:var(--muted); margin-bottom:4px; }
-.tank-ref__field input, .tank-ref__field select{ width:100%; padding:8px 10px; background:#0b1220; color:var(--ink); border:1px solid var(--line); border-radius:6px; }
-.tank-ref__info{ font-size:12px; color:var(--muted); padding-left:8px; }
+:root{
+  --bg:#0f172a;
+  --card:#111827;
+  --ink:#e5e7eb;
+  --muted:rgba(226,232,240,0.72);
+  --accent:#60a5fa;
+  --line:rgba(255,255,255,0.12);
+  --active:#22c55e;
+  --shadow:0 18px 36px -24px rgba(15,23,42,0.8);
+}
 
-.gear-card{ max-width:1000px; margin:16px auto; background:var(--card); border:1px solid var(--line); border-radius:10px; overflow:hidden; }
-.gear-card__header{ display:flex; align-items:center; justify-content:space-between; padding:14px 16px; cursor:pointer; user-select:none; }
-.gear-card__header h2{ margin:0; font-size:18px; }
-.info-btn{ border:1px solid var(--line); background:#0b1220; color:var(--ink); border-radius:50%; width:22px; height:22px; font-size:12px; }
-.chevron{ transition:transform .2s ease; }
-.gear-card__header[aria-expanded="true"] .chevron{ transform:rotate(90deg); }
-.gear-card__body{ padding:12px 16px 16px; display:grid; gap:12px; }
-.range{ border:1px dashed var(--line); border-radius:8px; padding:10px 12px; }
-.range.is-active{ border-color:var(--active); box-shadow:0 0 0 2px rgba(34,197,94,.25) inset; }
-.range__title{ font-weight:600; margin:0 0 4px; }
-.range__tip{ color:var(--muted); font-size:13px; margin:0 0 8px; }
-.option{ margin:2px 0; }
-.option a{ color:var(--accent); text-decoration:none; }
-.option a:hover{ text-decoration:underline; }
+body{
+  background:var(--bg);
+  color:var(--ink);
+  font:16px/1.5 "Inter",system-ui,-apple-system,Segoe UI,Roboto,Arial;
+  margin:0;
+}
+
+[data-include]{
+  display:block;
+}
+
+.gear-page{
+  min-height:100vh;
+}
+
+.tank-ref{
+  position:sticky;
+  top:0;
+  z-index:90;
+  backdrop-filter:saturate(160%) blur(12px);
+  -webkit-backdrop-filter:saturate(160%) blur(12px);
+  background:rgba(15,23,42,0.92);
+  border-bottom:1px solid rgba(148,163,184,0.16);
+  padding:14px 16px 18px;
+}
+
+.card{
+  background:rgba(17,24,39,0.86);
+  border:1px solid rgba(148,163,184,0.24);
+  border-radius:18px;
+  box-shadow:var(--shadow);
+  padding:18px;
+}
+
+.card--tank{
+  width:min(960px,100%);
+  margin:0 auto;
+  display:flex;
+  flex-direction:column;
+  gap:14px;
+}
+
+.card-title{
+  margin:0;
+  font-size:clamp(1.4rem,2.4vw,1.8rem);
+  font-weight:700;
+  letter-spacing:-0.01em;
+}
+
+.card-field{
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+
+.field-label{
+  margin:0;
+  font-size:0.8rem;
+  text-transform:uppercase;
+  letter-spacing:0.12em;
+  color:var(--muted);
+}
+
+.select-wrap{
+  position:relative;
+}
+
+.select-wrap select{
+  display:block;
+  width:100%;
+  height:44px;
+  line-height:44px;
+  padding:0 44px 0 14px;
+  border-radius:12px;
+  border:1px solid rgba(255,255,255,0.16);
+  background:rgba(255,255,255,0.06);
+  color:inherit;
+  -webkit-appearance:none;
+  -moz-appearance:none;
+  appearance:none;
+}
+
+.select-wrap select:focus{
+  outline:2px solid rgba(96,165,250,0.65);
+  outline-offset:2px;
+}
+
+.select-wrap .chevron{
+  position:absolute;
+  right:16px;
+  top:50%;
+  width:16px;
+  height:16px;
+  transform:translateY(-50%);
+  opacity:0.8;
+  pointer-events:none;
+  transition:transform 0.18s ease,opacity 0.18s ease;
+}
+
+.select-wrap.open .chevron{
+  transform:translateY(-50%) rotate(180deg);
+}
+
+.tank-meta{
+  margin:4px 0 0;
+  font-size:0.95rem;
+  color:var(--muted);
+}
+
+.gear-shell{
+  width:min(960px,100%);
+  margin:0 auto;
+  padding:28px 16px 120px;
+  display:flex;
+  flex-direction:column;
+  gap:20px;
+}
+
+.gear-card{
+  background:rgba(17,24,39,0.88);
+  border:1px solid var(--line);
+  border-radius:18px;
+  box-shadow:var(--shadow);
+  overflow:hidden;
+}
+
+.gear-card__header{
+  display:flex;
+  align-items:center;
+  gap:12px;
+  padding:18px 20px;
+  cursor:pointer;
+  user-select:none;
+}
+
+.gear-card__header h2{
+  margin:0;
+  font-size:1.25rem;
+  font-weight:600;
+  flex:1;
+}
+
+.info-btn{
+  border:1px solid rgba(148,163,184,0.35);
+  background:rgba(15,23,42,0.6);
+  color:var(--ink);
+  border-radius:50%;
+  width:24px;
+  height:24px;
+  font-size:0.75rem;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+}
+
+.info-btn:focus-visible{
+  outline:2px solid var(--accent);
+  outline-offset:2px;
+}
+
+.gear-card__header .chevron{
+  transition:transform 0.2s ease;
+}
+
+.gear-card__body{
+  padding:12px 20px 20px;
+  display:grid;
+  gap:14px;
+}
+
+.range{
+  border:1px dashed rgba(148,163,184,0.45);
+  border-radius:12px;
+  padding:12px 14px;
+  background:rgba(15,23,42,0.45);
+}
+
+.range.is-active{
+  border-color:var(--active);
+  box-shadow:0 0 0 2px rgba(34,197,94,0.25) inset;
+}
+
+.range__title{
+  font-weight:600;
+  margin:0 0 6px;
+}
+
+.range__tip{
+  color:var(--muted);
+  font-size:0.9rem;
+  margin:0 0 10px;
+}
+
+.option{
+  margin:4px 0;
+}
+
+.option a{
+  color:var(--accent);
+  text-decoration:none;
+}
+
+.option a:hover,
+.option a:focus-visible{
+  text-decoration:underline;
+}
 
 @media (max-width:640px){
-  .tank-ref__row{ grid-template-columns: 1fr 1fr; }
-  .tank-ref__info{ grid-column: 1 / -1; padding:0; margin-top:4px; }
+  .card-title{
+    font-size:1.4rem;
+  }
+
+  .gear-card__header{
+    padding:16px;
+  }
+
+  .gear-card__body{
+    padding:12px 16px 18px;
+  }
 }

--- a/assets/js/gear.v2.js
+++ b/assets/js/gear.v2.js
@@ -1,37 +1,80 @@
 (function(){
-  /* Utility: simple element builder */
-  function el(tag, attrs={}, html=""){
-    const n = document.createElement(tag);
-    Object.entries(attrs).forEach(([k,v])=>{
-      if(k==="class") n.className=v;
-      else if(k==="html") n.innerHTML=v;
-      else n.setAttribute(k,v);
+  const STORAGE_KEY = 'gearTankSelection';
+  const INCH_TO_CM = 2.54;
+
+  const TANK_PRESETS = [
+    { id:'5g',   label:'5 Gallon (19 L)',    gallons:5,   liters:19,  lengthIn:16.2,   widthIn:8.4,   heightIn:10.5,  weightLbs:62 },
+    { id:'10g',  label:'10 Gallon (38 L)',   gallons:10,  liters:38,  lengthIn:20.25,  widthIn:10.5,  heightIn:12.6,  weightLbs:111 },
+    { id:'15g',  label:'15 Gallon (57 L)',   gallons:15,  liters:57,  lengthIn:20.25,  widthIn:10.5,  heightIn:18.75, weightLbs:170 },
+    { id:'20h',  label:'20 Gallon High (75 L)', gallons:20, liters:75, lengthIn:24.25, widthIn:12.5,  heightIn:16.75, weightLbs:225 },
+    { id:'20l',  label:'20 Gallon Long (75 L)', gallons:20, liters:75, lengthIn:30.25, widthIn:12.5,  heightIn:12.75, weightLbs:225 },
+    { id:'29g',  label:'29 Gallon (110 L)',   gallons:29,  liters:110, lengthIn:30.25, widthIn:12.5,  heightIn:18.75, weightLbs:330 },
+    { id:'40b',  label:'40 Gallon Breeder (151 L)', gallons:40, liters:151, lengthIn:36.25, widthIn:18.25, heightIn:16.75, weightLbs:458 },
+    { id:'55g',  label:'55 Gallon (208 L)',   gallons:55,  liters:208, lengthIn:48.25, widthIn:12.75, heightIn:21,    weightLbs:625 },
+    { id:'75g',  label:'75 Gallon (284 L)',   gallons:75,  liters:284, lengthIn:48.5,  widthIn:18.5,  heightIn:21.25, weightLbs:850 },
+    { id:'90g',  label:'90 Gallon (341 L)',   gallons:90,  liters:341, lengthIn:48.375,widthIn:18.375,heightIn:25,    weightLbs:1050 },
+    { id:'125g', label:'125 Gallon (473 L)',  gallons:125, liters:473, lengthIn:72,    widthIn:18,    heightIn:21,    weightLbs:1206 }
+  ];
+
+  const PRESET_MAP = new Map(TANK_PRESETS.map((preset) => [preset.id, preset]));
+
+  function el(tag, attrs = {}, html = ''){
+    const node = document.createElement(tag);
+    Object.entries(attrs).forEach(([key, value]) => {
+      if (key === 'class') node.className = value;
+      else if (key === 'html') node.innerHTML = value;
+      else node.setAttribute(key, value);
     });
-    if(html) n.innerHTML = html;
-    return n;
+    if (html) node.innerHTML = html;
+    return node;
   }
 
-  /* Info tips modal (lightweight) */
+  function toNumber(value){
+    const num = Number(value);
+    return Number.isFinite(num) ? num : null;
+  }
+
+  function round(value, places = 2){
+    const factor = Math.pow(10, places);
+    return Math.round(value * factor) / factor;
+  }
+
+  function formatNumber(value){
+    if (!Number.isFinite(value)) return '';
+    if (Number.isInteger(value)) return String(value);
+    return String(round(value, 2));
+  }
+
+  function buildInfoLine(preset){
+    if (!preset) return '';
+    const gallons = Number.isFinite(preset.gallons) ? `${formatNumber(preset.gallons)}g` : '';
+    const liters = Number.isFinite(preset.liters) ? `${formatNumber(preset.liters)} L` : '';
+    const dimsIn = `${formatNumber(preset.lengthIn)} × ${formatNumber(preset.widthIn)} × ${formatNumber(preset.heightIn)} in`;
+    const dimsCm = `(${formatNumber(preset.lengthIn * INCH_TO_CM)} × ${formatNumber(preset.widthIn * INCH_TO_CM)} × ${formatNumber(preset.heightIn * INCH_TO_CM)} cm)`;
+    const weight = Number.isFinite(preset.weightLbs) && preset.weightLbs > 0 ? ` • ~${Math.round(preset.weightLbs)} lbs filled` : '';
+    return [gallons, liters, dimsIn, dimsCm].filter(Boolean).join(' • ') + weight;
+  }
+
   function showTip(kind){
-    const msg = TIPS[kind] || "No tip available.";
-    const wrap = el("div",{class:"tip-wrap",style:"position:fixed;inset:0;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center;z-index:60"});
-    const card = el("div",{style:"max-width:520px;background:#0b1220;color:#e5e7eb;border:1px solid #1f2937;border-radius:10px;padding:16px"});
-    card.innerHTML = `<h3 style="margin:0 0 8px">Tip</h3><p style="margin:0 0 12px;color:#9ca3af">${msg}</p><button style="padding:8px 12px;background:#111827;color:#e5e7eb;border:1px solid #1f2937;border-radius:6px">Close</button>`;
-    card.querySelector("button").onclick = ()=>wrap.remove();
-    wrap.onclick = (e)=>{ if(e.target===wrap) wrap.remove(); };
-    wrap.appendChild(card); document.body.appendChild(wrap);
+    const msg = TIPS[kind] || 'No tip available.';
+    const wrap = el('div',{class:'tip-wrap',style:'position:fixed;inset:0;background:rgba(0,0,0,.45);display:flex;align-items:center;justify-content:center;z-index:120'});
+    const card = el('div',{style:'max-width:520px;background:#0b1220;color:#e5e7eb;border:1px solid #1f2937;border-radius:14px;padding:18px;box-shadow:0 18px 36px -24px rgba(0,0,0,0.6)'});
+    card.innerHTML = `<h3 style="margin:0 0 10px;font-size:1.1rem;">Tip</h3><p style="margin:0 0 16px;color:#cbd5f5;line-height:1.45;">${msg}</p><button style="padding:8px 14px;background:#111827;color:#e5e7eb;border:1px solid #1f2937;border-radius:8px;cursor:pointer;">Close</button>`;
+    card.querySelector('button').onclick = () => wrap.remove();
+    wrap.onclick = (event) => { if (event.target === wrap) wrap.remove(); };
+    wrap.appendChild(card);
+    document.body.appendChild(wrap);
   }
 
-  /* Render a category body from data */
   function renderRangeBlock(range){
-    const wrap = el("div",{class:"range", "data-range-id":range.id});
-    wrap.appendChild(el("p",{class:"range__title"}, range.label));
-    if(range.tip) wrap.appendChild(el("p",{class:"range__tip"}, range.tip));
-    const list = el("div",{class:"range__list"});
-    (range.options||[]).forEach(opt=>{
-      const row = el("div",{class:"option"});
-      const linkOk = !!opt.href;
-      row.innerHTML = `<strong>${opt.label} — ${opt.title || "(add title)"}</strong><br>${ linkOk ? `<a href="${opt.href}" target="_blank" rel="noopener noreferrer">Buy on Amazon</a>` : `<span style="color:#9ca3af">Add link</span>` }`;
+    const wrap = el('div',{class:'range','data-range-id':range.id});
+    wrap.appendChild(el('p',{class:'range__title'}, range.label));
+    if (range.tip) wrap.appendChild(el('p',{class:'range__tip'}, range.tip));
+    const list = el('div',{class:'range__list'});
+    (range.options || []).forEach((opt) => {
+      const row = el('div',{class:'option'});
+      const hasLink = !!opt.href;
+      row.innerHTML = `<strong>${opt.label} — ${opt.title || '(add title)'}</strong><br>${hasLink ? `<a href="${opt.href}" target="_blank" rel="noopener noreferrer">Buy on Amazon</a>` : '<span style="color:#94a3b8;">Add link</span>'}`;
       list.appendChild(row);
     });
     wrap.appendChild(list);
@@ -39,112 +82,199 @@
   }
 
   function buildCategory(kind, container){
-    container.innerHTML = ""; // clear
+    if (!container) return;
+    container.innerHTML = '';
     let blocks = [];
-    if(kind==="heaters"){
-      blocks = (GEAR.heaters?.ranges||[]).map(renderRangeBlock);
-    } else if(kind==="filters"){
-      blocks = (GEAR.filters?.ranges||[]).map(renderRangeBlock);
-    } else if(kind==="lights"){
-      blocks = (GEAR.lights?.ranges||[]).map(renderRangeBlock);
-    } else if(kind==="substrate"){
-      blocks = (GEAR.substrate?.groups||[]).map(renderRangeBlock);
-    }
-    blocks.forEach(b=>container.appendChild(b));
+    if (kind === 'heaters') blocks = (GEAR.heaters?.ranges || []).map(renderRangeBlock);
+    else if (kind === 'filters') blocks = (GEAR.filters?.ranges || []).map(renderRangeBlock);
+    else if (kind === 'lights') blocks = (GEAR.lights?.ranges || []).map(renderRangeBlock);
+    else if (kind === 'substrate') blocks = (GEAR.substrate?.groups || []).map(renderRangeBlock);
+    blocks.forEach((block) => container.appendChild(block));
   }
 
-  /* Accordion behavior */
   function wireAccordions(){
-    document.querySelectorAll('[data-accordion="toggle"]').forEach(h=>{
-      h.addEventListener("click", toggle);
-      h.addEventListener("keydown", (e)=>{ if(e.key==="Enter"||e.key===" ") toggle.call(h,e); });
-      function toggle(e){
-        const expanded = this.getAttribute("aria-expanded")==="true";
-        const body = document.getElementById(this.getAttribute("aria-controls"));
-        this.setAttribute("aria-expanded", String(!expanded));
-        this.parentElement.querySelector(".chevron").style.transform = expanded ? "rotate(0deg)" : "rotate(90deg)";
-        body.hidden = expanded;
-      }
+    document.querySelectorAll('[data-accordion="toggle"]').forEach((header) => {
+      const controls = header.getAttribute('aria-controls');
+      const body = controls ? document.getElementById(controls) : null;
+      const chevron = header.querySelector('.chevron');
+
+      const setExpanded = (expanded) => {
+        if (!body) return;
+        body.hidden = !expanded;
+        header.setAttribute('aria-expanded', String(expanded));
+        if (chevron) {
+          chevron.style.transform = expanded ? 'rotate(90deg)' : 'rotate(0deg)';
+        }
+      };
+
+      header.__setExpanded = setExpanded;
+      setExpanded(header.getAttribute('aria-expanded') === 'true');
+
+      header.addEventListener('click', (event) => {
+        event.preventDefault();
+        const expanded = header.getAttribute('aria-expanded') === 'true';
+        setExpanded(!expanded);
+      });
+
+      header.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          const expanded = header.getAttribute('aria-expanded') === 'true';
+          setExpanded(!expanded);
+        }
+      });
     });
-    document.querySelectorAll('.info-btn').forEach(b=> b.addEventListener('click', ()=> showTip(b.getAttribute('data-tip')) ));
+
+    document.querySelectorAll('.info-btn').forEach((btn) => {
+      btn.addEventListener('click', () => showTip(btn.getAttribute('data-tip')));
+    });
   }
 
-  /* Sticky reference: matching + highlighting */
   function matchRange(value, ranges){
-    if(!value || isNaN(value)) return null;
-    const v = Number(value);
-    // choose the first range where v >= min and v <= max; else closest by min distance
-    let exact = ranges.find(r => v >= r.min && v <= r.max);
-    if(exact) return exact.id;
-    // nearest
-    let nearest = null, best = Infinity;
-    ranges.forEach(r=>{
-      const d = v < r.min ? (r.min - v) : (v - r.max);
-      if(d < best){ best = d; nearest = r; }
+    const numeric = toNumber(value);
+    if (!Number.isFinite(numeric)) return null;
+    const exact = ranges.find((range) => numeric >= range.min && numeric <= range.max);
+    if (exact) return exact.id;
+    let nearest = null;
+    let bestDistance = Infinity;
+    ranges.forEach((range) => {
+      const distance = numeric < range.min ? range.min - numeric : numeric - range.max;
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        nearest = range;
+      }
     });
     return nearest ? nearest.id : null;
   }
 
-  function applyHighlights(){
-    const gVal = document.getElementById('ref-gallons').value;
-    const lVal = document.getElementById('ref-length').value;
+  function setActiveRange(bodyId, rangeId){
+    if (!rangeId) return false;
+    const body = document.querySelector(bodyId);
+    if (!body) return false;
+    const block = body.querySelector(`[data-range-id="${rangeId}"]`);
+    if (!block) return false;
+    block.classList.add('is-active');
+    const header = body.previousElementSibling;
+    if (header && typeof header.__setExpanded === 'function') {
+      header.__setExpanded(true);
+    }
+    return true;
+  }
 
-    const heaterId = matchRange(gVal, RANGES_HEATERS);
-    const filterId = matchRange(gVal, RANGES_FILTERS);
-    const lightId  = matchRange(lVal, RANGES_LIGHTS);
+  function clearHighlights(){
+    document.querySelectorAll('.range.is-active').forEach((node) => node.classList.remove('is-active'));
+  }
 
-    // clear old
-    document.querySelectorAll('.range.is-active').forEach(n=>n.classList.remove('is-active'));
+  function applyHighlights(gallons, length){
+    clearHighlights();
+    const heaterId = matchRange(gallons, RANGES_HEATERS);
+    const filterId = matchRange(gallons, RANGES_FILTERS);
+    const lightId = matchRange(length, RANGES_LIGHTS);
+    const matches = {};
+    if (setActiveRange('#heaters-body', heaterId)) matches.heaters = heaterId;
+    if (setActiveRange('#filters-body', filterId)) matches.filters = filterId;
+    if (setActiveRange('#lights-body', lightId)) matches.lights = lightId;
+    return matches;
+  }
 
-    // apply & auto-open section if match
-    function activate(sectionSel, id){
-      if(!id) return;
-      const body = document.querySelector(sectionSel);
-      const block = body ? body.querySelector(`[data-range-id="${id}"]`) : null;
-      if(block){
-        block.classList.add('is-active');
-        // open accordion if closed
-        const header = body.previousElementSibling;
-        if(header && header.getAttribute('aria-expanded')==="false"){
-          header.click();
-        }
-        // ensure body is visible (if user closed after)
-        body.hidden = false;
-        header.setAttribute("aria-expanded","true");
-        header.querySelector(".chevron").style.transform = "rotate(90deg)";
-      }
+  function initTankSelect(){
+    const select = document.getElementById('gear-tank-size');
+    const wrap = document.getElementById('gear-tank-select-wrap');
+    const meta = document.getElementById('gear-tank-meta');
+    if (!select || !meta) return;
+
+    const existingBlank = select.querySelector('option[value=""]');
+    if (!existingBlank) {
+      const blank = document.createElement('option');
+      blank.value = '';
+      blank.textContent = 'Select a tank size…';
+      select.appendChild(blank);
     }
 
-    activate('#heaters-body', heaterId);
-    activate('#filters-body', filterId);
-    activate('#lights-body',  lightId);
-  }
-
-  function wireTankRef(){
-    const g = document.getElementById('ref-gallons');
-    const l = document.getElementById('ref-length');
-    const p = document.getElementById('ref-preset');
-    [g,l].forEach(inp => inp.addEventListener('input', applyHighlights));
-    p.addEventListener('change', ()=>{
-      try{
-        const v = JSON.parse(p.value || "{}");
-        if(v.g) document.getElementById('ref-gallons').value = v.g;
-        if(v.l) document.getElementById('ref-length').value = v.l;
-        applyHighlights();
-      }catch(_){ }
+    const fragment = document.createDocumentFragment();
+    TANK_PRESETS.forEach((preset) => {
+      const option = document.createElement('option');
+      option.value = preset.id;
+      option.textContent = preset.label;
+      fragment.appendChild(option);
     });
+    select.appendChild(fragment);
+
+    const setInfo = (preset) => {
+      if (!preset) {
+        meta.textContent = '';
+        meta.hidden = true;
+        return;
+      }
+      meta.textContent = buildInfoLine(preset);
+      meta.hidden = false;
+      meta.setAttribute('role', 'note');
+    };
+
+    const persistSelection = (id) => {
+      try {
+        if (id) localStorage.setItem(STORAGE_KEY, id);
+        else localStorage.removeItem(STORAGE_KEY);
+      } catch (_) {
+        /* noop */
+      }
+    };
+
+    const handleSelection = (id) => {
+      const preset = PRESET_MAP.get(id) || null;
+      if (!preset) {
+        select.value = '';
+        setInfo(null);
+        persistSelection('');
+        applyHighlights();
+        return;
+      }
+      setInfo(preset);
+      persistSelection(preset.id);
+      applyHighlights(preset.gallons, preset.lengthIn);
+    };
+
+    select.addEventListener('change', (event) => {
+      handleSelection(event.target.value);
+    });
+
+    if (wrap) {
+      const setOpen = (state) => wrap.classList.toggle('open', !!state);
+      select.addEventListener('focus', () => setOpen(true));
+      select.addEventListener('blur', () => setOpen(false));
+      select.addEventListener('click', () => setOpen(true));
+      select.addEventListener('change', () => setOpen(false));
+      document.addEventListener('visibilitychange', () => {
+        if (document.hidden) setOpen(false);
+      });
+    }
+
+    let saved = '';
+    try {
+      saved = localStorage.getItem(STORAGE_KEY) || '';
+    } catch (_) {
+      saved = '';
+    }
+
+    if (saved && PRESET_MAP.has(saved)) {
+      select.value = saved;
+      handleSelection(saved);
+    } else {
+      select.value = '';
+      setInfo(null);
+      applyHighlights();
+    }
   }
 
-  /* Init on DOM ready */
   function init(){
-    // build categories
-    buildCategory("heaters",  document.getElementById('heaters-body'));
-    buildCategory("filters",  document.getElementById('filters-body'));
-    buildCategory("lights",   document.getElementById('lights-body'));
-    buildCategory("substrate",document.getElementById('substrate-body'));
-    // wire interactions
+    buildCategory('heaters', document.getElementById('heaters-body'));
+    buildCategory('filters', document.getElementById('filters-body'));
+    buildCategory('lights', document.getElementById('lights-body'));
+    buildCategory('substrate', document.getElementById('substrate-body'));
     wireAccordions();
-    wireTankRef();
+    initTankSelect();
   }
-  if(document.readyState!=="loading") init(); else document.addEventListener("DOMContentLoaded", init);
+
+  if (document.readyState !== 'loading') init();
+  else document.addEventListener('DOMContentLoaded', init);
 })();

--- a/gear/index.html
+++ b/gear/index.html
@@ -11,208 +11,88 @@
   <link rel="stylesheet" href="/assets/css/gear.v2.css">
   <script defer src="/js/nav.js?v=1.1.0"></script>
 </head>
-<body>
-  <header id="global-nav">
-    <div class="inner">
-      <button
-        id="ttg-nav-open"
-        class="hamburger"
-        type="button"
-        aria-controls="ttg-drawer"
-        aria-expanded="false"
-        aria-label="Open menu"
-        data-nav="hamburger"
-      >
-        <span class="hamburger__bars" aria-hidden="true"></span>
-        <span class="visually-hidden">Open menu</span>
-      </button>
-      <a class="site-brand brand" href="/" aria-label="The Tank Guide — Home">
-        <span class="site-brand__title">The Tank Guide</span>
-        <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
-      </a>
-      <nav class="site-links links" aria-label="Primary">
-        <ul class="nav__list">
-          <li class="nav__item"><a href="/index.html" class="nav__link" data-nav="home">Home</a></li>
-          <li class="nav__item"><a href="/stocking.html" class="nav__link" data-nav="stocking">Stocking Advisor</a></li>
-          <li class="nav__item"><a href="/gear/index.html" class="nav__link" data-nav="gear">Gear</a></li>
-          <li class="nav__item"><a href="/media.html" class="nav__link" data-nav="media">Media</a></li>
-          <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link" data-nav="feature-your-tank">Feature Your Tank</a></li>
-          <li class="nav__item"><a href="/store.html" class="nav__link" data-nav="store">Store</a></li>
-          <li class="nav__item"><a href="/contact-feedback.html" class="nav__link" data-nav="contact-feedback">Contact &amp; Feedback</a></li>
-          <li class="nav__item"><a href="/about.html" class="nav__link" data-nav="about">About</a></li>
-          <li class="nav__item"><a href="/privacy-legal.html" class="nav__link" data-nav="privacy-legal">Privacy &amp; Legal</a></li>
-          <li class="nav__item"><a href="/terms.html" class="nav__link" data-nav="terms">Terms of Use</a></li>
-          <li class="nav__item"><a href="/copyright-dmca.html" class="nav__link" data-nav="copyright-dmca">Copyright &amp; DMCA</a></li>
-        </ul>
-      </nav>
+<body class="theme-dark">
+  <div id="site-nav"></div>
+  <main id="gear-page" class="gear-page" aria-labelledby="gear-title">
+    <section id="tank-ref" class="tank-ref" aria-label="Tank reference">
+      <div class="card card--tank">
+        <h1 id="gear-title" class="card-title">Tank Gear Guide</h1>
+        <div class="card-field">
+          <h3 class="field-label">Tank Size</h3>
+          <label for="gear-tank-size" class="sr-only">Tank Size</label>
+          <div id="gear-tank-select-wrap" class="select-wrap">
+            <select id="gear-tank-size" name="tank-size" data-role="tank-size" aria-label="Tank Size">
+              <option value="">Select a tank size…</option>
+            </select>
+            <svg class="chevron" aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+              <path d="M7 10l5 5 5-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </div>
+        </div>
+        <p id="gear-tank-meta" class="tank-meta" aria-live="polite" hidden></p>
+      </div>
+    </section>
+
+    <div class="gear-shell">
+      <section class="gear-card" data-gear="heaters">
+        <header class="gear-card__header" data-accordion="toggle" tabindex="0" aria-controls="heaters-body" aria-expanded="false">
+          <h2>Heaters</h2>
+          <button class="info-btn" type="button" aria-label="Heater tip" data-tip="heaters">i</button>
+          <span class="chevron" aria-hidden="true">▸</span>
+        </header>
+        <div id="heaters-body" class="gear-card__body" hidden></div>
+      </section>
+
+      <section class="gear-card" data-gear="filters">
+        <header class="gear-card__header" data-accordion="toggle" tabindex="0" aria-controls="filters-body" aria-expanded="false">
+          <h2>Filters</h2>
+          <button class="info-btn" type="button" aria-label="Filter tip" data-tip="filters">i</button>
+          <span class="chevron" aria-hidden="true">▸</span>
+        </header>
+        <div id="filters-body" class="gear-card__body" hidden></div>
+      </section>
+
+      <section class="gear-card" data-gear="lights">
+        <header class="gear-card__header" data-accordion="toggle" tabindex="0" aria-controls="lights-body" aria-expanded="false">
+          <h2>Lights</h2>
+          <button class="info-btn" type="button" aria-label="Light tip" data-tip="lights">i</button>
+          <span class="chevron" aria-hidden="true">▸</span>
+        </header>
+        <div id="lights-body" class="gear-card__body" hidden></div>
+      </section>
+
+      <section class="gear-card" data-gear="substrate">
+        <header class="gear-card__header" data-accordion="toggle" tabindex="0" aria-controls="substrate-body" aria-expanded="false">
+          <h2>Substrate</h2>
+          <button class="info-btn" type="button" aria-label="Substrate tip" data-tip="substrate">i</button>
+          <span class="chevron" aria-hidden="true">▸</span>
+        </header>
+        <div id="substrate-body" class="gear-card__body" hidden></div>
+      </section>
     </div>
-    <aside
-      id="ttg-drawer"
-      aria-label="Site"
-      data-nav="drawer"
-      aria-hidden="true"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="drawer-title"
-    >
-      <h2 id="drawer-title" class="ttg-visually-hidden">Site navigation</h2>
-      <div class="drawer-head">
-        <span class="drawer-title">The Tank Guide</span>
-        <button id="drawer-close" class="drawer-close" type="button" aria-label="Close menu" data-nav="drawer-close">
-          <span aria-hidden="true">×</span>
-        </button>
-      </div>
-      <nav class="drawer-links" aria-label="Mobile">
-        <ul class="nav__list nav__list--drawer">
-          <li class="nav__item"><a id="drawer-first" href="/index.html" class="nav__link" data-nav="home">Home</a></li>
-          <li class="nav__item"><a href="/stocking.html" class="nav__link" data-nav="stocking">Stocking Advisor</a></li>
-          <li class="nav__item"><a href="/gear/index.html" class="nav__link" data-nav="gear">Gear</a></li>
-          <li class="nav__item"><a href="/media.html" class="nav__link" data-nav="media">Media</a></li>
-          <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link" data-nav="feature-your-tank">Feature Your Tank</a></li>
-          <li class="nav__item"><a href="/store.html" class="nav__link" data-nav="store">Store</a></li>
-          <li class="nav__item"><a href="/contact-feedback.html" class="nav__link" data-nav="contact-feedback">Contact &amp; Feedback</a></li>
-          <li class="nav__item"><a href="/about.html" class="nav__link" data-nav="about">About</a></li>
-          <li class="nav__item"><a href="/privacy-legal.html" class="nav__link" data-nav="privacy-legal">Privacy &amp; Legal</a></li>
-          <li class="nav__item"><a href="/terms.html" class="nav__link" data-nav="terms">Terms of Use</a></li>
-          <li class="nav__item"><a href="/copyright-dmca.html" class="nav__link" data-nav="copyright-dmca">Copyright &amp; DMCA</a></li>
-        </ul>
-      </nav>
-    </aside>
-    <div id="ttg-overlay" data-nav="overlay" aria-hidden="true"></div>
-  </header>
+  </main>
 
-  <!-- Sticky Tank Reference -->
-  <section id="tank-ref" class="tank-ref" aria-label="Tank reference">
-    <div class="tank-ref__row">
-      <div class="tank-ref__field">
-        <label for="ref-gallons">Gallons</label>
-        <input id="ref-gallons" type="number" min="1" step="1" placeholder="e.g., 40">
-      </div>
-      <div class="tank-ref__field">
-        <label for="ref-length">Length (inches)</label>
-        <input id="ref-length" type="number" min="6" step="1" placeholder="e.g., 30">
-      </div>
-      <div class="tank-ref__field">
-        <label for="ref-preset">Preset</label>
-        <select id="ref-preset">
-          <option value="">Select common size…</option>
-          <option value='{"g":10,"l":20}'>10g (20")</option>
-          <option value='{"g":20,"l":24}'>20 High (24")</option>
-          <option value='{"g":20,"l":30}'>20 Long (30")</option>
-          <option value='{"g":29,"l":30}'>29g (30")</option>
-          <option value='{"g":40,"l":36}'>40 Breeder (36")</option>
-          <option value='{"g":55,"l":48}'>55g (48")</option>
-          <option value='{"g":75,"l":48}'>75g (48")</option>
-          <option value='{"g":90,"l":48}'>90g (48")</option>
-          <option value='{"g":125,"l":72}'>125g (72")</option>
-        </select>
-      </div>
-      <div class="tank-ref__info" role="note" aria-live="polite">
-        Set your tank once; matching ranges highlight below.
-      </div>
-    </div>
-  </section>
+  <div id="site-footer"></div>
 
-  <!-- Accordion: Heaters -->
-  <section class="gear-card" data-gear="heaters">
-    <header class="gear-card__header" data-accordion="toggle" tabindex="0" aria-controls="heaters-body" aria-expanded="false">
-      <h2>Heaters</h2>
-      <button class="info-btn" type="button" aria-label="Heater tip" data-tip="heaters">i</button>
-      <span class="chevron" aria-hidden="true">▸</span>
-    </header>
-    <div id="heaters-body" class="gear-card__body" hidden></div>
-  </section>
-
-  <!-- Accordion: Filters -->
-  <section class="gear-card" data-gear="filters">
-    <header class="gear-card__header" data-accordion="toggle" tabindex="0" aria-controls="filters-body" aria-expanded="false">
-      <h2>Filters</h2>
-      <button class="info-btn" type="button" aria-label="Filter tip" data-tip="filters">i</button>
-      <span class="chevron" aria-hidden="true">▸</span>
-    </header>
-    <div id="filters-body" class="gear-card__body" hidden></div>
-  </section>
-
-  <!-- Accordion: Lights -->
-  <section class="gear-card" data-gear="lights">
-    <header class="gear-card__header" data-accordion="toggle" tabindex="0" aria-controls="lights-body" aria-expanded="false">
-      <h2>Lights</h2>
-      <button class="info-btn" type="button" aria-label="Light tip" data-tip="lights">i</button>
-      <span class="chevron" aria-hidden="true">▸</span>
-    </header>
-    <div id="lights-body" class="gear-card__body" hidden></div>
-  </section>
-
-  <!-- Accordion: Substrate -->
-  <section class="gear-card" data-gear="substrate">
-    <header class="gear-card__header" data-accordion="toggle" tabindex="0" aria-controls="substrate-body" aria-expanded="false">
-      <h2>Substrate</h2>
-      <button class="info-btn" type="button" aria-label="Substrate tip" data-tip="substrate">i</button>
-      <span class="chevron" aria-hidden="true">▸</span>
-    </header>
-    <div id="substrate-body" class="gear-card__body" hidden></div>
-  </section>
-
-  <!-- FOOTER v1.3.0 — unified -->
-  <footer class="site-footer">
-    <!-- SOCIALS -->
-    <div class="social-strip" role="navigation" aria-label="Social links">
-      <a href="https://www.instagram.com/FishKeepingLifeCo" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on Instagram">
-        <i class="fab fa-instagram" aria-hidden="true"></i>
-      </a>
-      <a href="https://www.tiktok.com/@FishKeepingLifeCo" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on TikTok">
-        <i class="fab fa-tiktok" aria-hidden="true"></i>
-      </a>
-      <a href="https://www.facebook.com/fishkeepinglifeco" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on Facebook">
-        <i class="fab fa-facebook" aria-hidden="true"></i>
-      </a>
-      <a href="https://x.com/fishkeepinglife?s=21" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on X (Twitter)">
-        <i class="fab fa-x-twitter" aria-hidden="true"></i>
-      </a>
-      <a href="https://www.youtube.com/@fishkeepinglifeco" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on YouTube">
-        <i class="fab fa-youtube" aria-hidden="true"></i>
-      </a>
-      <a href="https://www.amazon.com/author/fishkeepinglifeco" target="_blank" rel="noopener noreferrer" aria-label="The Tank Guide on Amazon">
-        <i class="fab fa-amazon" aria-hidden="true"></i>
-      </a>
-    </div>
-
-    <!-- LEGAL LINKS (exact order) -->
-    <nav class="footer-links" aria-label="Footer links">
-      <a href="/privacy-legal.html">Privacy &amp; Legal</a>
-      <span class="dot">·</span>
-      <a href="/terms.html">Terms of Use</a>
-      <span class="dot">·</span>
-      <a href="/cookie-settings.html">Cookie Settings</a>
-      <span class="dot">·</span>
-      <a href="/cookie-settings.html">Do Not Sell or Share My Personal Information</a>
-      <span class="dot">·</span>
-      <a href="/contact-feedback.html">Contact &amp; Feedback</a>
-      <span class="dot">·</span>
-      <a href="/store.html">Store</a>
-      <span class="dot">·</span>
-      <a href="/copyright-dmca.html">Copyright &amp; DMCA</a>
-    </nav>
-
-    <!-- COPYRIGHT + AMAZON CTA -->
-    <p class="footer-note">
-      © 2025 The Tank Guide • FishKeepingLifeCo
-      <br>
-      As an Amazon Associate, we earn from qualifying purchases.
-      <br>
-      <a class="amazon-cta" href="https://www.amazon.com/author/fishkeepinglifeco" target="_blank" rel="noopener noreferrer">
-        Shop our books on Amazon »
-      </a>
-    </p>
-  </footer>
   <script>
-    window.addEventListener('DOMContentLoaded', () => {
-      if (typeof window.ttgInitNav === 'function') {
-        window.ttgInitNav();
-      }
+    document.addEventListener('DOMContentLoaded', () => {
+      window.ttgInitNav?.();
     });
+
+    (async () => {
+      try {
+        const res = await fetch('/footer.v1.3.0.html?v=1.3.0', { cache: 'no-cache' });
+        const html = await res.text();
+        const host = document.getElementById('site-footer');
+        if (host) {
+          host.outerHTML = html;
+        }
+      } catch (error) {
+        console.error('[Footer] load failed:', error);
+      }
+    })();
   </script>
-  <script src="/assets/js/gear.v2.data.js" defer></script>
-  <script src="/assets/js/gear.v2.js" defer></script>
+  <script defer src="/assets/js/gear.v2.data.js"></script>
+  <script defer src="/assets/js/gear.v2.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- swap the gear page over to the shared nav/footer includes used by Stocking Advisor and restructure the shell
- add the Stocking Advisor-style Tank Size card with sticky layout, dropdown, and info line tied to canonical tank presets
- refresh the gear script to drive the new selector, persist selections, and auto-highlight heater/filter/light ranges based on gallons and length

## Testing
- Manually loaded /gear and verified highlights update for 40 Breeder and 55 Gallon selections

------
https://chatgpt.com/codex/tasks/task_e_68e2cc5ffc3c8332b8ba02e95acb6ff0