### PR TITLE
Document lighting guidance handling for 30–36 inch range

### DIFF
--- a/assets/js/gear.v2.data.js
+++ b/assets/js/gear.v2.data.js
@@ -420,7 +420,7 @@ const GEAR = {
         return {
           id: "l-30-36",
           label: "Recommended Lights for 30–36 Inch Tanks",
-          tip: "",
+          tip: "", // Lighting guidance lives in the global Lighting info popup
           options: [
             {
               label: "Option 1",


### PR DESCRIPTION
## Summary
- Clarified that the 30–36 inch lighting recommendations defer to the shared lighting guidance popup while keeping the configured options available.

## Testing
- python3 -m http.server 8080

------
https://chatgpt.com/codex/tasks/task_e_68e40b8dc4a88332a6205a892acf27e6