### PR TITLE
Add Amazon buttons and update heaters options

### DIFF
--- a/assets/css/gear.v2.css
+++ b/assets/css/gear.v2.css
@@ -229,3 +229,15 @@ body{
     padding:12px 16px 18px;
   }
 }
+
+.btn{
+  display:inline-block; padding:8px 12px; border-radius:8px;
+  border:1px solid var(--line); background:#0b1220; color:var(--ink);
+  text-decoration:none; font-weight:600; line-height:1.2;
+}
+.btn:focus{ outline:2px solid var(--accent); outline-offset:2px; }
+.btn-amazon{ background:#111827; }
+.btn-amazon:hover{ filter:brightness(1.15); }
+.option__title{ margin:2px 0 6px; }
+.option__actions{ margin:0 0 8px; }
+.muted{ color:var(--muted); }

--- a/assets/js/gear.v2.data.js
+++ b/assets/js/gear.v2.data.js
@@ -39,9 +39,21 @@ const GEAR = {
         label: "Best Heaters for 5–10 Gallons",
         tip: "For 5–10 gal, target 25–50W. Place near gentle flow for even heat.",
         options: [
-          { label:"Option 1", title:"Hitop 50W Adjustable Aquarium Heater, Submersible Glass Water Heater for 5–15 Gallon Fish Tank", href:"https://amzn.to/3KFMlOx" },
-          { label:"Option 2", title:"(add title)", href:"" },  // TODO
-          { label:"Option 3", title:"(add title)", href:"" }   // TODO
+          {
+            label: "Option 1",
+            title: "Hitop 50W Adjustable Aquarium Heater, Submersible Glass Water Heater for 5–15 Gallon Fish Tank",
+            href: "https://amzn.to/3KFMlOx"
+          },
+          {
+            label: "Option 2",
+            title: "hygger Mini Fish Tank Submersible Heater 50W for 5–10 Gallons Small Betta Aquarium Heater with Digital Display Controller Adjustable Temperature",
+            href: "https://amzn.to/479AuRA"
+          },
+          {
+            label: "Option 3",
+            title: "hygger Aquarium Heater, Upgraded Ceramic 50W Small Fish Tank Heater with Digital LED Controller, Fast Heating, Precise Temperature Control, Turtle Tank Heater for Freshwater/Saltwater",
+            href: "https://amzn.to/3KBKiLp"
+          }
         ]
       },
       { id:"g-10-20",  label:"Best Heaters for 10–20 Gallons",  tip:"Aim 50–100W.", options:[ {label:"Option 1",title:"(add)",href:""}, {label:"Option 2",title:"(add)",href:""}, {label:"Option 3",title:"(add)",href:""} ] },

--- a/assets/js/gear.v2.js
+++ b/assets/js/gear.v2.js
@@ -66,6 +66,10 @@
     document.body.appendChild(wrap);
   }
 
+  function escapeHTML(s){
+    return String(s || '').replace(/[&<>"']/g, (m) => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;' }[m]));
+  }
+
   function renderRangeBlock(range){
     const wrap = el('div',{class:'range','data-range-id':range.id});
     wrap.appendChild(el('p',{class:'range__title'}, range.label));
@@ -73,8 +77,16 @@
     const list = el('div',{class:'range__list'});
     (range.options || []).forEach((opt) => {
       const row = el('div',{class:'option'});
-      const hasLink = !!opt.href;
-      row.innerHTML = `<strong>${opt.label} — ${opt.title || '(add title)'}</strong><br>${hasLink ? `<a href="${opt.href}" target="_blank" rel="noopener noreferrer">Buy on Amazon</a>` : '<span style="color:#94a3b8;">Add link</span>'}`;
+      row.innerHTML = `
+    <div class="option__title"><strong>${escapeHTML(opt.label)} — ${escapeHTML(opt.title)}</strong></div>
+    <div class="option__actions">
+      ${
+        opt.href
+          ? `<a class="btn btn-amazon" href="${opt.href}" target="_blank" rel="noopener noreferrer" aria-label="Buy ${escapeHTML(opt.title)} on Amazon">Buy on Amazon</a>`
+          : `<span class="muted">Add link</span>`
+      }
+    </div>
+  `;
       list.appendChild(row);
     });
     wrap.appendChild(list);
@@ -273,6 +285,7 @@
     buildCategory('substrate', document.getElementById('substrate-body'));
     wireAccordions();
     initTankSelect();
+    console.log("[Gear] Heaters g-5-10 options:", (GEAR.heaters?.ranges||[]).find(r=>r.id==="g-5-10")?.options?.length || 0);
   }
 
   if (document.readyState !== 'loading') init();


### PR DESCRIPTION
## Summary
- seed the Heaters 5–10 gallons range with the three confirmed Amazon products and links
- render each option title with a dedicated “Buy on Amazon” button using escaped HTML content
- add shared button styling and log the option count for visibility in the console

## Testing
- python3 -m http.server 4173

------
https://chatgpt.com/codex/tasks/task_e_68e2d2dbb8d08332bab260971a7d36d5