### PR TITLE
Add Cleanup & Extras accordion to gear page

### DIFF
--- a/assets/css/gear.v2.css
+++ b/assets/css/gear.v2.css
@@ -284,6 +284,59 @@ body{
   margin-top:0;
 }
 
+.gear-subcard--extras .gear-subcard__body{
+  gap:1.4rem;
+}
+
+.extras-groups{
+  display:grid;
+  gap:1.35rem;
+}
+
+.extras-group__title{
+  margin:0 0 0.65rem;
+  font-size:1rem;
+  font-weight:600;
+  letter-spacing:0.01em;
+}
+
+.extras-group__items{
+  display:grid;
+  gap:1rem;
+}
+
+.gear-subcard--extras .option{
+  border:1px solid rgba(148,163,184,0.35);
+  border-radius:12px;
+  padding:1rem 1.1rem;
+  background:rgba(15,23,42,0.38);
+  transition:border-color 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+}
+
+.gear-subcard--extras .option + .option{
+  border-top:none;
+  margin-top:0;
+  padding-top:0;
+}
+
+.gear-subcard--extras .option:hover,
+.gear-subcard--extras .option:focus-within{
+  border-color:#3bf97b;
+  box-shadow:0 0 0 1px rgba(59,249,123,0.28),0 6px 16px -12px rgba(59,249,123,0.5);
+  transform:translateY(-1px);
+}
+
+.gear-subcard--extras .option__actions{
+  background:transparent;
+  padding:0;
+}
+
+.extras-placeholder{
+  margin:0;
+  color:var(--muted);
+  font-size:0.95rem;
+}
+
 .range--food .range__tip{
   margin-top:0;
 }
@@ -370,6 +423,13 @@ body{
   cursor:not-allowed;
   pointer-events:none;
   filter:none;
+}
+.btn.btn-disabled,
+.btn[aria-disabled="true"]{
+  background:rgba(148,163,184,0.2);
+  border-color:rgba(148,163,184,0.45);
+  color:rgba(226,232,240,0.85);
+  opacity:1;
 }
 .option__cta-note{
   display:inline-block;

--- a/data/gear_extras.csv
+++ b/data/gear_extras.csv
@@ -1,0 +1,11 @@
+category,subgroup,title,notes,amazon_url
+Extras,Cloths,"Microfiber Towels (Pack)","Lint-free; great for glass and general cleanup.",
+Extras,Cloths,"Paper Towels (Bulk)","Keep a roll near your tank for quick drips.",
+Extras,Sprayers,"Reusable Spray Bottles (2-Pack)","Label one for distilled water + vinegar mix.",
+Extras,Water,"Distilled Water (1 Gal)","Use with vinegar for exterior glass cleaning.",
+Extras,Gloves,"Nitrile/Neoprene Gloves","Dedicated set for tank maintenance only.",
+Extras,Buckets,"5-Gallon Bucket (Dedicated)","Do not repurpose; keep for aquarium use only.",
+Extras,Cable,"Cable Ties / Velcro Straps","Tidy cords; add drip loops for safety.",
+Extras,Cloths,"Shop Towels / Rags","Absorbent option for bigger spills.",
+Extras,Misc,"Small Parts Organizer","Store spare media, o-rings, test kit bits.",
+Extras,Misc,"Silicone Mat / Tray","Set damp tools on this to protect surfaces.",


### PR DESCRIPTION
## Summary
- add a gear_extras.csv seed file covering cleanup and maintenance extras
- extend the gear data pipeline and maintenance tools UI to render the new Cleanup & Extras accordion with subgrouped cards and disabled buy buttons when links are missing
- style the extras layout and disabled buttons to match the site’s gear design

## Testing
- python3 -m http.server 8080 (manual verification of /gear)


------
https://chatgpt.com/codex/tasks/task_e_68e5aa3bcf28833295753a2ac185bd98