### PR TITLE
Lighting remediation: depth metadata, anchors, highlight-by-depth, Amazon rel flag

### DIFF
--- a/data/gear_lighting.csv
+++ b/data/gear_lighting.csv
@@ -1,11 +1,11 @@
-Category,Product_Type,Product_Name,Use_Case,Recommended_Specs,Plant_Ready,Price_Range,Notes,Amazon_Link,Chewy_Link,ASIN,Source_List
-Lighting,Bar Light,Aqueon OptiBright MAX LED Aquarium Light Fixture 48 Inch,,,,,,https://www.amazon.com/dp/B0LGT00010/?tag=fishkeepingli-20,,B0LGT00010,LIGHTS.csv
-Lighting,Bar Light,Aqueon Planted Aquarium Clip-On LED Light,,,,,,https://www.amazon.com/dp/B0LGT00007/?tag=fishkeepingli-20,,B0LGT00007,LIGHTS.csv
-Lighting,Bar Light,Beamswork DA FSPEC LED Aquarium Light 36 Inch,,,,,,https://www.amazon.com/dp/B0LGT00009/?tag=fishkeepingli-20,,B0LGT00009,LIGHTS.csv
-Lighting,Bar Light,Current USA Satellite Freshwater Plus PRO LED Light 48 Inch,,,,,,https://www.amazon.com/dp/B0LGT00008/?tag=fishkeepingli-20,,B0LGT00008,LIGHTS.csv
-Lighting,Bar Light,Finnex Planted+ 24/7 HLC Aquarium LED 30 Inch,,,,,,https://www.amazon.com/dp/B0LGT00006/?tag=fishkeepingli-20,,B0LGT00006,LIGHTS.csv
-Lighting,Bar Light,Fluval Plant 3.0 LED Planted Aquarium Light 24-34 Inch,,,,,,https://www.amazon.com/dp/B0LGT00003/?tag=fishkeepingli-20,,B0LGT00003,LIGHTS.csv
-Lighting,Bar Light,Fluval Plant 3.0 LED Planted Aquarium Light 36-46 Inch,,,,,,https://www.amazon.com/dp/B0LGT00004/?tag=fishkeepingli-20,,B0LGT00004,LIGHTS.csv
-Lighting,Bar Light,Hygger Advanced Full Spectrum LED Aquarium Light 24-30 Inch,,,,,,https://www.amazon.com/dp/B0LGT00005/?tag=fishkeepingli-20,,B0LGT00005,LIGHTS.csv
-Lighting,Bar Light,NICREW ClassicLED Plus Planted Aquarium Light 18-24 Inch,,,,,,https://www.amazon.com/dp/B0LGT00001/?tag=fishkeepingli-20,,B0LGT00001,LIGHTS.csv
-Lighting,Bar Light,NICREW ClassicLED Plus Planted Aquarium Light 24-30 Inch,,,,,,https://www.amazon.com/dp/B0LGT00002/?tag=fishkeepingli-20,,B0LGT00002,LIGHTS.csv
+Category,Product_Type,Product_Name,Use_Case,Recommended_Specs,Plant_Ready,Price_Range,Notes,Amazon_Link,Chewy_Link,ASIN,Source_List,depth_in,group_id,group_label,group_anchor
+Lighting,Bar Light,Aqueon OptiBright MAX LED Aquarium Light Fixture 48 Inch,,,,,,https://www.amazon.com/dp/B0LGT00010/?tag=fishkeepingli-20,,B0LGT00010,LIGHTS.csv,24,deep_19_24,High Light (Deep 19–24″),light-depth-19-24
+Lighting,Bar Light,Aqueon Planted Aquarium Clip-On LED Light,,,,,,https://www.amazon.com/dp/B0LGT00007/?tag=fishkeepingli-20,,B0LGT00007,LIGHTS.csv,12,shallow_8_12,Low Light (Shallow 8–12″),light-depth-8-12
+Lighting,Bar Light,Beamswork DA FSPEC LED Aquarium Light 36 Inch,,,,,,https://www.amazon.com/dp/B0LGT00009/?tag=fishkeepingli-20,,B0LGT00009,LIGHTS.csv,22,deep_19_24,High Light (Deep 19–24″),light-depth-19-24
+Lighting,Bar Light,Current USA Satellite Freshwater Plus PRO LED Light 48 Inch,,,,,,https://www.amazon.com/dp/B0LGT00008/?tag=fishkeepingli-20,,B0LGT00008,LIGHTS.csv,24,deep_19_24,High Light (Deep 19–24″),light-depth-19-24
+Lighting,Bar Light,Finnex Planted+ 24/7 HLC Aquarium LED 30 Inch,,,,,,https://www.amazon.com/dp/B0LGT00006/?tag=fishkeepingli-20,,B0LGT00006,LIGHTS.csv,18,standard_13_18,Medium Light (Standard 13–18″),light-depth-13-18
+Lighting,Bar Light,Fluval Plant 3.0 LED Planted Aquarium Light 24-34 Inch,,,,,,https://www.amazon.com/dp/B0LGT00003/?tag=fishkeepingli-20,,B0LGT00003,LIGHTS.csv,22,deep_19_24,High Light (Deep 19–24″),light-depth-19-24
+Lighting,Bar Light,Fluval Plant 3.0 LED Planted Aquarium Light 36-46 Inch,,,,,,https://www.amazon.com/dp/B0LGT00004/?tag=fishkeepingli-20,,B0LGT00004,LIGHTS.csv,24,deep_19_24,High Light (Deep 19–24″),light-depth-19-24
+Lighting,Bar Light,Hygger Advanced Full Spectrum LED Aquarium Light 24-30 Inch,,,,,,https://www.amazon.com/dp/B0LGT00005/?tag=fishkeepingli-20,,B0LGT00005,LIGHTS.csv,18,standard_13_18,Medium Light (Standard 13–18″),light-depth-13-18
+Lighting,Bar Light,NICREW ClassicLED Plus Planted Aquarium Light 18-24 Inch,,,,,,https://www.amazon.com/dp/B0LGT00001/?tag=fishkeepingli-20,,B0LGT00001,LIGHTS.csv,16,standard_13_18,Medium Light (Standard 13–18″),light-depth-13-18
+Lighting,Bar Light,NICREW ClassicLED Plus Planted Aquarium Light 24-30 Inch,,,,,,https://www.amazon.com/dp/B0LGT00002/?tag=fishkeepingli-20,,B0LGT00002,LIGHTS.csv,18,standard_13_18,Medium Light (Standard 13–18″),light-depth-13-18

