### PR TITLE
Fix: Filters accordions now render product cards like heaters

### DIFF
--- a/assets/css/gear.v2.css
+++ b/assets/css/gear.v2.css
@@ -183,6 +183,14 @@ body{
   padding:1rem 1.25rem;
   cursor:pointer;
   user-select:none;
+  background:none;
+  border:0;
+  width:100%;
+  color:inherit;
+  text-align:left;
+  font:inherit;
+  -webkit-appearance:none;
+  appearance:none;
 }
 
 .gear-card__header:focus-visible{


### PR DESCRIPTION
## Summary
- rebuild the filters bucket accordion markup with unique IDs, button headers, and sub-accordion hooks so the panels match the heater experience and display their product options
- sync the accordion animation with aria-hidden updates to keep assistive tech in step when panels open and close
- tweak the gear card header styles so the new button triggers inherit the existing layout and visuals

## Testing
- Manual Playwright spot check of filters accordion (desktop & mobile)

------
https://chatgpt.com/codex/tasks/task_e_68e68b1d2f54833296590a93a59f1acd