### PR TITLE
Standardize The Tank Guide (site) vs FishKeepingLifeCo (publisher) identity across blog templates and pages

### DIFF
--- a/acclimating-shrimp-after-shipping-guide/index.html
+++ b/acclimating-shrimp-after-shipping-guide/index.html
@@ -171,7 +171,7 @@
       <header class="article-header">
         <h1>How to Acclimate Shrimp After Shipping: Receiving and Early Adjustment</h1>
         <p class="deck">Experience-based guidance for winter arrivals, ammonia concerns, and the first day after delivery.</p>
-        <p class="deck">By FishKeepingLifeCo — Jan 2026</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication — Jan 2026</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero">

--- a/aquarium-fertilizers-guide-liquid-root-tabs/index.html
+++ b/aquarium-fertilizers-guide-liquid-root-tabs/index.html
@@ -168,7 +168,7 @@
 
       <header class="article-header">
         <h1>Aquarium Fertilizers Explained: Liquid, Root Tabs, EI Dosing, and DIY Options</h1>
-        <p class="deck">By FishKeepingLifeCo — Mar 2026</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication — Mar 2026</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero">

--- a/aquarium-livestock-sourcing-comparison/index.html
+++ b/aquarium-livestock-sourcing-comparison/index.html
@@ -178,7 +178,7 @@ publisher: The Tank Guide
 
       <header class="article-header">
         <h1>Online vs. In-Store Aquarium Sourcing: What Actually Matters</h1>
-        <p class="deck">By FishKeepingLifeCo</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero">

--- a/blogs/aquarium-filtration-for-beginners.html
+++ b/blogs/aquarium-filtration-for-beginners.html
@@ -192,7 +192,7 @@
 
       <header class="article-header">
         <h1>Aquarium Filtration for Beginners: The Real-World Guide to Filters, Flow &amp; the Nitrogen Cycle</h1>
-        <p class="deck">By FishKeepingLifeCo | Part of the <a href="https://www.amazon.com/dp/B0FR299HW7?_encoding=UTF8&pd_rd_w=130xK&pd_rd_wg=5sEqt&pd_rd_r=a80e90b7-2c77-438b-a3ad-9128ea7c3042&content-id=amzn1.sym.299f645c-0a78-440a-94a2-fb482e7cb326&linkCode=ll1&tag=fishkeepingli-20&linkId=fd9f4300253c37243ad02542918cbf53&language=en_US&ref_=as_li_ss_tl" target="_blank" rel="noopener">Life in Balance Ecosystem</a> at <a href="/">TheTankGuide.com</a> — Nov 2025</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication | Part of the <a href="https://www.amazon.com/dp/B0FR299HW7?_encoding=UTF8&pd_rd_w=130xK&pd_rd_wg=5sEqt&pd_rd_r=a80e90b7-2c77-438b-a3ad-9128ea7c3042&content-id=amzn1.sym.299f645c-0a78-440a-94a2-fb482e7cb326&linkCode=ll1&tag=fishkeepingli-20&linkId=fd9f4300253c37243ad02542918cbf53&language=en_US&ref_=as_li_ss_tl" target="_blank" rel="noopener">Life in Balance Ecosystem</a> at <a href="/">TheTankGuide.com</a> — Nov 2025</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero">

--- a/blogs/betta-fish-in-a-community-tank.html
+++ b/blogs/betta-fish-in-a-community-tank.html
@@ -169,7 +169,7 @@
 
       <header class="article-header">
         <h1>Betta Fish in a Community Tank</h1>
-        <p class="deck"><strong>How to Keep the King of the Aquarium Peacefully Among Others</strong><br>By FishKeepingLifeCo | Part of the <a href="https://www.amazon.com/dp/B0FR299HW7?tag=fishkeepingli-20" target="_blank" rel="noopener">Life in Balance Ecosystem</a> at <a href="/">TheTankGuide.com</a> — Oct 2025</p>
+        <p class="deck"><strong>How to Keep the King of the Aquarium Peacefully Among Others</strong><br>The Tank Guide · A FishKeepingLifeCo publication | Part of the <a href="https://www.amazon.com/dp/B0FR299HW7?tag=fishkeepingli-20" target="_blank" rel="noopener">Life in Balance Ecosystem</a> at <a href="/">TheTankGuide.com</a> — Oct 2025</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero">

--- a/blogs/blackbeard/index.html
+++ b/blogs/blackbeard/index.html
@@ -169,7 +169,7 @@
       <header class="article-header">
         <h1 itemprop="headline">BBA Gone: How I Finally Beat Black Beard Algae (Spot Dose Guide)</h1>
         <p class="deck" itemprop="description">My exact spot-dosing routine, lighting &amp; flow fixes, and sump refugium tweaks that finally beat BBA—safely.</p>
