### PR TITLE
Add lights recommendations for 30–36 inch tanks

### DIFF
--- a/assets/js/gear.v2.data.js
+++ b/assets/js/gear.v2.data.js
@@ -416,6 +416,31 @@ const GEAR = {
         };
       }
 
+      if (r.id === "l-30-36") {
+        return {
+          id: "l-30-36",
+          label: "Recommended Lights for 30–36 Inch Tanks",
+          tip: "",
+          options: [
+            {
+              label: "Option 1",
+              title: "hygger 20W Full Spectrum Aquarium Light with Aluminum Alloy Shell Extendable Brackets, White Blue Red LEDs, External Controller, for Freshwater Fish Tank (30-36 inch)",
+              href: "https://amzn.to/3Wo63Rt"
+            },
+            {
+              label: "Option 2",
+              title: "hygger 20W Full Spectrum Aquarium Light with Aluminum Alloy Shell Extendable Brackets, White Blue Red LEDs, External Controller, for Freshwater Fish Tank (30-36 inch)",
+              href: "https://amzn.to/4q2HWWo"
+            },
+            {
+              label: "Option 3",
+              title: "hygger Advanced Remote Control Aquarium Light Customizable Full Spectrum Fish Tank LED with DIY, Default & Weather Mode Freshwater Planted Tank",
+              href: "https://amzn.to/46L2CZS"
+            }
+          ]
+        };
+      }
+
       return {
         id: r.id,
         label: `Recommended Lights for ${r.label}`,


### PR DESCRIPTION
## Summary
- add a dedicated 30–36 inch light range with three full-spectrum LED options and affiliate links

## Testing
- not run (http-server package download blocked in container)

------
https://chatgpt.com/codex/tasks/task_e_68e409aedfe08332b9df0fa3ffe5e5be