### PR TITLE
Add 2026-04-11 journal entry: Maintenance Reset & Nitrate-Control Experiment (Day 0)

### DIFF
--- a/data/journal.csv
+++ b/data/journal.csv
@@ -1,4 +1,5 @@
 Date,Time,Category,Action/Observation,Notes/Results,Nitrate(ppm),Dosing,ThrivePlus(pumps),WaterChange,tags,Image
+2026-04-11,,Journal Update,Maintenance Reset & Start of Nitrate-Control Experiment (Day 0),"Major maintenance reset performed with filtration and plant updates, initiating a nitrate-driven water change experiment and entering a controlled observation phase.",,,,,"journal,29g-tank,maintenance-reset,water-change,filtration,plants,nitrate-experiment,system-monitoring",
 2025-09-09,,Feeding,Fed: veggie-only (zucchini/spinach or wafers),Scheduled feeding (backfilled per user approval),,,,,,
 2025-09-10,,Feeding,Fed: flakes + bloodworms,Scheduled feeding (backfilled per user approval),,,,,,
 2025-09-11,,Feeding,Fed: flakes + brine shrimp,Scheduled feeding (backfilled per user approval),,,,,,

--- a/data/journal/2026-04.json
+++ b/data/journal/2026-04.json
@@ -1,0 +1,10 @@
+[
+  {
+    "date": "2026-04-11",
+    "title": "Maintenance Reset & Start of Nitrate-Control Experiment (Day 0)",
+    "body": "Performed a standard maintenance water change with additional filter and plant adjustments. Pre–water change nitrate levels measured between 40–80 ppm, indicating elevated nutrient buildup. Completed the usual large-volume change: ~90%+ sump drain; ~70–75% display drain. 🔧 Filtration Updates: Replaced polyfill layer; Replaced 5-in-1 filter sponge (Temu media) positioned before the polyfill; Dosed Stability to support bacterial re-establishment following media replacement; Dosed Prime during refill as usual. 🌱 Plant Maintenance: Trimmed Java moss in both sump and display; Removed and discarded browned/decaying sections; Transferred healthy moss from display into sump to maintain refugium density. Plant mass remains strong and actively growing. 🧪 Experiment Begins — Day 0: Transitioning from schedule-based water changes → nitrate-driven water changes. Goal: Reduce unnecessary large water changes; Allow system to find natural nutrient balance; Track nitrate accumulation under current lower bioload + high plant mass. 📊 Follow-Up Reading: April 14, 2026 (Day 3): Nitrates measured at ~5–10 ppm. This indicates strong nutrient uptake from plants, effective reset from the April 11 water change, and readiness for controlled observation phase. 📌 System Status: Filtration refreshed; Plant mass redistributed and cleaned; Nitrates reset to low range; System stable. Tank is now officially in a controlled nitrate-monitoring phase.",
+    "category": "Journal Update",
+    "quick_facts": "Maintenance reset completed; pre-WC nitrate 40–80 ppm; ~90%+ sump / ~70–75% display water change; polyfill and 5-in-1 sponge replaced; Stability and Prime dosed; moss trimmed and redistributed; nitrate-driven experiment started; day-3 nitrate ~5–10 ppm",
+    "nitrate_ppm": "5–10 (Day 3 follow-up)"
+  }
+]

--- a/journal.html
+++ b/journal.html
@@ -221,7 +221,8 @@
       <nav class="month-nav" aria-label="Monthly navigation">
           <h2 class="sr-only">Jump to Month</h2>
           <ul class="month-nav-list">
-              <li><a href="#march-2026" class="active">March 2026</a></li>
+              <li><a href="#april-2026" class="active">April 2026</a></li>
+              <li><a href="#march-2026">March 2026</a></li>
               <li><a href="#february-2026">February 2026</a></li>
               <li><a href="#january-2026">January 2026</a></li>
               <li><a href="#december-2025">December 2025</a></li>
@@ -229,6 +230,135 @@
               <li><a href="#october-2025">October 2025</a></li>
           </ul>
       </nav>