-        <p class="deck">By FishKeepingLifeCo | Part of the <a href="https://www.amazon.com/dp/B0FR299HW7?tag=fishkeepingli-20" target="_blank" rel="noopener">Life in Balance Ecosystem</a> at <a href="/">TheTankGuide.com</a> — Oct 2025</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication | Part of the <a href="https://www.amazon.com/dp/B0FR299HW7?tag=fishkeepingli-20" target="_blank" rel="noopener">Life in Balance Ecosystem</a> at <a href="/">TheTankGuide.com</a> — Oct 2025</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero">

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -75,13 +75,7 @@
           "@type": "ImageObject",
           "url": "https://thetankguide.com/assets/img/Logo-Master-512x512.PNG"
         },
-        "parentOrganization": { "@id": "https://thetankguide.com/#organization" },
-        "sameAs": [
-          "https://www.instagram.com/FishKeepingLifeCo",
-          "https://www.tiktok.com/@FishKeepingLifeCo",
-          "https://x.com/fishkeepinglife",
-          "https://www.youtube.com/@fishkeepinglifeco"
-        ]
+        "parentOrganization": { "@id": "https://thetankguide.com/#organization" }
       },
       {
         "@type": "WebSite",
@@ -90,6 +84,9 @@
         "name": "The Tank Guide",
         "description": "The Tank Guide is an educational aquarium website from FishKeepingLifeCo, offering tools like the Cycling Coach, stocking advice, and beginner-friendly guides.",
         "publisher": {
+          "@id": "https://thetankguide.com/#organization"
+        },
+        "owner": {
           "@id": "https://thetankguide.com/#organization"
         },
         "brand": {

--- a/blogs/nitrogen-cycle/index.html
+++ b/blogs/nitrogen-cycle/index.html
@@ -143,7 +143,7 @@
       <header class="article-header">
         <h1>The Nitrogen Cycle for Beginners: My First Real Wall in Fishkeeping</h1>
         <p class="deck">If you're new and this part feels confusing, you're not alone. This is the story of how I went from totally stuck to "I've got this," and the simple habits that keep my tanks stable today.</p>
-        <p class="deck">By FishKeepingLifeCo | Part of the <a href="https://www.amazon.com/dp/B0FR299HW7?tag=fishkeepingli-20" target="_blank" rel="noopener">Life in Balance Ecosystem</a> at <a href="/">TheTankGuide.com</a> — Oct 2025</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication | Part of the <a href="https://www.amazon.com/dp/B0FR299HW7?tag=fishkeepingli-20" target="_blank" rel="noopener">Life in Balance Ecosystem</a> at <a href="/">TheTankGuide.com</a> — Oct 2025</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero tg-figure--nocrop">

--- a/blogs/purigen/index.html
+++ b/blogs/purigen/index.html
@@ -140,7 +140,7 @@
       <header class="article-header">
         <h1 itemprop="headline">Chasing Crystal Clear Aquarium Water (And What Finally Worked)</h1>
         <p class="deck">You can — and it's easier than you think. Just a simple addition in the right place of your filtration setup can take your tank from clear… to showroom-level clarity.</p>
-        <p class="deck">By FishKeepingLifeCo | Part of the <a href="https://www.amazon.com/dp/B0FR299HW7?tag=fishkeepingli-20" target="_blank" rel="noopener">Life in Balance Ecosystem</a> at <a href="/">TheTankGuide.com</a> — Oct 2025</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication | Part of the <a href="https://www.amazon.com/dp/B0FR299HW7?tag=fishkeepingli-20" target="_blank" rel="noopener">Life in Balance Ecosystem</a> at <a href="/">TheTankGuide.com</a> — Oct 2025</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero">

--- a/blogs/sick-fish-ich-freshwater-disease-guide/index.html
+++ b/blogs/sick-fish-ich-freshwater-disease-guide/index.html
@@ -225,7 +225,7 @@
       <header class="article-header">
         <h1>When Your Fish Gets Sick</h1>
         <p class="deck">Ich, Common Freshwater Fish Diseases, and Doing Right by the Fish You Care For</p>
-        <p class="deck">By FishKeepingLifeCo — Jan 2026</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication — Jan 2026</p>
         <p class="affiliate-disclosure">Affiliate disclosure: Some links on this page may be affiliate links. If you buy through them, we may earn a small commission at no extra cost to you.</p>
       </header>
 

--- a/buying-shrimp-online-process-guide/index.html
+++ b/buying-shrimp-online-process-guide/index.html
@@ -206,7 +206,7 @@
 
       <header class="article-header">
         <h1>Buying Shrimp Online: A Documentation of the Process</h1>
-        <p class="deck">By FishKeepingLifeCo | Updated January 2026</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication | Updated January 2026</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero">

--- a/diy-freshwater-sump-design-29-gallon/index.html
+++ b/diy-freshwater-sump-design-29-gallon/index.html
@@ -70,13 +70,7 @@
         },
         "parentOrganization": {
           "@id": "https://thetankguide.com/#organization"
-        },
-        "sameAs": [
-          "https://www.instagram.com/FishKeepingLifeCo",
-          "https://www.tiktok.com/@FishKeepingLifeCo",
-          "https://x.com/fishkeepinglife",
-          "https://www.youtube.com/@fishkeepinglifeco"
-        ]
+        }
       },
       {
         "@type": "WebSite",
@@ -85,6 +79,9 @@
         "name": "The Tank Guide",
         "description": "The Tank Guide is an educational aquarium website offering tools, guides, and beginner-friendly resources.",
         "publisher": {
+          "@id": "https://thetankguide.com/#organization"
+        },
+        "owner": {
           "@id": "https://thetankguide.com/#organization"
         },
         "inLanguage": "en-US",
@@ -285,7 +282,7 @@
 
       <header class="article-header">
         <h1>DIY Freshwater Sump Design: Building a 5-Gallon Sump for a 29-Gallon Aquarium</h1>
-        <p class="deck">By FishKeepingLifeCo | Updated January 2026</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication | Updated January 2026</p>
       </header>
 
       <figure class="tg-figure tg-figure--section-hero">

--- a/freshwater-aquarium-clean-up-crew-snail-welfare.html
+++ b/freshwater-aquarium-clean-up-crew-snail-welfare.html
@@ -204,7 +204,7 @@
             fetchpriority="high"
           >
         </figure>
-        <p class="deck">By FishKeepingLifeCo | Published January 2026</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication | Published January 2026</p>
       </header>
 
       <div class="section-split" aria-hidden="true"></div>

--- a/high-tech-vs-low-tech-planted-aquarium/index.html
+++ b/high-tech-vs-low-tech-planted-aquarium/index.html
@@ -137,7 +137,7 @@
 
       <header class="article-header">
         <h1>High Tech vs. Low Tech Planted Aquariums: Which Setup is Right for You?</h1>
-        <p class="deck">By FishKeepingLifeCo — Mar 2026</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication — Mar 2026</p>
       </header>
 
       <div class="section-split" aria-hidden="true"></div>

--- a/includes/schema-organization.html
+++ b/includes/schema-organization.html
@@ -34,6 +34,10 @@
       "@id": "https://thetankguide.com/#organization",
       "name": "FishKeepingLifeCo",
       "url": "https://thetankguide.com/",
+      "description": "FishKeepingLifeCo is the parent company and publisher of The Tank Guide.",
+      "owns": {
+        "@id": "https://thetankguide.com/#website"
+      },
       "sameAs": [
         "https://www.instagram.com/FishKeepingLifeCo",
         "https://www.tiktok.com/@FishKeepingLifeCo",
@@ -53,15 +57,8 @@
       },
       "parentOrganization": {
         "@type": "Organization",
-        "@id": "https://thetankguide.com/#fishkeepinglifeco"
-      },
-      "sameAs": [
-        "https://www.instagram.com/FishKeepingLifeCo",
-        "https://www.tiktok.com/@FishKeepingLifeCo",
-        "https://x.com/fishkeepinglife",
-        "https://www.youtube.com/@fishkeepinglifeco",
-        "https://www.facebook.com/fishkeepinglifeco"
-      ]
+        "@id": "https://thetankguide.com/#organization"
+      }
     },
     {
       "@type": "WebSite",
@@ -70,16 +67,19 @@
       "name": "The Tank Guide",
       "description": "The Tank Guide is an educational aquarium website offering tools, guides, and beginner-friendly resources.",
       "publisher": {
-        "@id": "https://thetankguide.com/#fishkeepinglifeco"
+        "@id": "https://thetankguide.com/#organization"
       },
       "creator": {
-        "@id": "https://thetankguide.com/#fishkeepinglifeco"
+        "@id": "https://thetankguide.com/#organization"
       },
       "author": {
         "@id": "https://thetankguide.com/#brand"
       },
       "brand": {
         "@id": "https://thetankguide.com/#brand"
+      },
+      "owner": {
+        "@id": "https://thetankguide.com/#organization"
       },
       "inLanguage": "en-US",
       "potentialAction": {

--- a/low-maintenance-fish-aquariums/index.html
+++ b/low-maintenance-fish-aquariums/index.html
@@ -180,7 +180,7 @@
       <header class="article-header">
         <h1>Low Maintenance Fish for Aquariums: Low Bioload, Not Tougher Fish</h1>
         <p class="deck">Why “Hardy” Is the Wrong Term — and What Actually Makes a Fish Low Maintenance</p>
-        <p class="deck">By FishKeepingLifeCo — Dec 2025</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication — Dec 2025</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero">

--- a/neocaridina-shrimp-diet-biofilm-guide/index.html
+++ b/neocaridina-shrimp-diet-biofilm-guide/index.html
@@ -241,7 +241,7 @@
 
       <header class="article-header">
         <h1>Neocaridina Shrimp Diet Guide: What They Really Eat (From Biofilm to Balanced Feeding)</h1>
-        <p class="deck">By FishKeepingLifeCo | Published February 2026</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication | Published February 2026</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero tg-figure--diet-hero">

--- a/planted-aquarium-substrate-guide-aquasoil-dirt/index.html
+++ b/planted-aquarium-substrate-guide-aquasoil-dirt/index.html
@@ -71,13 +71,7 @@
         },
         "parentOrganization": {
           "@id": "https://thetankguide.com/#organization"
-        },
-        "sameAs": [
-          "https://www.instagram.com/FishKeepingLifeCo",
-          "https://www.tiktok.com/@FishKeepingLifeCo",
-          "https://x.com/fishkeepinglife",
-          "https://www.youtube.com/@fishkeepinglifeco"
-        ]
+        }
       },
       {
         "@type": "WebSite",
@@ -86,6 +80,9 @@
         "name": "The Tank Guide",
         "description": "The Tank Guide is an educational aquarium website offering tools, guides, and beginner-friendly resources.",
         "publisher": {
+          "@id": "https://thetankguide.com/#organization"
+        },
+        "owner": {
           "@id": "https://thetankguide.com/#organization"
         },
         "inLanguage": "en-US",
@@ -267,7 +264,7 @@
 
       <header class="article-header">
         <h1>Aquarium Substrate Guide: From Aquasoil to DIY Dirt</h1>
-        <p class="deck">By FishKeepingLifeCo | Updated March 2026</p>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication | Updated March 2026</p>
       </header>
 
       <figure class="tg-figure tg-figure--hero tg-figure--nocrop">


### PR DESCRIPTION
### Motivation
- Remove identity confusion where pages showed FishKeepingLifeCo as the visible site name and make the relationship explicit sitewide (The Tank Guide = website/publication; FishKeepingLifeCo = parent company/owner/publisher). 
- Apply a shared, template-level fix so future blog pages inherit the correct `isPartOf`/`publisher` relationships and visible byline pattern automatically.

### Description
- Updated the shared entity include `includes/schema-organization.html` to keep two distinct nodes and explicit references: `https://thetankguide.com/#organization` for FishKeepingLifeCo and `https://thetankguide.com/#website` for The Tank Guide, added `owner`/`owns` links and preserved all FishKeepingLifeCo `sameAs` social links on the Organization node. 
- Removed company social `sameAs` attachments from `Brand` nodes and ensured `Brand`/`WebSite` nodes reference the Organization node by `@id` rather than merging entities. 
- Adjusted the blogs collection schema (`blogs/index.html`) and patched inline one-off article schema blocks (for example `planted-aquarium-substrate-guide-aquasoil-dirt/index.html` and `diy-freshwater-sump-design-29-gallon/index.html`) so `isPartOf -> #website` and `publisher -> #organization` are consistent. 
- Standardized visible bylines across blog pages from `By FishKeepingLifeCo` to the pattern: `The Tank Guide · A FishKeepingLifeCo publication ...` on the set of blog pages updated (see changed files list in the commit). 
- Exact IDs used: FishKeepingLifeCo Organization `@id` = `https://thetankguide.com/#organization`, The Tank Guide WebSite `@id` = `https://thetankguide.com/#website`.

### Testing
- Ran a representative content check script (`python` snippet) on sample pages and confirmed `og:site_name = The Tank Guide`, `isPartOf -> #website`, `publisher` references to `#organization`, and FishKeepingLifeCo social URLs remain present; all checks passed. 
- Searched repository with `rg` to ensure there are no remaining `By FishKeepingLifeCo` visible bylines; the search returned no matches. 
- Verified FishKeepingLifeCo `sameAs` social links still exist in `includes/schema-organization.html` and in patched inline-schema pages using `rg`; results show the social URLs are preserved. 
- Verified article-level schema and collection schema include the `isPartOf` and `publisher` links and that `og:site_name` remains `The Tank Guide`; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d65dbf911c8332a963b385a6a6b160)