### PR TITLE
Simplify Community Video Picks section on media page

### DIFF
--- a/media.html
+++ b/media.html
@@ -242,77 +242,19 @@
         </div>
 
         <div class="community-video-picks">
-          <hr class="card-sep" aria-hidden="true">
           <h3>Community Video Picks</h3>
           <p class="muted">
             Curated how-to videos and inspiration from creators we trust — and from folks who use and follow The Tank Guide.
             We rotate a featured pick regularly and keep an archive of favorites you can explore anytime.
           </p>
-          <div class="video-embed">
-            <iframe
-              src="https://www.youtube.com/embed/EEhY2ppoIVQ?rel=0&amp;modestbranding=1"
-              title="FishKeepingLifeCo — Aquarium Equipment Simplified: A Compatibility-First Guide to Gear"
-              aria-label="FishKeepingLifeCo — Aquarium Equipment Simplified: A Compatibility-First Guide to Gear community pick"
-              loading="lazy"
-              referrerpolicy="strict-origin-when-cross-origin"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-              allowfullscreen
-            ></iframe>
-          </div>
-          <noscript>
-            <p>
-              <a href="https://youtu.be/EEhY2ppoIVQ" target="_blank" rel="noopener noreferrer">
-                <img src="https://img.youtube.com/vi/EEhY2ppoIVQ/hqdefault.jpg" alt="Watch Aquarium Equipment Simplified: A Compatibility-First Guide to Gear by FishKeepingLifeCo on YouTube" width="480" height="270">
-              </a>
-            </p>
-          </noscript>
-          <h4 class="card-subtitle community-video-title">Aquarium Equipment Simplified: A Compatibility-First Guide to Gear</h4>
-          <p class="muted community-video-attribution">by <a href="https://www.youtube.com/@FishKeepingLifeCo" target="_blank" rel="noopener noreferrer">FishKeepingLifeCo</a></p>
-          <hr class="media-divider" />
-          <p>
-            This video breaks down aquarium equipment through a compatibility-first lens, helping hobbyists understand how filters, heaters, lights, and other essentials work together as a system. It’s a practical guide for choosing gear that fits your tank, livestock, and goals without overbuying or creating avoidable problems later.
-          </p>
-          <p>
-            Watch it for: A clearer way to think about aquarium gear so each piece supports the rest of your setup.
-          </p>
           <div class="community-video-cta">
-            <a class="yt-cta" href="https://youtu.be/EEhY2ppoIVQ" target="_blank" rel="noopener noreferrer" title="Watch Aquarium Equipment Simplified: A Compatibility-First Guide to Gear on YouTube" aria-label="Watch Aquarium Equipment Simplified: A Compatibility-First Guide to Gear on YouTube">
-              <span class="yt-icon" aria-hidden="true">
-                <svg class="yt-cta-svg" viewBox="0 0 24 24" width="20" height="20" focusable="false" aria-hidden="true">
-                  <path d="M9 7v10l8-5z" fill="#fff"></path>
-                </svg>
-              </span>
-              <span class="yt-label">Watch on YouTube</span>
-            </a>
-          </div>
-          <p class="muted community-video-added-date">
-            <time datetime="2026-04-17">Added: 2026-04-17</time>
-          </p>
-          <p class="lead" style="margin-top: 20px;">Community Video Picks Archive</p>
-          <div class="legacy-grid" aria-label="Community Video Picks Archive">
-          </div>
-          <div class="community-archive-cta">
-            <a class="community-archive-button"
-               href="/pages/community-video-picks.html"
-               aria-label="View past Community Video Picks">
-              <svg
-                class="youtube-rewind-icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 60 36"
-                preserveAspectRatio="xMidYMid meet"
-                role="img"
-                focusable="false"
-                aria-hidden="true"
-              >
-                <title>YouTube Rewind — View past Community Video Picks</title>
-                <rect width="60" height="36" rx="9" fill="#FF0000" />
-                <g class="rewind-chevrons" fill="currentColor">
-                  <path d="M40 10v16L24 18z" />
-                  <path d="M30 10v16L14 18z" />
-                </g>
-              </svg>
-              <span class="community-archive-button__label">View past Community Video Picks</span>
-              <span class="community-archive-button__arrow" aria-hidden="true">→</span>
+            <a
+              class="yt-cta"
+              href="https://thetankguide.com/pages/community-video-picks.html"
+              aria-label="View Past Community Video Picks"
+              title="View Past Community Video Picks"
+            >
+              <span class="yt-label">View Past Community Video Picks</span>
             </a>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- The Community Video Picks area previously included a full featured card with an embedded YouTube video and supporting copy; the intent is to remove the featured card and leave only the header, intro paragraph, and a single CTA to the archive page.
- Reduce page weight and visual clutter while keeping the archive accessible via a single primary CTA.

### Description
- Removed the featured card block from `media.html`, including the `<iframe>` embed, `<noscript>` fallback, card title, creator attribution, description copy, watch CTA, date line, separators, and the old archive-card markup.
- Added a single centered CTA link that reuses the existing button style (`yt-cta`) with the label `View Past Community Video Picks` and `href="https://thetankguide.com/pages/community-video-picks.html"`.
- Kept the section header (`Community Video Picks`) and the intro paragraph intact and preserved existing classes and spacing without introducing new CSS.
- Cleaned up markup so no leftover featured-video containers remain in the section.

### Testing
- Searched and inspected the updated file with `rg` and `sed` to confirm the embedded video (`iframe`) and all featured-card markup were removed; the commands returned the new CTA block only and succeeded.
- Verified file changes and staged commit with `git status --short` and `git commit` which completed successfully.
- Created the PR record via the automation tool which returned the PR title/body payload successfully.
- Screenshot capture could not be performed in this environment (automation tool unavailable), all automated textual checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e361bb9c9c8332b5eca5dec807da89)