### PR TITLE
chore: finalize codex post-flight sync

### DIFF
--- a/_codex_sync/codex_diff_snapshots/sync_20251008T140004Z.json
+++ b/_codex_sync/codex_diff_snapshots/sync_20251008T140004Z.json
@@ -1,0 +1,53 @@
+{
+  "generated_at": "2025-10-08T14:00:04Z",
+  "entries": [
+    {
+      "name": "Homepage",
+      "path": "index.html",
+      "last_modified": "2025-10-08T12:49:34Z",
+      "size_bytes": 28608
+    },
+    {
+      "name": "Gear",
+      "path": "gear/index.html",
+      "last_modified": "2025-10-08T12:49:34Z",
+      "size_bytes": 7526
+    },
+    {
+      "name": "Stocking",
+      "path": "stocking.html",
+      "last_modified": "2025-10-08T12:49:34Z",
+      "size_bytes": 43999
+    },
+    {
+      "name": "Params",
+      "path": "params.html",
+      "last_modified": "2025-10-08T12:49:34Z",
+      "size_bytes": 30341
+    },
+    {
+      "name": "Media",
+      "path": "media.html",
+      "last_modified": "2025-10-08T12:49:34Z",
+      "size_bytes": 25407
+    },
+    {
+      "name": "Feature Tank",
+      "path": "feature-your-tank.html",
+      "last_modified": "2025-10-08T12:49:34Z",
+      "size_bytes": 40579
+    },
+    {
+      "name": "About",
+      "path": "about.html",
+      "last_modified": "2025-10-08T12:49:34Z",
+      "size_bytes": 25336
+    },
+    {
+      "name": "Feedback",
+      "path": "contact-feedback.html",
+      "last_modified": "2025-10-08T12:49:34Z",
+      "size_bytes": 24631
+    }
+  ]
+}

--- a/_codex_sync/codex_status.json
+++ b/_codex_sync/codex_status.json
@@ -1,7 +1,7 @@
 {
-  "last_sync": "2025-10-08T13:53:33Z",
-  "status": "verified",
-  "notes": "Pre-flight scan completed successfully. Ready for live sync.",
+  "last_sync": "2025-10-08T14:01:23Z",
+  "status": "live",
+  "notes": "Post-flight sync complete. Codex and Chat alignment verified.",
   "active_tasks": [],
   "last_result": "PASS"
 }


### PR DESCRIPTION
## Summary
- capture a post-flight snapshot of key site entry points with their metadata
- update the Codex sync status to reflect the live handoff completion

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e66e3cfd188332bf0210518f241228