### PR TITLE
Add aquarium fertilizers guide entry to Spotlight Blogs index

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -166,9 +166,29 @@
             "@id": "https://thetankguide.com/undergravel-filters-planted-tank-case-study/"
           },
           {
+            "@id": "https://thetankguide.com/aquarium-fertilizers-guide-liquid-root-tabs/"
+          },
+          {
             "@id": "https://thetankguide.com/blog/holiday-gift-guide-aquarium-lovers.html"
           }
         ]
+      },
+      {
+        "@type": "BlogPosting",
+        "@id": "https://thetankguide.com/aquarium-fertilizers-guide-liquid-root-tabs/",
+        "url": "https://thetankguide.com/aquarium-fertilizers-guide-liquid-root-tabs/",
+        "headline": "Aquarium Fertilizers Explained: Liquid, Root Tabs, EI Dosing, and DIY Options",
+        "description": "Master aquarium plant fertilizers with our guide. Compare liquid fertilizers, root tabs, EI dosing, and DIY options for planted tanks.",
+        "image": "https://thetankguide.com/assets/images/aquarium-fertilizers-explained-liquid-root-tabs-diy.jpeg",
+        "inLanguage": "en-US",
+        "publisher": {
+          "@id": "https://thetankguide.com/#organization"
+        },
+        "author": {
+          "@id": "https://thetankguide.com/#organization"
+        },
+        "mainEntityOfPage": "https://thetankguide.com/aquarium-fertilizers-guide-liquid-root-tabs/",
+        "datePublished": "2026-03-11"
       },
       {
         "@type": "BlogPosting",
@@ -729,6 +749,29 @@
         <p class="topic-sub">Custom builds, plumbing layouts, and hands-on system upgrades.</p>
       </header>
       <div class="blogs-grid">
+        <article class="blog-card">
+          <a class="card-thumb-link" href="/aquarium-fertilizers-guide-liquid-root-tabs/" aria-label="Read: Aquarium Fertilizers Explained: Liquid, Root Tabs, EI Dosing, and DIY Options">
+            <span class="card-media">
+              <img
+                class="blog-card-image"
+                src="/assets/images/aquarium-fertilizers-explained-liquid-root-tabs-diy.jpeg"
+                alt="Aquarium fertilizers explained with liquid fertilizer, root tabs, and DIY planted tank dosing"
+                loading="lazy"
+                decoding="async"
+              >
+            </span>
+          </a>
+          <div class="card-content">
+            <p class="card-kicker">
+              <span class="card-author">The Tank Guide</span>
+            </p>
+            <h3 class="card-title">
+              <a href="/aquarium-fertilizers-guide-liquid-root-tabs/">Aquarium Fertilizers Explained: Liquid, Root Tabs, EI Dosing, and DIY Options</a>
+            </h3>
+            <p class="card-excerpt">Master aquarium plant fertilizers by comparing liquid fertilizers, root tabs, EI dosing, and DIY options to support healthy planted tank growth.</p>
+            <a class="card-read" href="/aquarium-fertilizers-guide-liquid-root-tabs/">Read the blog →</a>
+          </div>
+        </article>
         <article class="blog-card">
           <a class="card-thumb-link" href="/diy-freshwater-sump-design-29-gallon/" aria-label="Read: DIY Freshwater Sump Design: Building a 5-Gallon Sump for a 29-Gallon Aquarium">
             <span class="card-media">


### PR DESCRIPTION
### Motivation
- The Spotlight Blogs index needs to include the new fertilizers article so site visitors can find the guide from the main blogs listing.
- The change should follow the existing blog-card structure and site URL conventions used across `blogs/index.html`.

### Description
- Updated `blogs/index.html` to add the new article URL to the CollectionPage `hasPart` list and added a `BlogPosting` JSON-LD block for `https://thetankguide.com/aquarium-fertilizers-guide-liquid-root-tabs/` with `datePublished` set to `2026-03-11`.
- Inserted a new blog card in the `#topic-diy` section linking to `/aquarium-fertilizers-guide-liquid-root-tabs/` using the article title `Aquarium Fertilizers Explained: Liquid, Root Tabs, EI Dosing, and DIY Options` and the hero image path `/assets/images/aquarium-fertilizers-explained-liquid-root-tabs-diy.jpeg` while preserving the existing card markup and author/excerpt/read link pattern.
- No other blog cards or unrelated markup were modified.

### Testing
- Ran `rg` to confirm the new URL, title, and image strings exist in `blogs/index.html` and the article file, which succeeded and showed the expected matches.
- Verified the insertion by inspecting the diff with `git diff -- blogs/index.html`, which showed the added JSON-LD block and the new `article.blog-card` markup, and this check succeeded.
- Confirmed working tree status with `git status --short` and committed the change with a commit message, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6637b5b4883329b4a43266fe53290)