### PR TITLE
Set featured Community Video Pick to compatibility-first gear guide

### DIFF
--- a/pages/community-video-picks.html
+++ b/pages/community-video-picks.html
@@ -135,6 +135,38 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
       <h2>Community Video Picks</h2>
       <div class="legacy-grid" aria-label="Featured Community Video Pick">
+        <article class="card legacy-card">
+          <div class="video-embed" style="margin-bottom: 10px;">
+            <iframe
+              src="https://www.youtube.com/embed/EEhY2ppoIVQ?rel=0&amp;modestbranding=1"
+              title="Aquarium Equipment Simplified: A Compatibility-First Guide to Gear"
+              frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+              allowfullscreen
+              loading="lazy"></iframe>
+          </div>
+          <h2 class="legacy-title">
+            <a href="https://youtu.be/EEhY2ppoIVQ" target="_blank" rel="noopener noreferrer">Aquarium Equipment Simplified: A Compatibility-First Guide to Gear</a>
+          </h2>
+          <p class="muted legacy-creator">by <a href="https://www.youtube.com/@FishKeepingLifeCo" target="_blank" rel="noopener noreferrer">FishKeepingLifeCo</a></p>
+          <p class="legacy-description">
+            This video breaks down aquarium equipment through a compatibility-first lens, helping hobbyists understand how filters, heaters, lights, and other essentials work together as a system. It’s a practical guide for choosing gear that fits your tank, livestock, and goals—without overbuying or creating problems later.
+          </p>
+          <p class="legacy-description"><strong>Watch it for:</strong> A clearer way to think about aquarium gear so each piece supports the rest of your setup.</p>
+          <div class="legacy-card-footer">
+            <div class="legacy-card-cta">
+              <a class="yt-cta" href="https://youtu.be/EEhY2ppoIVQ" target="_blank" rel="noopener noreferrer" aria-label="Watch on YouTube: Aquarium Equipment Simplified: A Compatibility-First Guide to Gear">
+                <span class="yt-icon" aria-hidden="true">
+                  <svg class="yt-cta-svg" viewBox="0 0 24 24" width="20" height="20" focusable="false" aria-hidden="true">
+                    <path d="M9 7v10l8-5z" fill="#fff"></path>
+                  </svg>
+                </span>
+                <span class="yt-label">Watch on YouTube</span>
+              </a>
+            </div>
+            <p class="legacy-meta">Added: 2026-04-17</p>
+          </div>
+        </article>
       </div>
       <p class="lead" style="margin-top: 20px;">Community Video Picks Archive</p>
       <div class="legacy-grid" aria-label="Community Video Picks Archive">
@@ -241,6 +273,23 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
               "position": 1,
               "item": {
                 "@type": "VideoObject",
+                "name": "Aquarium Equipment Simplified: A Compatibility-First Guide to Gear",
+                "description": "A compatibility-first walkthrough that explains how filters, heaters, lights, and other essentials work together in one reliable system.",
+                "url": "https://youtu.be/EEhY2ppoIVQ",
+                "thumbnailUrl": "https://img.youtube.com/vi/EEhY2ppoIVQ/hqdefault.jpg",
+                "uploadDate": "2026-04-17",
+                "inLanguage": "en",
+                "creator": {
+                  "@type": "Organization",
+                  "name": "FishKeepingLifeCo"
+                }
+              }
+            },
+            {
+              "@type": "ListItem",
+              "position": 2,
+              "item": {
+                "@type": "VideoObject",
                 "name": "This is ACTUALLY The Method for Crystal Clear Aquarium Water",
                 "description": "AQUAPROS tests Seachem Purigen to see how well it polishes water and what still matters for clarity.",
                 "url": "https://www.youtube.com/watch?v=TlF4_lzUR1M",
@@ -255,7 +304,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             },
             {
               "@type": "ListItem",
-              "position": 2,
+              "position": 3,
               "item": {
                 "@type": "VideoObject",
                 "name": "Make a Freshwater Aquarium Sump",


### PR DESCRIPTION
### Motivation
- Make the specified YouTube video the main featured Community Video Pick on the page while preserving the existing Archive section and styling. 
- Ensure the featured card includes proper embed, title, creator credit, description, CTA, and an accurate Added date.
- Update the page schema (`CollectionPage` JSON-LD) so the featured video is position 1 and archive items follow, and remove any duplicate appearances of the same video on the page.

### Description
- Populated the featured card block in `pages/community-video-picks.html` with an embedded iframe pointing to `https://www.youtube.com/embed/EEhY2ppoIVQ?rel=0&amp;modestbranding=1` and set the card title link to `https://youtu.be/EEhY2ppoIVQ`.
- Inserted the creator credit line linking to `https://www.youtube.com/@FishKeepingLifeCo` and used `FishKeepingLifeCo` as the creator name in the same pattern as existing entries.
- Added the supplied description and a `Watch it for:` line matching the site voice, kept CTA/button markup consistent, and set the Added date to `2026-04-17`.
- Updated the CollectionPage JSON-LD in the same file so the new video is `position: 1` with its metadata and shifted existing archive items to positions 2 and 3; ensured no duplicate archive card for the same video remains.
- Modified file: `/workspace/website-fish-keeper/pages/community-video-picks.html`.

### Testing
- Ran `git -C /workspace/website-fish-keeper status --short` to confirm one modified file and it succeeded. 
- Searched the page with `rg` for `EEhY2ppoIVQ` and related markers to verify embeds/links and it succeeded. 
- Ran a small Python check to count occurrences of the video ID and confirmed a single featured presence where intended and a total of `5` internal references (embed/link/schema); the visible archive card for this video was not duplicated. 
- Attempted a YouTube oEmbed lookup to fetch official metadata but the request failed in this environment with `403 Forbidden`, so the creator name was taken from the repository pattern (`FishKeepingLifeCo`) instead; the oEmbed check failed. 
- Committed the change with message `Update featured community video pick to compatibility-first gear guide` and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e2aea3bf5c8332acf798d87486fb82)