### PR TITLE
Add lighting recommendations for 20–24 inch tanks

### DIFF
--- a/assets/js/gear.v2.data.js
+++ b/assets/js/gear.v2.data.js
@@ -365,6 +365,31 @@ const GEAR = {
         };
       }
 
+      if (r.id === "l-20-24") {
+        return {
+          id: "l-20-24",
+          label: "Recommended Lights for 20–24 Inch Tanks",
+          tip: "",
+          options: [
+            {
+              label: "Option 1",
+              title: "NICREW C10 Plants LED Aquarium Light, 18-24 in, 13 Watts, Full Spectrum Fish Tank Light with Timer, Day and Night Cycle, Brightness Adjustable",
+              href: "https://amzn.to/3WpCKxX"
+            },
+            {
+              label: "Option 2",
+              title: "hygger 14W Full Spectrum Aquarium Light with Aluminum Alloy Shell Extendable Brackets, White Blue Red LEDs, External Controller, for Freshwater Fish Tank (18-24 inch)",
+              href: "https://amzn.to/3VRUYIs"
+            },
+            {
+              label: "Option 3",
+              title: "hygger Auto On Off LED Aquarium Light 18-24 Inches Dimmable 7 Colors Full Spectrum Fish Tank Light Fixture for Freshwater Planted Tank Build in Timer Sunrise Sunset",
+              href: "https://amzn.to/4gWRH45"
+            }
+          ]
+        };
+      }
+
       return {
         id: r.id,
         label: `Recommended Lights for ${r.label}`,


### PR DESCRIPTION
## Summary
- add a dedicated 20–24 inch lighting range in the gear data with three full-spectrum LED options and no inline tip text

## Testing
- python3 -m http.server 8080 (manual verification of /gear page)

------
https://chatgpt.com/codex/tasks/task_e_68e403ff075c8332afda96699b4d4c5e