--- a/src/components/gear/ProductCard.js
+++ b/src/components/gear/ProductCard.js
@@ -61,7 +61,7 @@ export function ProductCard(item, options = {}) {
         attrs: {
           href: amazonLink,
           target: '_blank',
-          rel: 'noopener noreferrer',
+          rel: 'sponsored noopener noreferrer',
         },
       }),
     );

--- a/src/components/gear/RecommendedRow.js
+++ b/src/components/gear/RecommendedRow.js
@@ -66,7 +66,7 @@ function createRecommendedCard(slot, item, context, onSelect, onAdd) {
           attrs: {
             href: amazonLink,
             target: '_blank',
-            rel: 'noopener noreferrer',
+            rel: 'sponsored noopener noreferrer',
           },
         }),
       );

--- a/src/pages/GearPage.js
+++ b/src/pages/GearPage.js
@@ -141,6 +141,7 @@ const state = {
   context: { ...CONTEXT_DEFAULTS },
   openCategory: readStoredOpenCategory(),
   filtrationTab: 'All',
+  lightingFilter: '',
   selectedItem: null,
   showModal: false,
   alternatives: { Budget: null, Mid: null, Premium: null },
@@ -195,6 +196,18 @@ function setState(patch) {
     state.alternatives = computeAlternatives(state.selectedItem);
   }
   render();
+}
+
+function scrollToAnchor(anchor) {
+  if (!anchor) {
+    return;
+  }
+  requestAnimationFrame(() => {
+    const target = document.getElementById(anchor);
+    if (target) {
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  });
 }
 
 function handleSelectItem(item) {
@@ -334,7 +347,11 @@ function render() {
     CategoryAccordion(
       groups,
       state.context,
-      { openCategory: state.openCategory, filtrationTab: state.filtrationTab },
+      {
+        openCategory: state.openCategory,
+        filtrationTab: state.filtrationTab,
+        lightingFilter: state.lightingFilter,
+      },
       {
         onToggleCategory: (key, open) => {
           if (open) {
@@ -346,6 +363,15 @@ function render() {
         onSelect: handleSelectItem,
         onAdd: handleAddToBuild,
         onFiltrationTab: (tab) => setState({ filtrationTab: tab }),
+        onLightingFilter: (groupId, anchor) => {
+          const nextFilter = state.lightingFilter === groupId ? '' : groupId;
+          const patch = { lightingFilter: nextFilter };
+          if (state.openCategory !== 'Lighting') {
+            patch.openCategory = 'Lighting';
+          }
+          setState(patch);
+          scrollToAnchor(anchor);
+        },
       },
     ),
     WhyPickDrawer({

--- a/src/styles/gear.css
+++ b/src/styles/gear.css
@@ -418,6 +418,65 @@ main {
   margin-bottom: 16px;
 }
 
+.lighting-section {
+  display: grid;
+  gap: 20px;
+}
+
+.lighting-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.lighting-chip {
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--fg);
+  padding: 8px 14px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.lighting-chip.is-active {
+  background: var(--accent);
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 6px 18px rgba(91, 140, 255, 0.35);
+}
+
+.lighting-chip.is-empty {
+  opacity: 0.7;
+}
+
+.lighting-groups {
+  display: grid;
+  gap: 24px;
+}
+
+.lighting-group {
+  border: 1px solid transparent;
+  border-radius: 16px;
+  padding: 12px 16px 4px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.lighting-group.is-highlighted {
+  border-color: rgba(91, 140, 255, 0.6);
+  box-shadow: 0 0 0 1px rgba(91, 140, 255, 0.45);
+  background: rgba(91, 140, 255, 0.12);
+}
+
+.lighting-group__title {
+  margin: 0 0 12px;
+  font-size: 1.05rem;
+  font-weight: 600;
+  scroll-margin-top: 120px;
+}
+
 .sub-tab {
   border-radius: 999px;
   border: 1px solid var(--border);

--- a/src/utils/tankDimensions.js
+++ b/src/utils/tankDimensions.js
@@ -1,0 +1,24 @@
+const TANK_HEIGHTS = new Map([
+  ['5g', 10.5],
+  ['10g', 12.6],
+  ['20g', 16.75],
+  ['20 Long', 12.75],
+  ['29g', 18.75],
+  ['40 Breeder', 16.75],
+  ['55g', 21],
+  ['75g', 21.25],
+  ['90g', 25],
+  ['110g', 30],
+  ['125g', 21],
+]);
+
+export function getTankHeightInches(label) {
+  if (!label) {
+    return null;
+  }
+  const height = TANK_HEIGHTS.get(label);
+  if (typeof height === 'number' && Number.isFinite(height)) {
+    return height;
+  }
+  return null;
+}


### PR DESCRIPTION
## Summary
- add depth metadata fields to the lighting gear CSV and populate depth buckets for each product
- render lighting depth anchors, filter chips, and depth-based highlighting driven by tank height
- add tank height lookup utility, styling for depth sections, and ensure Amazon links use sponsored rel attributes

## Testing
- not run (not requested)

## Screenshots
![Mobile vertical lighting depth highlight](browser:/invocations/cvtcqein/artifacts/artifacts/lighting-mobile-vertical.png)
![Mobile horizontal depth filter chip](browser:/invocations/zczuhcph/artifacts/artifacts/lighting-mobile-horizontal.png)
![Desktop lighting depth sections](browser:/invocations/ytczsnie/artifacts/artifacts/lighting-desktop.png)

------
https://chatgpt.com/codex/tasks/task_e_68e46dfe40a48332bf70d92bf2e6e4b2