### PR TITLE
Make gear matching logic metric-specific

### DIFF
--- a/assets/js/gear.v2.data.js
+++ b/assets/js/gear.v2.data.js
@@ -41,6 +41,7 @@ const TIPS = {
 */
 const GEAR = {
   heaters: {
+    match: "gallons",
     ranges: [
       {
         id: "g-5-10",
@@ -178,6 +179,7 @@ const GEAR = {
   },
 
   filters: {
+    match: "gallons",
     ranges: RANGES_FILTERS.map(r => {
       if (r.id === "g-5-10") {
         return {
@@ -340,6 +342,7 @@ const GEAR = {
   },
 
   lights: {
+    match: "length",
     ranges: RANGES_LIGHTS.map(r => {
       if (r.id === "l-12-20") {
         return {
@@ -451,6 +454,7 @@ const GEAR = {
   },
 
   substrate: {
+    match: "gallons",
     groups: [
       {
         id:"sub-fish-only",


### PR DESCRIPTION
## Summary
- add explicit match metrics to each gear category
- centralize highlight logic to respect gallons-only vs length-only matching and add per-card data attributes
- expose helper hooks for external triggers while keeping substrate grouping intact

## Testing
- Manual QA via local browser (mobile + desktop scenarios)

------
https://chatgpt.com/codex/tasks/task_e_68e40bd7ad3c83329a60fe45bc491c28