### PR TITLE
Add Cycling Coach link and Amazon affiliate disclosures

### DIFF
--- a/gear/index.html
+++ b/gear/index.html
@@ -14,6 +14,13 @@
   <link rel="stylesheet" href="/css/site.css?v=2024-07-05a">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
   <link rel="stylesheet" href="/assets/css/gear.v2.css">
+  <style>
+    .affiliate-disclaimer {
+      margin: 1rem 0;
+      font-size: 0.9em;
+      color: #c8d0da;
+    }
+  </style>
   <script defer src="/js/nav.js?v=1.1.0"></script>
 </head>
 <body class="theme-dark">
@@ -37,6 +44,10 @@
         <p id="gear-tank-meta" class="tank-meta" aria-live="polite" hidden></p>
       </div>
     </section>
+
+    <p class="affiliate-disclaimer">
+      <em>As an Amazon Associate, we earn from qualifying purchases.</em>
+    </p>
 
     <div class="gear-shell">
       <section class="gear-card" data-gear="heaters">

--- a/nav.html
+++ b/nav.html
@@ -28,6 +28,7 @@
       <ul class="nav__list">
         <li class="nav__item"><a href="/" class="nav__link" data-nav="home">Home</a></li>
         <li class="nav__item"><a href="/stocking.html" class="nav__link" data-nav="stocking">Stocking Advisor</a></li>
+        <li class="nav__item"><a href="/params.html" class="nav__link" data-nav="params">Cycling Coach</a></li>
         <li class="nav__item"><a href="/gear/" class="nav__link" data-nav="gear">Gear</a></li>
         <li class="nav__item"><a href="/media.html" class="nav__link" data-nav="media">Media</a></li>
         <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link" data-nav="feature-your-tank">Feature Your Tank</a></li>
@@ -60,6 +61,7 @@
       <ul class="nav__list nav__list--drawer">
         <li class="nav__item"><a id="drawer-first" href="/" class="nav__link" data-nav="home">Home</a></li>
         <li class="nav__item"><a href="/stocking.html" class="nav__link" data-nav="stocking">Stocking Advisor</a></li>
+        <li class="nav__item"><a href="/params.html" class="nav__link" data-nav="params">Cycling Coach</a></li>
         <li class="nav__item"><a href="/gear/" class="nav__link" data-nav="gear">Gear</a></li>
         <li class="nav__item"><a href="/media.html" class="nav__link" data-nav="media">Media</a></li>
         <li class="nav__item"><a href="/feature-your-tank.html" class="nav__link" data-nav="feature-your-tank">Feature Your Tank</a></li>

--- a/store.html
+++ b/store.html
@@ -65,6 +65,7 @@
     .btn.primary:hover { filter: brightness(0.95); }
     .btn.secondary { background: transparent; color: #c8d0da; border-color: rgba(255,255,255,0.18); }
     .note { color: #9aa3af; font-size: 12px; margin-top: 4px; }
+    .affiliate-disclaimer { margin: 12px 0 0; font-size: 0.9em; color: #9aa3af; }
 
     /* Responsive: two columns on medium+ */
     @media (min-width: 760px) {
@@ -155,6 +156,10 @@
           </ul>
 
           <div class="meta">Category: Aquariums • Science • Family &amp; Education</div>
+
+          <p class="affiliate-disclaimer">
+            <em>As an Amazon Associate, we earn from qualifying purchases.</em>
+          </p>
 
           <div class="cta-row">
             <a class="btn primary" href="https://amzn.to/3IRKvK0" target="_blank" rel="sponsored noopener noreferrer">


### PR DESCRIPTION
## Summary
- add a Cycling Coach link to the desktop and mobile primary navigation
- surface an Amazon Associates disclosure near the gear recommendations and store CTAs with light styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e566a38ac48332a43093c50dbfe64b