### PR TITLE
Adjust 20–40 gallon filter tip comment placement

### DIFF
--- a/assets/js/gear.v2.data.js
+++ b/assets/js/gear.v2.data.js
@@ -204,7 +204,8 @@ const GEAR = {
         return {
           id: "g-20-40",
           label: "Recommended Filters for 20–40 Gallons",
-          tip: "",  // all educational text handled by the Filter Tip popup
+          // all educational text handled by the Filter Tip popup
+          tip: "",
           options: [
             {
               label: "Option 1",


### PR DESCRIPTION
## Summary
- move the 20–40 gallon filter range note to its own line so the inline tip stays empty and instructions remain in the popup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e31a812a0883328305d3062e843f03