### PR TITLE
Add heater recommendations for 40–60 gallon tanks

### DIFF
--- a/assets/js/gear.v2.data.js
+++ b/assets/js/gear.v2.data.js
@@ -79,7 +79,28 @@ const GEAR = {
         ]
       },
       { id:"g-20-40",  label:"Best Heaters for 20–40 Gallons",  tip:"Aim 100–200W.", options:[ {label:"Option 1",title:"(add)",href:""}, {label:"Option 2",title:"(add)",href:""}, {label:"Option 3",title:"(add)",href:""} ] },
-      { id:"g-40-60",  label:"Best Heaters for 40–60 Gallons",  tip:"Aim 150–300W.", options:[ {label:"Option 1",title:"(add)",href:""}, {label:"Option 2",title:"(add)",href:""}, {label:"Option 3",title:"(add)",href:""} ] },
+      {
+        id: "g-40-60",
+        label: "Best Heaters for 40–60 Gallons",
+        tip: "For 40–60 gal tanks, aim for ~200–300W and place the heater in steady flow for even temperature. (Full placement/safety details are in the Heater Tip popup.)",
+        options: [
+          {
+            label: "Option 1",
+            title: "Hitop 300W Aquarium Heater, Submersible Glass Water Heater (35–70 Gallon Fish Tank)",
+            href: "https://amzn.to/46Qv3ps"
+          },
+          {
+            label: "Option 2",
+            title: "hygger Aquarium Heater 300W, Fish Tank Heater with Digital LED Controller, Overheating & Auto Shut Off Protection, Memory Function, Submersible Fish Heater for Saltwater & Freshwater Fish Tank 25–80 Gallon",
+            href: "https://amzn.to/4nF3vuv"
+          },
+          {
+            label: "Option 3",
+            title: "AQQA Aquarium Heater 500W for 55–130 Gallon Fish Tank Heater Quartz Glass Submersible Betta Fish Heater for Aquarium Thermostat Heater with External Digital Controller (AQ136-500W for 55–130Gal)",
+            href: "https://amzn.to/3WsfsHG"
+          }
+        ]
+      },
       { id:"g-60-90",  label:"Best Heaters for 60–90 Gallons",  tip:"Aim 300–500W.", options:[ {label:"Option 1",title:"(add)",href:""}, {label:"Option 2",title:"(add)",href:""}, {label:"Option 3",title:"(add)",href:""} ] },
       { id:"g-90-125", label:"Best Heaters for 90–125 Gallons", tip:"Aim 500–800W.", options:[ {label:"Option 1",title:"(add)",href:""}, {label:"Option 2",title:"(add)",href:""}, {label:"Option 3",title:"(add)",href:""} ] }
     ]

--- a/assets/js/gear.v2.js
+++ b/assets/js/gear.v2.js
@@ -287,6 +287,7 @@
     initTankSelect();
     console.log("[Gear] Heaters g-5-10 options:", (GEAR.heaters?.ranges||[]).find(r=>r.id==="g-5-10")?.options?.length || 0);
     console.log("[Gear] Added heaters 10–20 range:", (GEAR.heaters?.ranges||[]).find(r=>r.id==="g-10-20")?.options?.length || 0);
+    console.log("[Gear] Heaters g-40-60 options:", (GEAR.heaters?.ranges||[]).find(r=>r.id==="g-40-60")?.options?.length || 0);
   }
 
   if (document.readyState !== 'loading') init();


### PR DESCRIPTION
## Summary
- populate the 40–60 gallon heater range with three specific Amazon recommendations and an updated placement tip
- add a console log confirming the 40–60 gallon heater option count during initialization for easier verification

## Testing
- node -e "const fs=require('fs'); const vm=require('vm'); const context={}; context.globalThis = context; vm.createContext(context); const script = fs.readFileSync('assets/js/gear.v2.data.js','utf8') + '\n;this.GEAR_EXPORT=GEAR;'; vm.runInContext(script, context); console.log('Options for g-40-60:', context.GEAR_EXPORT.heaters.ranges.find(r=>r.id==='g-40-60').options.length);"


------
https://chatgpt.com/codex/tasks/task_e_68e2e37883dc8332bb1099673c264024