### PR TITLE
Add glow and lift to matched gear ranges

### DIFF
--- a/assets/css/gear.v2.css
+++ b/assets/css/gear.v2.css
@@ -281,3 +281,44 @@ body{
 @media (prefers-reduced-motion: reduce) {
   .btn { transition: none; }
 }
+/* ===== Matched-range active effect ===== */
+:root{
+  /* Use existing success/accent if present; fallback emerald */
+  --match-green: var(--accent-green, var(--ok, #34d399));
+  --card-bg-lift: rgba(255,255,255,0.02);
+  --card-lift-shadow: 0 6px 12px rgba(0,0,0,.35);
+  --card-glow: 0 0 10px color-mix(in srgb, var(--match-green) 40%, transparent);
+}
+
+/* Base gear card hook: already present on range panels; if not, we’ll add it in Step 2 */
+.gear-card {
+  transition: background-color .25s ease, box-shadow .25s ease, transform .25s ease, border-color .25s ease;
+}
+
+/* ACTIVE: solid green bar + glow + slight lift */
+.gear-card--active{
+  background-color: var(--card-bg-lift);
+  border-left: 4px solid var(--match-green);
+  box-shadow: var(--card-lift-shadow), var(--card-glow);
+  transform: translateY(-2px);
+}
+
+/* Ensure old dashed outlines don’t show when active */
+.gear-card--active,
+.gear-card--active * {
+  outline: none !important;
+}
+
+/* Respect reduced motion */
+@media (prefers-reduced-motion: reduce){
+  .gear-card{ transition:none; }
+  .gear-card--active{ transform:none; }
+}
+
+/* Hard override for any previous dashed “match” rule (keep this last for specificity) */
+.gear-card[data-match="1"]{
+  border-left: 4px solid var(--match-green);
+  box-shadow: var(--card-lift-shadow), var(--card-glow);
+  background-color: var(--card-bg-lift);
+  transform: translateY(-2px);
+}

--- a/assets/js/gear.v2.js
+++ b/assets/js/gear.v2.js
@@ -45,6 +45,28 @@
     return String(round(value, 2));
   }
 
+  function parseRangeId(id){
+    const m = /^g-(\d+)-(\d+)$/.exec(id);
+    if (!m) return null;
+    return { min: Number(m[1]), max: Number(m[2]) };
+  }
+
+  function gallonsInRange(g, range){
+    return typeof g === 'number' && range && g >= range.min && g <= range.max;
+  }
+
+  function updateGearHighlights(selectedGallons){
+    const cards = document.querySelectorAll('.gear-card[data-range-id]');
+    cards.forEach((card) => {
+      const id = card.dataset.rangeId || '';
+      const r = parseRangeId(id);
+      const match = r ? gallonsInRange(selectedGallons, r) : false;
+      card.classList.toggle('gear-card--active', !!match);
+      if (match) card.setAttribute('data-match', '1');
+      else card.removeAttribute('data-match');
+    });
+  }
+
   function buildInfoLine(preset){
     if (!preset) return '';
     const gallons = Number.isFinite(preset.gallons) ? `${formatNumber(preset.gallons)}g` : '';
@@ -71,7 +93,9 @@
   }
 
   function renderRangeBlock(range){
-    const wrap = el('div',{class:'range','data-range-id':range.id});
+    const wrap = el('div',{class:'range'});
+    wrap.classList.add('gear-card');
+    if (range?.id) wrap.dataset.rangeId = range.id;
     wrap.appendChild(el('p',{class:'range__title'}, range.label));
     if (range.tip) wrap.appendChild(el('p',{class:'range__tip'}, range.tip));
     const list = el('div',{class:'range__list'});
@@ -178,6 +202,7 @@
   }
 
   function applyHighlights(gallons, length){
+    updateGearHighlights(gallons);
     clearHighlights();
     const heaterId = matchRange(gallons, RANGES_HEATERS);
     const filterId = matchRange(gallons, RANGES_FILTERS);


### PR DESCRIPTION
## Summary
- Implemented `.gear-card--active` matched-range effect for gear recommendation cards.
- Added JavaScript helpers to toggle the active state based on the selected tank gallons.
- Left all existing gear content and outbound links unchanged.

## Testing
- ⚠️ `npm run serve:static` *(fails: registry.npmjs.org is unreachable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3555c686c8332a6d438f4e9f24546