### PR TITLE
Harden SEO fragments and canonical redirects

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,2 @@
+/gear.html /gear/ 301
+/copyright.html /copyright-dmca.html 301

--- a/footer.v1.3.0.html
+++ b/footer.v1.3.0.html
@@ -1,5 +1,5 @@
 <!-- FOOTER v1.3.0 — unified -->
-<meta name="robots" content="noindex,follow">
+<meta name="robots" content="noindex,nofollow">
 <footer class="site-footer">
   <!-- SOCIALS -->
   <div class="social-strip" role="navigation" aria-label="Social links">

--- a/js/nav.js
+++ b/js/nav.js
@@ -273,6 +273,23 @@
     overlay.setAttribute('aria-hidden', 'true');
   }
 
+  function extractNav(markup) {
+    try {
+      const parser = new DOMParser();
+      const doc = parser.parseFromString(markup, 'text/html');
+      const nav = doc.querySelector('#global-nav');
+      if (nav) {
+        return nav;
+      }
+    } catch (error) {
+      console.warn('Nav parser fallback', error);
+    }
+
+    const template = document.createElement('template');
+    template.innerHTML = markup;
+    return template.content.querySelector('#global-nav');
+  }
+
   async function mountNav() {
     const host = document.getElementById(NAV_PLACEHOLDER_ID);
     if (!host) {
@@ -284,6 +301,13 @@
         throw new Error(`Failed to fetch nav: ${response.status}`);
       }
       const markup = await response.text();
+      const nav = extractNav(markup);
+      if (nav) {
+        host.replaceWith(nav);
+        initNav();
+        return;
+      }
+
       host.outerHTML = markup;
       initNav();
     } catch (error) {

--- a/nav.html
+++ b/nav.html
@@ -1,3 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="robots" content="noindex,nofollow" />
+  <title>The Tank Guide — Navigation</title>
+</head>
+<body>
 <header id="global-nav">
   <div class="inner">
     <button
@@ -66,3 +74,5 @@
   </aside>
   <div id="ttg-overlay" data-nav="overlay" aria-hidden="true"></div>
 </header>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,7 +1,3 @@
-# Robots.txt for TheTankGuide.com
 User-agent: *
-Disallow: /admin/
-Disallow: /drafts/
 Allow: /
-
 Sitemap: https://thetankguide.com/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,46 +7,16 @@
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://thetankguide.com/stocking.html</loc>
-    <lastmod>2025-09-30</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.9</priority>
-  </url>
-  <url>
     <loc>https://thetankguide.com/gear/</loc>
     <lastmod>2025-10-06</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://thetankguide.com/store.html</loc>
-    <lastmod>2025-10-01</lastmod>
-    <changefreq>weekly</changefreq>
-    <priority>0.80</priority>
-  </url>
-  <url>
-    <loc>https://thetankguide.com/params.html</loc>
+    <loc>https://thetankguide.com/params/</loc>
     <lastmod>2025-09-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://thetankguide.com/feature-your-tank.html</loc>
-    <lastmod>2025-09-30</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.7</priority>
-  </url>
-  <url>
-    <loc>https://thetankguide.com/about.html</loc>
-    <lastmod>2025-09-30</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
-    <loc>https://thetankguide.com/contact-feedback.html</loc>
-    <lastmod>2025-09-30</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://thetankguide.com/media.html</loc>
@@ -55,22 +25,16 @@
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://thetankguide.com/privacy-legal.html</loc>
+    <loc>https://thetankguide.com/feature-your-tank.html</loc>
     <lastmod>2025-09-30</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.5</priority>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://thetankguide.com/cookie-settings.html</loc>
-    <lastmod>2025-10-01</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://thetankguide.com/terms.html</loc>
+    <loc>https://thetankguide.com/stocking.html</loc>
     <lastmod>2025-09-30</lastmod>
-    <changefreq>yearly</changefreq>
-    <priority>0.5</priority>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://thetankguide.com/copyright-dmca.html</loc>


### PR DESCRIPTION
## Summary
- block indexing of shared footer/nav fragments while keeping nav loader functional
- add permanent redirects for legacy .html stubs and streamline robots/sitemap to canonical URLs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c473bc5c8332a40faa54e8d91d3f