### PR TITLE
Add separators and raised action slab to gear options

### DIFF
--- a/assets/css/gear.v2.css
+++ b/assets/css/gear.v2.css
@@ -241,3 +241,43 @@ body{
 .option__title{ margin:2px 0 6px; }
 .option__actions{ margin:0 0 8px; }
 .muted{ color:var(--muted); }
+/* --- Step 2: Option separators + raised button slab --- */
+
+/* Between sibling options, add a very subtle top divider and rhythm */
+.option + .option {
+  border-top: 1px dashed rgba(255, 255, 255, 0.08);
+  margin-top: 14px;
+  padding-top: 14px;
+}
+
+/* Compact spacing from title → actions slab */
+.option__title { 
+  margin: 2px 0 6px;
+}
+
+/* Raised slab behind the button row (gentle lift on dark bg) */
+.option__actions {
+  background: rgba(255, 255, 255, 0.03);
+  border-radius: 10px;
+  padding: 10px;
+}
+
+/* Keep buttons readable and accessible within the slab */
+.btn {
+  display: inline-block;
+  padding: 8px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: #0b1220;
+  color: var(--ink);
+  text-decoration: none;
+  font-weight: 600;
+  line-height: 1.2;
+}
+.btn:hover { text-decoration: underline; }
+.btn:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* Respect reduced motion users (no extra motion here, but kept for parity) */
+@media (prefers-reduced-motion: reduce) {
+  .btn { transition: none; }
+}


### PR DESCRIPTION
## Summary
- add dashed separators between gear options to improve scan-ability
- tighten option title spacing and elevate the action row with a subtle slab
- refresh button styling to maintain readability and focus visibility within the slab

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e33657f4c4833290644906ba0d2efb