### PR TITLE
Add curated options for 10–20 gallon filters

### DIFF
--- a/assets/js/gear.v2.data.js
+++ b/assets/js/gear.v2.data.js
@@ -175,6 +175,31 @@ const GEAR = {
         };
       }
 
+      if (r.id === "g-10-20") {
+        return {
+          id: "g-10-20",
+          label: "Recommended Filters for 10–20 Gallons",
+          tip: "",  // keep empty — all education lives in the Filter Tip popup
+          options: [
+            {
+              label: "Option 1",
+              title: "AC30 Power Filter, 10–30 US Gal / 38–114 L – Fluval USA (fluvalaquatics.com)",
+              href: "https://amzn.to/4n9MXK9"
+            },
+            {
+              label: "Option 2",
+              title: "hygger Aquarium Double Sponge Filter for Fresh Water and Salt-Water Fish Tank (M)",
+              href: "https://amzn.to/3VTKSXo"
+            },
+            {
+              label: "Option 3",
+              title: "AQUANEAT Aquarium Bio Sponge Filter Breeding Fry Betta Shrimp Nano Fish Tank (Middle up to 20Gal)",
+              href: "https://amzn.to/4mTK28f"
+            }
+          ]
+        };
+      }
+
       return {
         id: r.id,
         label: `Recommended Filters for ${r.label}`,

--- a/assets/js/gear.v2.js
+++ b/assets/js/gear.v2.js
@@ -292,6 +292,7 @@
     console.log("[Gear] Heaters g-90-125 options:", (GEAR.heaters?.ranges||[]).find(r=>r.id==="g-90-125")?.options?.length || 0);
     console.log("[Gear] Heading language normalized to 'Recommended' for all categories.");
     console.log("[Gear] Filters g-5-10 options:", (GEAR.filters?.ranges||[]).find(r=>r.id==="g-5-10")?.options?.length || 0);
+    console.log("[Gear] Filters g-10-20 options:", (GEAR.filters?.ranges||[]).find(r=>r.id==="g-10-20")?.options?.length || 0);
   }
 
   if (document.readyState !== 'loading') init();


### PR DESCRIPTION
## Summary
- add the specified 10–20 gallon filter recommendations with Amazon links and leave inline tip empty
- log the number of configured options for the 10–20 gallon filter block during init

## Testing
- Not run (manual verification)


------
https://chatgpt.com/codex/tasks/task_e_68e2fae4ae0c8332b52a0fa29051e005