### PR TITLE
Fix remaining brand/entity conflict on fertilizers article byline

### DIFF
--- a/aquarium-fertilizers-guide-liquid-root-tabs/index.html
+++ b/aquarium-fertilizers-guide-liquid-root-tabs/index.html
@@ -168,7 +168,7 @@
 
       <header class="article-header">
         <h1>Aquarium Fertilizers Explained: Liquid, Root Tabs, EI Dosing, and DIY Options</h1>
-        <p class="deck">By FishKeepingLifeCo — Mar 2026</p>
+        <p class="deck">The Tank Guide — Owned and published by FishKeepingLifeCo — Mar 2026</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero">


### PR DESCRIPTION
### Motivation
- Resolve the visible byline that read `By FishKeepingLifeCo` because it created brand/entity confusion by making the company appear as the site/article author while preserving the existing schema relationship model.

### Description
- Replaced the visible deck/byline in `aquarium-fertilizers-guide-liquid-root-tabs/index.html` from `By FishKeepingLifeCo — Mar 2026` to `The Tank Guide — Owned and published by FishKeepingLifeCo — Mar 2026`; the shared `includes/schema-organization.html` (FishKeepingLifeCo `@id`, `sameAs` links, and WebSite `@id`) and article schema fields (`publisher`, `isPartOf`, `mainEntityOfPage`) were left intact and unchanged, and this change was applied page-specifically.

### Testing
- Ran targeted source checks with `rg` to confirm the new deck text and preserved schema entries, inspected the modified file, and committed the change with `git add`/`git commit`, with all checks and the commit completing successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d65ca867cc833281507aab5437729f)