### PR TITLE
Sanitize stand titles and extend link audit manifest support

### DIFF
--- a/assets/js/gear.v2.js
+++ b/assets/js/gear.v2.js
@@ -196,6 +196,15 @@
     return String(s || '').replace(/[&<>"']/g, (m) => ({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#39;' }[m]));
   }
 
+  const URL_PATTERN = /https?:\/\/\S+/gi;
+
+  function stripUrls(text = ''){
+    return String(text || '')
+      .replace(URL_PATTERN, ' ')
+      .replace(/\s+/g, ' ')
+      .trim();
+  }
+
   function createOptionRow(option = {}, options = {}){
     const row = el('div',{class:'option'});
     row.dataset.category = option.category || '';
@@ -206,15 +215,19 @@
     row.dataset.affiliate = option.affiliate || 'amazon';
     row.dataset.tag = option.tag || 'fishkeepingli-20';
     const href = (option?.href || '').trim();
-    const labelText = (option?.label || '').trim();
-    const titleText = (option?.title || '').trim();
+    const labelText = stripUrls(option?.label || '').trim();
+    const titleText = stripUrls(option?.title || '').trim();
     const displayTitle = titleText || labelText || 'this item';
     const headingHtml = labelText && titleText
       ? `<strong>${escapeHTML(labelText)} — ${escapeHTML(titleText)}</strong>`
       : `<strong>${escapeHTML(displayTitle)}</strong>`;
     const noteText = (option?.note ?? option?.notes ?? '').trim();
     const buttonLabel = options.buttonLabel || 'Buy on Amazon';
-    const actionsHtml = href
+    const hasValidHref = /^https?:\/\//i.test(href);
+    if (href && !hasValidHref && typeof console !== 'undefined' && typeof console.warn === 'function') {
+      console.warn('[Gear] Skipping stand link without http(s):', href);
+    }
+    const actionsHtml = hasValidHref
       ? `<a class="btn btn-amazon" href="${escapeHTML(href)}" target="_blank" rel="sponsored noopener noreferrer" aria-label="Buy ${escapeHTML(displayTitle)} on Amazon">${buttonLabel}</a>`
       : `<span class="muted">Add link</span>`;
     row.innerHTML = `

--- a/gear_nav.json
+++ b/gear_nav.json
@@ -1,0 +1,12 @@
+{
+  "files": [
+    {
+      "category": "stands",
+      "path": "data/gear_stands.csv",
+      "product_field": "title",
+      "url_field": "amazon_url",
+      "notes_field": "notes",
+      "id_field": "product_id"
+    }
+  ]
+}

--- a/reports/link_audit.csv
+++ b/reports/link_audit.csv
@@ -1,117 +1,16 @@
 Category,Product_Name,Amazon_Link,Resolved_URL,Domain,Page_Title,Match_Status,Notes
-Filtration,AQUANEAT Sponge,https://amzn.to/3KwArqb,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Tetra Whisper 10i,https://amzn.to/42XwEZi,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,AquaClear 20,https://amzn.to/4o1y7WN,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,AquaClear 30,https://amzn.to/4nYav5l,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,AquaClear 50,https://amzn.to/4nXVh05,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,AquaClear 70,https://amzn.to/4nTTyZK,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,AquaClear 110,https://amzn.to/4312pke,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Fluval 107,https://amzn.to/4879D9S,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Fluval 207,https://amzn.to/3KtrYEh,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Fluval 307,https://amzn.to/47bRUfx,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Fluval 407,https://amzn.to/4nvN57p,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Fluval FX4,https://amzn.to/3ITUYVf,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Fluval FX6,https://amzn.to/4q8CiCb,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Seachem Tidal 35,https://amzn.to/3ITWKWp,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Seachem Tidal 55,https://amzn.to/4pMD2g5,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Seachem Tidal 75,https://amzn.to/4pW7Gni,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Seachem Tidal 110,https://amzn.to/431O6Mj,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Cascade 500,https://amzn.to/4757LgP,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Cascade 700,https://amzn.to/48HSBzg,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Cascade 1000,https://amzn.to/48h3oAx,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Cascade 1500,https://amzn.to/46P5pBk,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Cascade 2000,https://amzn.to/4ntRKqp,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Penguin 100,https://amzn.to/46Q2rg6,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Penguin 150,https://amzn.to/46P5qFo,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Penguin 200,https://amzn.to/3VNMUs3,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Penguin 350,https://amzn.to/3VLNaHZ,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Penguin 400,https://amzn.to/4mGG6az,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,QuietFlow 10,https://amzn.to/3VHCESa,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,QuietFlow 20,https://amzn.to/3VNjcn3,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,QuietFlow 30,https://amzn.to/4nZf2Ew,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,QuietFlow 50,https://amzn.to/42XxbKM,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,QuietFlow 75,https://amzn.to/4o4vnbk,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,QuietFlow 90,https://amzn.to/42mFBLB,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,SunSun HW-302,https://amzn.to/4nZRkbk,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,SunSun HW-303B,https://amzn.to/3Whsbgi,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,SunSun HW-304B,https://amzn.to/4mIPPgE,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Eheim Classic 150,https://amzn.to/46A7h24,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Eheim Classic 250,https://amzn.to/4mGGkyr,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Eheim Classic 350,https://amzn.to/46vTNo2,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Eheim Classic 600,https://amzn.to/3IAUO57,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Eheim Pro 4+ 250,https://amzn.to/3KoJ7z5,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Eheim Pro 4+ 350,https://amzn.to/4o36KLX,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Eheim Pro 4+ 600,https://amzn.to/4gRAgC5,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Biomaster Thermo 250,https://amzn.to/3VLjfQo,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Biomaster Thermo 350,https://amzn.to/4gNOVhw,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Biomaster Thermo 600,https://amzn.to/3KuIlR0,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Biomaster Thermo 850,https://amzn.to/4gUDYuE,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Hygger Sponge Double,https://amzn.to/46NTAeW,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Hygger Internal Power,https://amzn.to/42W1YHZ,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Hygger Canister HG-915,https://amzn.to/46SU6s4,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Filtration,Hygger Canister HG-918,https://amzn.to/46LTvrZ,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,NICREW ClassicLED Plus 18in,https://amzn.to/46Oetq2,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,NICREW ClassicLED Plus 24in,https://amzn.to/3IRfhTd,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,NICREW ClassicLED Plus 30in,https://amzn.to/4n4x9Z7,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,NICREW ClassicLED Plus 36in,https://amzn.to/46WyHOO,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,NICREW ClassicLED Plus 48in,https://amzn.to/4nq2Exu,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,NICREW SkyLED Plus 24in,https://amzn.to/48LB1dN,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,NICREW SkyLED Plus 36in,https://amzn.to/3ITYtuR,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,NICREW SkyLED Plus 48in,https://amzn.to/48ceAOH,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,NICREW Reef LED 30in,https://amzn.to/47bTqOL,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Fluval Aquasky 24-36in,https://amzn.to/3WhthIW,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Fluval Aquasky 36-48in,https://amzn.to/46LULvd,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Fluval Plant 3.0 24-34in,https://amzn.to/4mK1I5Q,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Fluval Plant 3.0 36-48in,https://amzn.to/3VLtFzq,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Fluval Plant 3.0 Nano 15in,https://amzn.to/46Oex9g,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Hygger Clip-On 18in,https://amzn.to/48bCV7f,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Hygger 24in Full-Spectrum LED,https://amzn.to/42my2Vn,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Hygger 36in Full-Spectrum LED,https://amzn.to/4nwtLXR,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Hygger 48in Full-Spectrum LED,https://amzn.to/4ntyOYX,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Aqueon Clip-On Planted 20in,https://amzn.to/42kSTbs,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Aqueon Planted 30in,https://amzn.to/42p2OwO,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Aqueon Planted 48in,https://amzn.to/4pS0CYI,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Beamswork DA 36in,https://amzn.to/4nx2TXy,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Beamswork DA 48in,https://amzn.to/4nHYXDm,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Beamswork DA 72in,https://amzn.to/4q8DXaT,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Beamswork EA 24in,https://amzn.to/3WhtsnA,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Beamswork EA 36in,https://amzn.to/3KwJck7,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Beamswork EA 48in,https://amzn.to/4pOqHHY,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Beamswork Vivio 24in,https://amzn.to/4pRESMy,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Beamswork Vivio 36in,https://amzn.to/4pWeBNk,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Beamswork Vivio 48in,https://amzn.to/4mGHBWf,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Hygger Advanced LED 24in,https://amzn.to/4pQHz0J,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Hygger Advanced LED 36in,https://amzn.to/4mNWPIZ,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Hygger Advanced LED 48in,https://amzn.to/4pOqEfg,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Hygger Advanced LED 72in,https://amzn.to/4pS5uNg,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Chihiros WRGB II 30in,https://amzn.to/4mKTtGP,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Chihiros WRGB II 36in,https://amzn.to/474piWp,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Chihiros WRGB II 48in,https://amzn.to/3WjlH0w,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Lighting,Chihiros WRGB II 72in,https://amzn.to/4gUd06z,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,hygger Aquarium Heater 500W,https://amzn.to/4o1C1ip,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,hygger Aquarium Heater 800W,https://amzn.to/4o1C1ip,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,hygger Aquarium Heater 1000W,https://amzn.to/4o1C1ip,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,hygger Small Aquarium Heater 10W,https://amzn.to/4nxu199,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,hygger Small Aquarium Heater 25W,https://amzn.to/3KwEIdd,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,hygger Small Aquarium Heater 50W,https://amzn.to/4nxu199,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,hygger Small Aquarium Heater 100W,https://amzn.to/3KwEIdd,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,hygger ETL Certified Heater 50W,https://amzn.to/46ylbSr,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,hygger ETL Certified Heater 100W,https://amzn.to/46ymD7l,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,hygger ETL Certified Heater 200W,https://amzn.to/46ylbSr,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,hygger ETL Certified Heater 300W,https://amzn.to/46ymD7l,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,Marineland Precision Heater 200W,https://amzn.to/4pPMBuv,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,Marineland Precision Heater 250W,https://amzn.to/48GqKPZ,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,Marineland Precision Heater (assorted watts),https://amzn.to/3VIySYP,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,Inkbird Aquarium Temperature Controller,https://amzn.to/46IMpEB,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,Cobalt Neo-Therm Pro 100W,https://www.cobaltaquatics.com/products/neo-therm-pro-heater,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,Cobalt Neo-Therm Pro 200W,https://www.cobaltaquatics.com/products/neo-therm-pro-heater,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,TBD (enter product + watt),https://amzn.to/476spgs,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,TBD (enter product + watt),https://amzn.to/3INi6Vh,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,TBD (enter product + watt),https://amzn.to/42U1jGT,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,TBD (enter product + watt),https://amzn.to/4pSi4fx,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,TBD (enter product + watt),https://amzn.to/46N20TL,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,TBD (enter product + watt),https://amzn.to/4nZjenK,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,TBD (enter product + watt),https://amzn.to/3WfXoAC,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,TBD (enter product + watt),https://amzn.to/42l2Q8X,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,TBD (enter product + watt),https://amzn.to/4nVrEwl,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
-Heating,TBD (enter product + watt),https://amzn.to/48J1wjW,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"Fish Tank Stand, 10 Gallon Heavy Duty Metal Aquarium Stand, Reptile Tank, Turtle Tank, Breeder Tank Stand, Fish Tank and Stand Combo Set (Black, 24.8""x9.2""x30)""",https://amzn.to/48RoENi,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"Snughome 10 Gallon Aquarium Stand with Storage, 3-Tier Heavy Metal Fish Tank Stand Shelf 20.47"" x 11.42"" x 30.91"", Rustic Brown",https://amzn.to/46UqOJn,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"10 Gallon Fish Tank Stand with Power Outlet, 3-Tier Aquarium Stand with Shelf, Turtle/Reptile Tank Stand for Home Office, Adjustable Boards, 20.47''L×11.42''W×30.91''H, Retro Brown",https://amzn.to/3WpFAmz,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"5–10 Gallon Fish Tank Stand, Metal Double Aquarium Stand with Cabinet for Fish Tank Accessories Storage, Heavy Duty 20.5"" L × 11.02"" W Tabletop, 500 lb Capacity, Black (PG06YGB)",https://amzn.to/46Iemh6,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"Bestier 10 Gallon Fish Tank Stand with Power Outlet, 20.3x10.6 Metal Aquarium Stand with Filter Storage, 6-Leg Reptile Tank Stand with 3-Tier Adjustable Storage Shelves, 264 lb Capacity, Black Oak",https://amzn.to/48iYlQ3,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"CADUKE Aquarium Stand 20 Gallon, Metal Fish Tank Stand, Aquarium Rack Stand for Fish Tank Accessories, 3-Tier Turtle/Reptile Terrarium Stand for Living Room or Office",https://amzn.to/3KwHbVh,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"Fish Tank Stand – 20 Gallon Heavy-Duty Metal Aquarium Stand, Reptile & Turtle Breeder Tank Combo (Black, 24.8""x13""x30)""",https://amzn.to/3WrgTWV,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"YITAHOME 10-29-37 Gallon Fish Tank Stand with Power Outlet, 30×16"" Metal Aquarium Stand with 3-Tier Adjustable Storage Shelves and Hooks, 450 lb Capacity, Black",https://amzn.to/48Q0jYa,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"LANDEN Gray Metal Frame Stand, Three-Shelf for Fish Tanks up to 20 Gal, CLX45 (17.7×17.7×31.5 in) for Fish Tanks and Reptile Terrariums, Home & Office Use",https://amzn.to/47cCA38,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"Ollie & Hutch Flipper 10/20 Gallon Aquarium Stand, Black Oak",https://amzn.to/3VUr9XI,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"10–20 Gallon Fish Tank Stand, Metal Aquarium Stand with Adjustable Non-Slip Foot and Wooden Shelf, Reptile Tank Stand Easy to Assemble for Home Office, Firm and Steady (Tank not Included)",https://amzn.to/4nGDOtu,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"YITAHOME 10-29-37 Gallon Fish Tank Stand with Power Outlet, 30x16 Inch Metal Aquarium Stand with 3-Tier Adjustable Storage Shelves and Hooks, 450LBS Capacity, Black",https://amzn.to/4nOZOSX,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"Fish Tank Stand, 40 Gallon Heavy Duty Metal Aquarium Stand, Reptile Tank, Turtle Tank, Breeder Tank Stand, Fish Tank and Stand Combo Set (Black, 36.5x18.5x29.5)",https://amzn.to/3Wp9JT5,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"GRLEAF 20-40 Gallon Aquarium Stand: 1000LB Capacity, Built-In Power Outlets, 3-Tier Shelves for Fish Tank Accessories Storage, Heavy-Duty Steel/Wood Hybrid for Fish & Reptile Tanks | Excludes Tank",https://amzn.to/437Cmb4,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL
+stands,"20-29 Gallon Fish Tank Stand, Aquarium Stand with Cabinet Accessories Storage, Heavy Duty Metal Frame, 31.49 L×15.74 W Tabletop, 330LBS Capacity, Black PG07YGB",https://amzn.to/4mVXhVT,,,,NO_TITLE,EXPAND_ERR:URLError:Tunnel connection failed: 403 Forbidden;NO_URL

--- a/reports/link_audit.txt
+++ b/reports/link_audit.txt
@@ -1,1 +1,13 @@
-Link Audit Source: master:gear_master.csv\nTotal audited: 116\n  Filtration: 51\n  Heating: 27\n  Lighting: 38\n\nMISMATCH rows: 0\n\nNO_TITLE rows: 116\n\nUNKNOWN rows: 0\n\nNotes: EXPAND_ERR = redirect/resolve failed; TITLE_ERR = fetch or parse title failed.\n
+Link Audit Source: manifest:gear_nav.json (category=stands)
+Total audited: 15
+Missing sponsored: 0
+HTTP 404 errors: 0
+  stands: 15
+
+MISMATCH rows: 0
+
+NO_TITLE rows: 15
+
+UNKNOWN rows: 0
+
+Notes: EXPAND_ERR = redirect/resolve failed; TITLE_ERR = fetch or parse title failed.

--- a/scripts/link_audit.py
+++ b/scripts/link_audit.py
@@ -24,6 +24,23 @@ except Exception:  # pragma: no cover - network sandbox lacks pip
     BeautifulSoup = None
 
 
+AUDIT_DEFAULT_KEYS = [
+    "Category",
+    "Tank_Size",
+    "Product_Type",
+    "Product_Name",
+    "Use_Case",
+    "Recommended_Specs",
+    "Plant_Ready",
+    "Price_Range",
+    "Notes",
+    "Amazon_Link",
+    "Chewy_Link",
+    "ASIN",
+    "Source_List",
+]
+
+
 class _UrlLibResponse(SimpleNamespace):
     """Lightweight response object for urllib fallback."""
 
@@ -69,15 +86,30 @@ def _extract_title(html):
 
 UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
 
+def ensure_default_keys(row):
+    for key in AUDIT_DEFAULT_KEYS:
+        row.setdefault(key, "")
+    return row
+
+
+def ci_get(row, key, default=""):
+    if not key:
+        return default
+    target = key.strip().casefold()
+    for existing, value in row.items():
+        if existing is None:
+            continue
+        if existing.strip().casefold() == target:
+            return value
+    return default
+
+
 def read_csv_rows(path):
     rows = []
     with open(path, newline="", encoding="utf-8") as f:
         r = csv.DictReader(f)
         for row in r:
-            # Normalize missing keys
-            for k in ["Category","Tank_Size","Product_Type","Product_Name","Use_Case","Recommended_Specs","Plant_Ready","Price_Range","Notes","Amazon_Link","Chewy_Link"]:
-                row.setdefault(k, "")
-            rows.append(row)
+            rows.append(ensure_default_keys(dict(row)))
     return rows
 
 def read_from_master_or_nav(master_csv="gear_master.csv", nav_json="data/master_nav.json"):
@@ -114,6 +146,74 @@ def read_from_master_or_nav(master_csv="gear_master.csv", nav_json="data/master_
     if combined:
         return combined, "list:" + ",".join(used)
     raise FileNotFoundError("No input found. Provide --input CSV or ensure gear_master.csv or data/master_nav.json exists.")
+
+
+def read_from_manifest(manifest_path, category_filter=None):
+    path = Path(manifest_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+    with open(path, "r", encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    entries = data.get("files") or data.get("entries") or []
+    if not isinstance(entries, list):
+        raise ValueError("Manifest must contain a list under 'files' or 'entries'.")
+
+    rows = []
+    used_sources = []
+    base_dir = path.parent
+    cat_filter = category_filter.strip().casefold() if category_filter else None
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_category = (entry.get("category") or entry.get("id") or "").strip()
+        if cat_filter and entry_category.strip().casefold() != cat_filter:
+            continue
+        csv_path = entry.get("path") or entry.get("file")
+        if not csv_path:
+            continue
+        csv_path = Path(csv_path)
+        if not csv_path.is_absolute():
+            csv_path = (base_dir / csv_path).resolve()
+        if not csv_path.exists():
+            continue
+
+        product_field = entry.get("product_field") or entry.get("title_field") or entry.get("product") or "Product_Name"
+        url_field = entry.get("url_field") or entry.get("amazon_field") or entry.get("href_field") or "Amazon_Link"
+        chewy_field = entry.get("chewy_field") or "Chewy_Link"
+        notes_field = entry.get("notes_field") or entry.get("note_field")
+        category_field = entry.get("category_field") or "Category"
+        id_field = entry.get("id_field") or "product_id"
+
+        with open(csv_path, newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle, escapechar='\\')
+            for raw in reader:
+                row = {k: (v or "") for k, v in raw.items()}
+                product_name = str(ci_get(row, product_field, "")).strip()
+                url = str(ci_get(row, url_field, "")).strip()
+                row_id = str(ci_get(row, id_field, "")).strip()
+                category_value = str(ci_get(row, category_field, entry_category)).strip() or entry_category
+                if row_id.startswith("#") or product_name.startswith("#") or url.startswith("#"):
+                    continue
+                if not (product_name or url):
+                    continue
+                notes_value = str(ci_get(row, notes_field, "")).strip() if notes_field else str(row.get("Notes", "")).strip()
+                chewy_value = str(ci_get(row, chewy_field, "")).strip() if chewy_field else ""
+
+                normalized = ensure_default_keys({})
+                normalized["Category"] = category_value or entry_category
+                normalized["Product_Name"] = product_name
+                normalized["Amazon_Link"] = url
+                normalized["Chewy_Link"] = chewy_value
+                normalized["Notes"] = notes_value
+                normalized["Source_List"] = entry.get("source") or entry_category or csv_path.name
+                rows.append(normalized)
+        used_sources.append(str(csv_path))
+
+    if category_filter:
+        return rows, f"manifest:{manifest_path} (category={category_filter})"
+    return rows, f"manifest:{manifest_path}"
 
 def expand_url(url, session, timeout=2):
     if not url:
@@ -179,15 +279,24 @@ def ensure_dir(p):
 def main():
     ap = argparse.ArgumentParser(description="Audit product links and titles vs Product_Name.")
     ap.add_argument("--input", help="Path to CSV (optional if gear_master.csv or data/master_nav.json exists).")
+    ap.add_argument("--manifest", help="Path to manifest JSON describing category CSVs.")
+    ap.add_argument("--category", help="Filter rows by category (case-insensitive).")
     ap.add_argument("--sleep", type=float, default=1.0, help="Delay between requests (seconds).")
     ap.add_argument("--limit", type=int, default=0, help="Limit number of rows audited (0 = no limit).")
     args = ap.parse_args()
 
-    if args.input:
+    if args.manifest:
+        rows, src = read_from_manifest(args.manifest, category_filter=args.category)
+    elif args.input:
         rows = read_csv_rows(args.input)
         src = f"file:{args.input}"
     else:
         rows, src = read_from_master_or_nav()
+
+    if args.category and not args.manifest:
+        target = args.category.strip().casefold()
+        rows = [r for r in rows if (r.get("Category", "").strip().casefold() == target)]
+        src = f"{src} [category={args.category}]"
 
     ensure_dir("reports")
     out_csv = "reports/link_audit.csv"
@@ -199,6 +308,8 @@ def main():
 
     audited = []
     count = 0
+    missing_sponsored = 0
+    http_404 = 0
 
     for r in rows:
         if args.limit and count >= args.limit:
@@ -206,9 +317,13 @@ def main():
         url = (r.get("Amazon_Link") or "").strip() or (r.get("Chewy_Link") or "").strip()
         prod = r.get("Product_Name","")
         cat  = r.get("Category","")
+        if not url.lower().startswith("http"):
+            missing_sponsored += 1
         final_url, domain, expand_status = expand_url(url, session)
         title, title_status = ("","NO_URL") if not final_url else fetch_title(final_url, session)
         status = guess_status(prod, title)
+        if "HTTPError:404" in expand_status or "HTTPError:404" in title_status:
+            http_404 += 1
         note_bits = []
         if expand_status != "OK": note_bits.append(expand_status)
         if title_status != "OK":  note_bits.append(title_status)
@@ -244,20 +359,22 @@ def main():
         by_cat[a["Category"]] += 1
 
     with open(out_txt, "w", encoding="utf-8") as f:
-        f.write(f"Link Audit Source: {src}\\n")
-        f.write(f"Total audited: {len(audited)}\\n")
-        for k,v in sorted(by_cat.items()):
-            f.write(f"  {k or 'Uncategorized'}: {v}\\n")
-        f.write("\\nMISMATCH rows: {}\\n".format(len(mismatches)))
+        f.write(f"Link Audit Source: {src}\n")
+        f.write(f"Total audited: {len(audited)}\n")
+        f.write(f"Missing sponsored: {missing_sponsored}\n")
+        f.write(f"HTTP 404 errors: {http_404}\n")
+        for k, v in sorted(by_cat.items()):
+            f.write(f"  {k or 'Uncategorized'}: {v}\n")
+        f.write("\nMISMATCH rows: {}\n".format(len(mismatches)))
         for a in mismatches[:25]:
             f.write(f"  - [{a['Category']}] {a['Product_Name']}\\n")
             f.write(f"    Title: {a['Page_Title'][:160]}\\n")
             f.write(f"    URL:   {a['Resolved_URL']}\\n")
         if len(mismatches) > 25:
             f.write(f"  ... and {len(mismatches)-25} more\\n")
-        f.write("\\nNO_TITLE rows: {}\\n".format(len(no_titles)))
-        f.write("\\nUNKNOWN rows: {}\\n".format(len(unknowns)))
-        f.write("\\nNotes: EXPAND_ERR = redirect/resolve failed; TITLE_ERR = fetch or parse title failed.\\n")
+        f.write("\nNO_TITLE rows: {}\n".format(len(no_titles)))
+        f.write("\nUNKNOWN rows: {}\n".format(len(unknowns)))
+        f.write("\nNotes: EXPAND_ERR = redirect/resolve failed; TITLE_ERR = fetch or parse title failed.\n")
 
     print(f"[OK] Wrote {out_csv} and {out_txt}")
 


### PR DESCRIPTION
## Summary
- strip accidental URLs from rendered stand titles and skip invalid buy buttons in `gear.v2.js`
- add a manifest-driven flow to `link_audit.py`, track missing sponsored links and 404s, and emit a gear-only manifest
- regenerate the stand link audit reports using the new manifest for the stands category

## Testing
- python scripts/link_audit.py --manifest gear_nav.json --category stands --sleep 0.8

------
https://chatgpt.com/codex/tasks/task_e_68e53aae1d4083328f4af6307d2c88f0