+
+      <!-- APRIL 2026 SECTION -->
+      <section id="april-2026" class="month-section">
+
+          <header class="month-header">
+              <h2>April 2026</h2>
+              <p class="month-description">Major maintenance reset performed with filtration and plant updates, initiating a nitrate-driven water change experiment and entering a controlled observation phase.</p>
+          </header>
+
+          <!-- Card Grid Container -->
+          <div class="journal-grid">
+
+              <!-- Maintenance Reset & Start of Nitrate-Control Experiment (Day 0) -->
+              <article id="entry-2026-04-11-maintenance-reset-nitrate-experiment-day-0" class="journal-card standout-moment"
+                       data-date="2026-04-11"
+                       data-type="update"
+                       data-category="journal-update"
+                       data-focus="system-monitoring">
+                  <div class="card-header">
+                      <span class="card-icon">🧪</span>
+                      <h3><a href="/journal/2026-04-11-maintenance-reset-nitrate-experiment-day-0.html">Maintenance Reset &amp; Start of Nitrate-Control Experiment (Day 0)</a></h3>
+                      <time datetime="2026-04-11">Apr 11, 2026</time>
+                  </div>
+                  <div class="card-body">
+                      <ul>
+                          <li>Performed a standard maintenance water change with additional filter and plant adjustments.</li>
+
+                          <li>Pre–water change nitrate levels measured between 40–80 ppm, indicating elevated nutrient buildup. Completed the usual large-volume change:
+                              <ul>
+                                  <li>~90%+ sump drain</li>
+                                  <li>~70–75% display drain</li>
+                              </ul>
+                          </li>
+                      </ul>
+
+                      <hr>
+
+                      <ul>
+                          <li><strong>🔧 Filtration Updates</strong>
+                              <ul>
+                                  <li>Replaced polyfill layer</li>
+                                  <li>Replaced 5-in-1 filter sponge (Temu media) positioned before the polyfill</li>
+                                  <li>Dosed Stability to support bacterial re-establishment following media replacement</li>
+                                  <li>Dosed Prime during refill as usual</li>
+                              </ul>
+                          </li>
+                      </ul>
+
+                      <hr>
+
+                      <ul>
+                          <li><strong>🌱 Plant Maintenance</strong>
+                              <ul>
+                                  <li>Trimmed Java moss in both sump and display</li>
+                                  <li>Removed and discarded browned/decaying sections</li>
+                                  <li>Transferred healthy moss from display into sump to maintain refugium density</li>
+                              </ul>
+                          </li>
+
+                          <li>Plant mass remains strong and actively growing.</li>
+                      </ul>
+
+                      <hr>
+
+                      <ul>
+                          <li><strong>🧪 Experiment Begins — Day 0</strong></li>
+
+                          <li>This maintenance marks the start of a new system experiment:</li>
+
+                          <li>Transitioning from schedule-based water changes → nitrate-driven water changes</li>
+
+                          <li><strong>Goal:</strong>
+                              <ul>
+                                  <li>Reduce unnecessary large water changes</li>
+                                  <li>Allow system to find natural nutrient balance</li>
+                                  <li>Track nitrate accumulation under current lower bioload + high plant mass</li>
+                              </ul>
+                          </li>
+                      </ul>
+
+                      <hr>
+
+                      <ul>
+                          <li><strong>📊 Follow-Up Reading</strong></li>
+
+                          <li><strong>📅 April 14, 2026 (Day 3)</strong>
+                              <ul>
+                                  <li>Nitrates measured at ~5–10 ppm</li>
+                              </ul>
+                          </li>
+
+                          <li>This indicates:
+                              <ul>
+                                  <li>Strong nutrient uptake from plants</li>
+                                  <li>Effective reset from the April 11 water change</li>
+                                  <li>System ready for controlled observation phase</li>
+                              </ul>
+                          </li>
+                      </ul>
+
+                      <hr>
+
+                      <ul>
+                          <li><strong>📌 System Status</strong>
+                              <ul>
+                                  <li>Filtration refreshed</li>
+                                  <li>Plant mass redistributed and cleaned</li>
+                                  <li>Nitrates reset to low range</li>
+                                  <li>System stable</li>
+                              </ul>
+                          </li>
+
+                          <li>Tank is now officially in a controlled nitrate-monitoring phase.</li>
+                      </ul>
+                  </div>
+                  <div class="card-footer">
+                      <span class="card-tag tag-achievement">journal</span>
+                      <span class="card-tag tag-reflection">29g-tank</span>
+                      <span class="card-tag tag-achievement">maintenance-reset</span>
+                      <span class="card-tag tag-reflection">water-change</span>
+                      <span class="card-tag tag-achievement">filtration</span>
+                      <span class="card-tag tag-reflection">plants</span>
+                      <span class="card-tag tag-achievement">nitrate-experiment</span>
+                      <span class="card-tag tag-reflection">system-monitoring</span>
+                  </div>
+              </article>
+
+          </div>
+      </section>
 
       <!-- MARCH 2026 SECTION -->
       <section id="march-2026" class="month-section">


### PR DESCRIPTION
### Motivation
- Record a maintenance reset performed on 2026-04-11 and start a nitrate-driven water-change experiment as a new long-form journal entry that matches existing formatting and structure. 

### Description
- Inserted a new top-row in `data/journal.csv` for `2026-04-11` using the provided metadata and tags. 
- Created `data/journal/2026-04.json` and added the April 11 entry as the first item following the month-file structure used by other JSON files. 
- Updated `journal.html` to add April 2026 to the month navigation, create an April section above March, and insert the long-form structured card for `2026-04-11-maintenance-reset-nitrate-experiment-day-0` preserving emoji headers, divider style (`<hr>`), and nested bullet formatting. 
- Changes touch `data/journal.csv`, `data/journal/2026-04.json`, and `journal.html` and preserve existing content ordering and formatting conventions. 

### Testing
- Validated `data/journal/2026-04.json` syntax with `python -m json.tool`, which succeeded. 
- Confirmed HTML insertion and presence of key markers (`id="april-2026"`, entry ID, and required emoji headers) via targeted file inspections, which succeeded. 
- Performed a CSV column-shape check to ensure header alignment; check completed successfully and historical malformed rows (pre-existing) were not modified. 
- All automated validations executed during the update completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0776e522c83329b1970eba3104c17)