### PR TITLE
chore: run codex live sync daily maintenance

### DIFF
--- a/_codex_sync/codex_activity_log.md
+++ b/_codex_sync/codex_activity_log.md
@@ -10,3 +10,9 @@ Next: Run “Codex Pre-Flight” to verify integrity.
 Scope: Initial handshake between ChatGPT and Codex established.
 Result: All sync files verified.
 Next: Enable auto-logging on next task.
+
+Snapshot Cleanup — 2025-10-08 14:08:01Z
+
+Removed obsolete diffs:
+
+• None

--- a/_codex_sync/codex_diff_snapshots/diff_2025-10-08_1407.json
+++ b/_codex_sync/codex_diff_snapshots/diff_2025-10-08_1407.json
@@ -1,0 +1,152 @@
+{
+  "generated_at": "2025-10-08T14:07:54Z",
+  "previous_snapshot": "sync_20251008T140004Z.json",
+  "entry_count": 12,
+  "differences_detected": 12,
+  "entries": [
+    {
+      "path": "index.html",
+      "description": "Homepage entry",
+      "exists": true,
+      "is_directory": false,
+      "last_modified": "2025-10-08T12:58:22Z",
+      "size_bytes": 28608,
+      "differs_from_previous": true,
+      "diff_reasons": [
+        "timestamp_changed"
+      ]
+    },
+    {
+      "path": "gear/index.html",
+      "description": "Gear recommendations",
+      "exists": true,
+      "is_directory": false,
+      "last_modified": "2025-10-08T12:58:22Z",
+      "size_bytes": 7526,
+      "differs_from_previous": true,
+      "diff_reasons": [
+        "timestamp_changed"
+      ]
+    },
+    {
+      "path": "stocking.html",
+      "description": "Stocking Advisor",
+      "exists": true,
+      "is_directory": false,
+      "last_modified": "2025-10-08T12:58:22Z",
+      "size_bytes": 43999,
+      "differs_from_previous": true,
+      "diff_reasons": [
+        "timestamp_changed"
+      ]
+    },
+    {
+      "path": "params.html",
+      "description": "Cycling Coach",
+      "exists": true,
+      "is_directory": false,
+      "last_modified": "2025-10-08T12:58:22Z",
+      "size_bytes": 30341,
+      "differs_from_previous": true,
+      "diff_reasons": [
+        "timestamp_changed"
+      ]
+    },
+    {
+      "path": "media.html",
+      "description": "Media hub",
+      "exists": true,
+      "is_directory": false,
+      "last_modified": "2025-10-08T12:58:22Z",
+      "size_bytes": 25407,
+      "differs_from_previous": true,
+      "diff_reasons": [
+        "timestamp_changed"
+      ]
+    },
+    {
+      "path": "feature-your-tank.html",
+      "description": "Community submission form",
+      "exists": true,
+      "is_directory": false,
+      "last_modified": "2025-10-08T12:58:22Z",
+      "size_bytes": 40579,
+      "differs_from_previous": true,
+      "diff_reasons": [
+        "timestamp_changed"
+      ]
+    },
+    {
+      "path": "about.html",
+      "description": "About & mission",
+      "exists": true,
+      "is_directory": false,
+      "last_modified": "2025-10-08T12:58:22Z",
+      "size_bytes": 25336,
+      "differs_from_previous": true,
+      "diff_reasons": [
+        "timestamp_changed"
+      ]
+    },
+    {
+      "path": "contact-feedback.html",
+      "description": "Contact & feedback form",
+      "exists": true,
+      "is_directory": false,
+      "last_modified": "2025-10-08T12:58:22Z",
+      "size_bytes": 24631,
+      "differs_from_previous": true,
+      "diff_reasons": [
+        "timestamp_changed"
+      ]
+    },
+    {
+      "path": "assets/js/",
+      "description": "Scripts (nav, consent, app logic)",
+      "exists": true,
+      "is_directory": true,
+      "last_modified": "2025-10-08T14:06:50Z",
+      "size_bytes": 4096,
+      "differs_from_previous": true,
+      "diff_reasons": [
+        "no_previous_snapshot"
+      ]
+    },
+    {
+      "path": "assets/css/",
+      "description": "Stylesheets and responsive design",
+      "exists": true,
+      "is_directory": true,
+      "last_modified": "2025-10-08T12:58:22Z",
+      "size_bytes": 4096,
+      "differs_from_previous": true,
+      "diff_reasons": [
+        "no_previous_snapshot"
+      ]
+    },
+    {
+      "path": "sitemap.xml",
+      "description": "SEO and crawl manifest",
+      "exists": true,
+      "is_directory": false,
+      "last_modified": "2025-10-08T12:58:22Z",
+      "size_bytes": 1475,
+      "differs_from_previous": true,
+      "diff_reasons": [
+        "no_previous_snapshot"
+      ]
+    },
+    {
+      "path": "robots.txt",
+      "description": "Crawler rules",
+      "exists": true,
+      "is_directory": false,
+      "last_modified": "2025-10-08T12:58:22Z",
+      "size_bytes": 69,
+      "differs_from_previous": true,
+      "diff_reasons": [
+        "no_previous_snapshot"
+      ]
+    }
+  ]
+}

--- a/_codex_sync/codex_status.json
+++ b/_codex_sync/codex_status.json
@@ -1,7 +1,7 @@
 {
-  "last_sync": "2025-10-08T14:01:23Z",
+  "last_sync": "2025-10-08T14:08:06Z",
   "status": "live",
-  "notes": "Post-flight sync complete. Codex and Chat alignment verified.",
+  "notes": "Daily maintenance sync completed successfully. Snapshots older than 3 days pruned.",
   "active_tasks": [],
   "last_result": "PASS"
 }


### PR DESCRIPTION
## Summary
- capture a fresh Codex diff snapshot covering all manifest entries after verifying their state
- record the automated snapshot cleanup activity in the maintenance log
- update Codex status metadata to reflect the completed daily sync cycle

## Testing
- not run (maintenance-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e66ff237bc8332b6b8c6494fde163c