### PR TITLE
feat: seed CO₂ diffuser placeholders in Air & Aeration

### DIFF
--- a/assets/js/gear.v2.data.js
+++ b/assets/js/gear.v2.data.js
@@ -137,7 +137,7 @@ const MAINTENANCE_GROUP_META = new Map([
     'maintenance_air',
     {
       intro:
-        'Use a check valve on every airline to prevent back-siphon. Size your pump to the devices you’ll run (sponge filters, airstones). Consider a battery backup or UPS for outages.'
+        'Use a check valve on every airline to prevent back-siphon. Size your pump to the devices you’ll run (sponge filters, airstones). Consider a battery backup or UPS for outages. For CO₂, place diffusers under outflow for better circulation; use CO₂-rated check valves to protect your regulator.'
     }
   ],
   [

--- a/assets/js/gear.v2.js
+++ b/assets/js/gear.v2.js
@@ -278,9 +278,14 @@
     const standAria = `Buy on Amazon – ${escapeHTML(displayTitle)}`;
     const useSimpleButton = normalizedContext === 'substrate' || normalizedContext === 'maintenancetools';
     const isWaterTreatments = normalizedContext === 'watertreatments' || normalizedContext === 'watertreatmentsfertilizers';
-    const disabledSimpleButtonHtml = normalizedContext === 'substrate'
-      ? `<button class="btn" type="button" aria-disabled="true" title="Link coming soon" disabled>${buttonLabel}</button>`
-      : `<span class="btn btn-disabled" aria-disabled="true" role="button" tabindex="-1" title="Link coming soon">${buttonLabel}</span>`;
+    let disabledSimpleButtonHtml;
+    if (normalizedContext === 'substrate') {
+      disabledSimpleButtonHtml = `<button class="btn" type="button" aria-disabled="true" title="Link coming soon" disabled>${buttonLabel}</button>`;
+    } else if (normalizedContext === 'maintenancetools') {
+      disabledSimpleButtonHtml = `<button class="btn" aria-disabled="true" title="Link coming soon">${buttonLabel}</button>`;
+    } else {
+      disabledSimpleButtonHtml = `<span class="btn btn-disabled" aria-disabled="true" role="button" tabindex="-1" title="Link coming soon">${buttonLabel}</span>`;
+    }
     let actionsHtml = '';
     if (hasValidHref) {
       if (context === 'stands') {

--- a/data/gear_maintenance.csv
+++ b/data/gear_maintenance.csv
@@ -8,6 +8,12 @@ Maintenance & Tools,Air & Aeration,"hygger Aquarium Air Pump, Quiet Adjustable F
 Maintenance & Tools,Air & Aeration,"AQUANEAT Aquarium Check Valve, One Way Non Return Valve for Air Pump, Fit for 3/16 Inch Airline Tubing, Fish Tank Accessories, 10pcs (Red)","Prevents water backflow; use one per airline below tank water level.",https://amzn.to/42wLPZs
 Maintenance & Tools,Air & Aeration,"Aquarium Air Valve, 10 Pcs Aquarium Air Pump Control Valves T Shaped Single Way Plastic Air Flow Control Regulator Aquarium Air Pump Accessories for Fish Tank 3/16"" ID Tubing (Black)","Fine-tune airflow to multiple devices; easy inline installation.",https://amzn.to/46F8DIW
 Maintenance & Tools,Air & Aeration,"ALEGI Aquarium Air Pump Accessories Set 25 Feet Airline Tubing with 6 Check Valves, 6 Control Valve and 40 Connectors for Fish Tank White","Complete airline accessory kit for custom multi-line air systems.",https://amzn.to/48S7HlO
+Maintenance & Tools,Air & Aeration,"CO₂ Ceramic Diffuser (Small, Nano–20G)","In-tank ceramic disk; fine mist for small/medium tanks; place under gentle flow.",
+Maintenance & Tools,Air & Aeration,"CO₂ Ceramic Diffuser (Large, 20–55G)","Larger ceramic area for mid-size tanks; position low and under filter outflow.",
+Maintenance & Tools,Air & Aeration,"Inline CO₂ Atomizer (12/16 mm)","For canister filters with 12/16mm hose; ultra-fine microbubbles in-line.",
+Maintenance & Tools,Air & Aeration,"Inline CO₂ Atomizer (16/22 mm)","For canister filters with 16/22mm hose; high dissolution efficiency.",
+Maintenance & Tools,Air & Aeration,"CO₂ Bubble Counter (with Check Valve)","Monitors bubble rate; integrated one-way valve prevents back-siphon.",
+Maintenance & Tools,Air & Aeration,"CO₂-Rated Check Valves (2–4 pack)","Use CO₂-compatible valves on every line to protect regulator/solenoid.",
 Maintenance & Tools,Cleanup & Extras,"Bounty Quick-Size Paper Towels, White, 12 Family Triple Rolls = 40 Regular Rolls","Durable, absorbent paper towels for quick cleanups around the tank.",https://amzn.to/3VRQh1h
 Maintenance & Tools,Cleanup & Extras,"Amazon Basics 2-Ply Soft Toilet Paper, 30 Rolls (5 Packs of 6), Equivalent to 185 Regular Rolls, Packaging May Vary","Useful during maintenance; keep a roll near your setup.",https://amzn.to/3IAe4jj
 Maintenance & Tools,Cleanup & Extras,"Gorilla Super Glue Gel XL, Clear Glue, 25 Gram (Pack of 2) - All Purpose and Fast Setting for Projects and Repairs","Handy for quick décor or equipment fixes (use outside water contact points).",https://amzn.to/4q1j8hj


### PR DESCRIPTION
## Summary
- append six CO₂ diffuser and accessory placeholder rows under Maintenance & Tools → Air & Aeration
- extend the Air & Aeration tip copy with CO₂ placement guidance and adjust disabled CTA rendering for maintenance items

## Testing
- python -m http.server 8080


------
https://chatgpt.com/codex/tasks/task_e_68e5df552ca483328bac80e6e0fefe42