### PR TITLE
chore: normalize gear product titles

### DIFF
--- a/assets/js/gear.v2.js
+++ b/assets/js/gear.v2.js
@@ -228,6 +228,19 @@
       .trim();
   }
 
+  const OPTION_PREFIX_WITH_DASH = /^\s*(?:recommended\s+option|option)\s*\d*\s*[—–-]\s*/i;
+  const OPTION_PREFIX_GENERAL = /^\s*(?:recommended\s+option|option)\s*\d+\s*/i;
+
+  function normalizeOptionTitle(rawTitle = ''){
+    const value = String(rawTitle || '').trim();
+    if (!value) return '';
+    const withoutDashPrefix = value.replace(OPTION_PREFIX_WITH_DASH, '').trim();
+    if (withoutDashPrefix !== value) return withoutDashPrefix;
+    const withoutGeneralPrefix = value.replace(OPTION_PREFIX_GENERAL, '').trim();
+    if (withoutGeneralPrefix !== value) return withoutGeneralPrefix;
+    return value;
+  }
+
   function createOptionRow(option = {}, options = {}){
     const row = el('div',{class:'option'});
     row.dataset.category = option.category || '';
@@ -243,8 +256,10 @@
     if (option.material) row.dataset.material = option.material;
     if (option.color) row.dataset.color = option.color;
     const href = (option?.href || '').trim();
-    const labelText = stripUrls(option?.label || '').trim();
-    const titleText = stripUrls(option?.title || '').trim();
+    const rawLabelText = stripUrls(option?.label || '').trim();
+    const rawTitleText = stripUrls(option?.title || '').trim();
+    const labelText = normalizeOptionTitle(rawLabelText);
+    const titleText = normalizeOptionTitle(rawTitleText);
     const displayTitle = titleText || labelText || 'this item';
     const headingHtml = labelText && titleText
       ? `<strong>${escapeHTML(labelText)} — ${escapeHTML(titleText)}</strong>`


### PR DESCRIPTION
## Summary
- add a normalization helper to the gear option renderer to remove leading Option/Recommended Option prefixes before display
- render product headings and aria labels with the normalized title text so layout and links stay intact while dropping the prefixes

## Testing
- Manual Playwright QA across gear sections (mobile portrait/landscape + desktop) while serving locally via `python3 -m http.server 8080`

## Checklist
- [x] Normalization added to product title renderer only
- [x] No changes to non-Gear pages
- [x] Amazon link buttons unchanged (target _blank + rel="sponsored noopener noreferrer")
- [x] Visual QA on mobile P/L + desktop across multiple sections
- [ ] (If performed) Data cleanup applied only to Gear CSV rows with leading “Option …”


------
https://chatgpt.com/codex/tasks/task_e_68e5d8490fd0833297a80f5468f68243