### PR TITLE
Fix filters accordion bucket rendering

### DIFF
--- a/assets/js/gear.v2.data.js
+++ b/assets/js/gear.v2.data.js
@@ -306,6 +306,8 @@ const EXTRAS_DEFAULT_SUBGROUP = 'Misc';
 const EXTRAS_PLACEHOLDER = 'Links coming soon.';
 
 const CATEGORY_ALIASES = new Map([
+  ['filtration', 'filters'],
+  ['filter', 'filters'],
   ['substrate & aquascaping', 'substrate'],
   ['maintenance & tools', 'maintenance_tools'],
   ['maintenance tools', 'maintenance_tools'],


### PR DESCRIPTION
## Summary
- map Filtration CSV rows to the filters category so bucket data is passed to the renderer
- preserve existing loading for filter media groups

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e64f5af52483328ec196c1ba8731b2