### PR TITLE
feat(gear): enable Substrate & Aquascaping → Stones & Wood items with affiliate links

### DIFF
--- a/assets/js/gear.v2.data.js
+++ b/assets/js/gear.v2.data.js
@@ -148,6 +148,7 @@ const EXTRAS_DEFAULT_SUBGROUP = 'Misc';
 const EXTRAS_PLACEHOLDER = 'Links coming soon.';
 
 const CATEGORY_ALIASES = new Map([
+  ['substrate & aquascaping', 'substrate'],
   ['maintenance & tools', 'maintenance_tools'],
   ['maintenance tools', 'maintenance_tools'],
   ['maintenance-tools', 'maintenance_tools']

--- a/assets/js/gear.v2.js
+++ b/assets/js/gear.v2.js
@@ -258,16 +258,19 @@
     }
     const standAria = `Buy on Amazon – ${escapeHTML(displayTitle)}`;
     const useSimpleButton = normalizedContext === 'substrate' || normalizedContext === 'maintenancetools';
+    const disabledSimpleButtonHtml = normalizedContext === 'substrate'
+      ? `<button class="btn" type="button" aria-disabled="true" title="Link coming soon" disabled>${buttonLabel}</button>`
+      : `<span class="btn btn-disabled" aria-disabled="true" role="button" tabindex="-1" title="Link coming soon">${buttonLabel}</span>`;
     const actionsHtml = hasValidHref
       ? context === 'stands'
         ? `<a class="btn btn-amazon buy-amazon" href="${escapeHTML(href)}" target="_blank" rel="sponsored noopener noreferrer" aria-label="${standAria}">Buy on Amazon</a>`
         : useSimpleButton
           ? `<a class="btn" href="${escapeHTML(href)}" target="_blank" rel="sponsored noopener noreferrer" aria-label="Buy ${escapeHTML(displayTitle)} on Amazon">${buttonLabel}</a>`
-          : `<a class="btn btn-amazon" href="${escapeHTML(href)}" target="_blank" rel="sponsored noopener noreferrer" aria-label="Buy ${escapeHTML(displayTitle)} on Amazon">${buttonLabel}</a>`
+        : `<a class="btn btn-amazon" href="${escapeHTML(href)}" target="_blank" rel="sponsored noopener noreferrer" aria-label="Buy ${escapeHTML(displayTitle)} on Amazon">${buttonLabel}</a>`
       : context === 'stands'
         ? `<a class="btn btn-amazon buy-amazon disabled" aria-disabled="true" tabindex="-1">Buy on Amazon</a>`
         : useSimpleButton
-          ? `<span class="btn btn-disabled" aria-disabled="true" role="button" tabindex="-1" title="Link coming soon">${buttonLabel}</span>`
+          ? disabledSimpleButtonHtml
           : `<span class="muted">Add link</span>`;
     row.innerHTML = `
       <div class="option__title">${headingHtml}</div>

--- a/data/gear_substrate.csv
+++ b/data/gear_substrate.csv
@@ -2,9 +2,14 @@ category,subgroup,title,notes,amazon_url
 Substrate,Nutrient-Rich Soils,"Fluval 12695 Plant and Shrimp Stratum for Freshwater Fish Tanks, 17.6 lbs. – Aquarium Substrate for Strong Plant Growth, Supports Neutral to Slightly Acidic pH",,https://amzn.to/4gXDMuF
 Substrate,Nutrient-Rich Soils,"Upgraded Aquarium Soil Water Grass Mud, Ideal for Fish Tank Aquascaping Aquarium Substrate Soil for Plants and Shrimps, No Need to Wash (17.6 Pounds)",,https://amzn.to/3KvbaNk
 Substrate,Nutrient-Rich Soils,"Fluval 12698 Natural Mineral-Rich Volcanic Soil Bio Stratum for Planted Tanks, 17.6 lbs. - Aquarium Substrate for Healthy Plant Development, Growth, and Color",,https://amzn.to/3WtUCHW
-Substrate,Nutrient-Rich Soils,"Seachem Flourite Black Clay Gravel - Stable Porous Natural Planted Aquarium Substrate 15.4 lbs",,https://amzn.to/4mVTEiK
+Substrate,Nutrient-Rich Soils,Seachem Flourite Black Clay Gravel - Stable Porous Natural Planted Aquarium Substrate 15.4 lbs,,https://amzn.to/4mVTEiK
 Substrate,Nutrient-Rich Soils,"Flourite, 7 kg / 15.4 lbs",,https://amzn.to/48SfvUL
 Substrate,Gravel / Sand / Dirt Cap,"20LB Decorative River Rocks Gravel - 2/5"" Mixed Color Gravel for Vase Filling, Flower Pot Paving. Gravel for Garden Decoration, Landscaping, Aquarium Aquascape Gravel, Fish Tanks Gravel (8-12MM)",,https://amzn.to/3KH29k6
 Substrate,Gravel / Sand / Dirt Cap,"Sandtastik Sparkling White Play Sand, 25 lb (11.3 kg)",,https://amzn.to/4h8dp5h
 Substrate,Gravel / Sand / Dirt Cap,"Carib Sea ACS05820 Super Natural Moonlight Sand for Aquarium, 5-Pound",,https://amzn.to/3IxxGVd
 Substrate,Gravel / Sand / Dirt Cap,"Aqua Natural Diamond Black 10lb, Premium Gravel and Substrate for Aquariums, Fish Tanks and Terrariums, 1-2mm",,https://amzn.to/3IJ16jd
+Substrate & Aquascaping,Stones & Wood,Dragon Stone (Ohko) – Assorted Sizes,"Light, porous clay-stone; easy to shape scapes; rinse thoroughly.",https://www.amazon.com/dp/B07HFHKD8V/?tag=fishkeepingli-20
+Substrate & Aquascaping,Stones & Wood,Seiryu Stone – Assorted Sizes,Iconic ridged texture; may raise KH/GH slightly; test if keeping soft-water species.,
+Substrate & Aquascaping,Stones & Wood,Spiderwood (Root Form) – Assorted Sizes,Branching shapes; often floats initially—pre-soak and weigh down.,https://www.amazon.com/dp/B00GH7YDBQ/?tag=fishkeepingli-20
+Substrate & Aquascaping,Stones & Wood,Mopani Driftwood – Natural,Dense hardwood; sinks readily; releases tannins that may tint water.,https://www.amazon.com/dp/B0002DJ9WW/?tag=fishkeepingli-20
+Substrate & Aquascaping,Stones & Wood,Rock/Driftwood Soaking Tub,Use to pre-soak wood and test-leach stone safely before placing in tank.,


### PR DESCRIPTION
## Summary
- seed the Substrate & Aquascaping → Stones & Wood subgroup in `data/gear_substrate.csv`, including new affiliate links where available
- treat "Substrate & Aquascaping" as an alias of the substrate category so the new subgroup renders automatically
- update the substrate renderer to show an aria-disabled button when an item is missing an Amazon URL

## Testing
- Manual QA via local `python3 -m http.server 8080` and Playwright to verify the Stones & Wood subgroup renders with the correct mix of active and disabled buttons

------
https://chatgpt.com/codex/tasks/task_e_68e5bb525e64833285b79ff2b4d2d262