### PR TITLE
Fix journal dashboard data refresh pipeline

### DIFF
--- a/journal-dashboard.html
+++ b/journal-dashboard.html
@@ -520,15 +520,57 @@
                 this.allReadings = [];
             }
 
+            async loadCanonicalMonthList() {
+                const monthSet = new Set();
+
+                // Primary month list from index.json
+                try {
+                    const response = await fetch(`/data/journal/index.json?t=${Date.now()}`, { cache: 'no-store' });
+                    if (response.ok) {
+                        const months = await response.json();
+                        if (Array.isArray(months)) {
+                            months.forEach(month => {
+                                if (typeof month === 'string' && /^\d{4}-\d{2}$/.test(month)) {
+                                    monthSet.add(month);
+                                }
+                            });
+                        }
+                    }
+                } catch (e) {
+                    console.warn('⚠️ Could not load monthly index:', e);
+                }
+
+                // Fallback/verification source from canonical CSV dates
+                try {
+                    const response = await fetch(`/data/journal.csv?t=${Date.now()}`, { cache: 'no-store' });
+                    if (response.ok) {
+                        const csv = await response.text();
+                        const lines = csv.split(/\r?\n/).filter(Boolean);
+                        if (lines.length > 1) {
+                            for (let i = 1; i < lines.length; i++) {
+                                const row = lines[i];
+                                const match = row.match(/^"?(\d{4}-\d{2})(?:-\d{2})?"?,/);
+                                if (match) {
+                                    monthSet.add(match[1]);
+                                }
+                            }
+                        }
+                    }
+                } catch (e) {
+                    console.warn('⚠️ Could not load journal CSV month fallback:', e);
+                }
+
+                return [...monthSet].sort((a, b) => b.localeCompare(a));
+            }
+
             async loadMonthlyFiles() {
                 console.log('📅 Loading monthly files...');
                 try {
-                    const response = await fetch('/data/journal/index.json');
-                    if (!response.ok) {
-                        console.warn('⚠️ Could not load monthly index');
+                    const months = await this.loadCanonicalMonthList();
+                    if (!months.length) {
+                        console.warn('⚠️ No monthly files discovered');
                         return;
                     }
-                    const months = await response.json();
                     console.log(`   Found ${months.length} monthly files`);
 
                     for (const month of months) {
@@ -540,7 +582,7 @@
             }
 
             async loadMonthFile(month) {
-                const url = `/data/journal/${month}.json`;
+                const url = `/data/journal/${month}.json?t=${Date.now()}`;
                 console.log(`📆 Loading ${url}...`);
 
                 try {
@@ -680,7 +722,7 @@
                 console.log(`🗺️ Loading ${url}...`);
 
                 try {
-                    const response = await fetch(url);
+                    const response = await fetch(`${url}?t=${Date.now()}`, { cache: 'no-store' });
                     if (!response.ok) {
                         throw new Error(`Failed to load ${url}`);
                     }


### PR DESCRIPTION
### Motivation
- The dashboard was not reflecting newly added journal entries because it relied solely on `data/journal/index.json`, which in practice can be stale and omitted recent months (e.g. `2026-03`, `2026-04`).
- The change ensures the dashboard discovers the canonical journal dataset already present in the repo and automatically loads any new month files without redesigning the page or data model.

### Description
- Added `loadCanonicalMonthList()` to merge month keys from `data/journal/index.json` and the canonical `data/journal.csv` (parsing YYYY-MM dates) and return a sorted, deduplicated month list for loading via `loadMonthlyFiles()`.
- Updated monthly and legacy JSON fetches to use cache-busting (`?t=${Date.now()}`) and `cache: 'no-store'` to avoid serving stale client-side data and force fresh retrieval of index, month, and legacy files.
- Switched `loadMonthlyFiles()` to call `loadCanonicalMonthList()` and iterate the discovered months so missing month JSON files (present in the repo) are fetched and parsed into the dashboard dataset.
- Files changed: `journal-dashboard.html` (inlined loader/logic only), with no layout or styling changes to the page UI.

### Testing
- Ran a small verification script that parsed `data/journal.csv` and compared month keys to `data/journal/index.json`, which succeeded and showed missing months (`2026-04`, `2026-03`) that the new code now discovers. (Succeeded)
- Executed repository guard script used during commit (`node scripts/guard-live-files.js`) which completed without fatal errors (non-blocking warnings only). (Succeeded)
- Performed a static inspection of the updated `journal-dashboard.html` to confirm `loadCanonicalMonthList()`, cache-busting on month fetches, and that downstream rendering calls (`updateHeroMetric`, `updateMetricsBar`, `updateChart`, `updateQuickStats`) remain unchanged and will now receive newly-loaded data. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e079cc4e608332b4a6b541e45072f0)