### PR TITLE
Update 55-75 gallon stand entries

### DIFF
--- a/data/gear_stands.csv
+++ b/data/gear_stands.csv
@@ -4,10 +4,9 @@ tank_range,subgroup,title,notes,amazon_url,length_in,width_in,height_in,capacity
 20-40,Metal_Frame,"YITAHOME 30″ Metal Aquarium Stand with Power Outlet","Built-in outlet, hooks, and adjustable shelves for flexible storage.","https://amzn.to/4nOZOSX?tag=fishkeepingli-20",30,16,31.5,450,Metal/Wood,Black,amazon,fishkeepingli-20
 20-40,Metal_Frame,"Heavy-Duty 40 Gallon Metal Aquarium Stand","Heavy-duty frame sized for standard 36-inch tanks; great for 29–40 gallons.","https://amzn.to/3Wp9JT5?tag=fishkeepingli-20",36.5,18.5,29.5,,Metal,Black,amazon,fishkeepingli-20
 20-40,Hybrid,"GRLEAF 20–40 Gallon Aquarium Stand with Power Outlet","Steel and wood hybrid construction with deep storage shelves and outlet.","https://amzn.to/437Cmb4?tag=fishkeepingli-20",,,,1000,Steel/Wood,Black,amazon,fishkeepingli-20
-55-75,Metal_Frame,"Aquatic Fundamentals 75 Gallon Aquarium Stand","Powder-coated steel frame sized for standard 48″ × 18″ tanks.","https://www.amazon.com/dp/B009GCO7C8?tag=fishkeepingli-20",49.4,19.4,28.3,,Metal,Black,amazon,fishkeepingli-20
-55-75,Cabinet,"JAJALE 75 Gallon Aquarium Stand with Cabinet","Enclosed cabinet with adjustable storage and leveling feet for big tanks.","https://www.amazon.com/dp/B0833746QT?tag=fishkeepingli-20",48.4,18.9,31.5,,Metal/Wood,Black,amazon,fishkeepingli-20
-55-75,Hybrid,"Flipper Wildwood 55 Gallon Aquarium Stand","Barnwood-style cabinet with center braces to support 55–75 gallon setups.","https://www.amazon.com/dp/B07MV1JDZB?tag=fishkeepingli-20",50,19.5,30.3,,Wood,"Rustic Gray",amazon,fishkeepingli-20
-55-75,Cabinet,"Ameriwood Home Laguna Tide 55 Gallon Aquarium Stand","Two-tone cabinet stand with adjustable shelves and cable management.","https://www.amazon.com/dp/B01N6K3EHR?tag=fishkeepingli-20",,,,,Wood,Gray,amazon,fishkeepingli-20
+55-75,Metal_Frame,<PASTE_TITLE_1>,,<PASTE_URL_1>,,,,,,,amazon,fishkeepingli-20
+55-75,Cabinet,<PASTE_TITLE_2>,,<PASTE_URL_2>,,,,,,,amazon,fishkeepingli-20
+55-75,Hybrid,<PASTE_TITLE_3>,,<PASTE_URL_3>,,,,,,,amazon,fishkeepingli-20
 75-125,Metal_Frame,"Aquatic Fundamentals 125 Gallon Aquarium Stand","Sturdy steel frame with adjustable feet for six-foot tanks.","https://www.amazon.com/dp/B0085Y9AI6?tag=fishkeepingli-20",72.5,18.5,28.3,,Metal,Black,amazon,fishkeepingli-20
 75-125,Cabinet,"JAJALE 100 Gallon Aquarium Stand with Storage","Heavy-duty cabinet stand with reinforced frame and side shelving.","https://www.amazon.com/dp/B0B6L9H6DH?tag=fishkeepingli-20",53.5,19.7,32.3,,Metal/Wood,Black,amazon,fishkeepingli-20
 75-125,Cabinet,"Aquatic Fundamentals 125 Gallon Upright Aquarium Stand","Full-length cabinet with moisture-resistant finish for large aquariums.","https://www.amazon.com/dp/B0085Y9AKY?tag=fishkeepingli-20",72.5,18.5,28.2,,Wood,Black,amazon,fishkeepingli-20


### PR DESCRIPTION
## Summary
- remove outdated 55–75 gallon stand rows from gear_stands.csv
- add placeholder entries ready for owner-supplied titles and Amazon shortlinks

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e593c855b08332896c22c26c608dc4