### PR TITLE
Update featured Community Video pick and add Gear CTA on media.html

### DIFF
--- a/media.html
+++ b/media.html
@@ -188,18 +188,18 @@
         <div class="featured-video">
           <h3 class="now-playing">Now Playing:</h3>
           <p class="now-playing-title">
-            <a href="https://youtu.be/bNotFJdlSAc?si=BhKFPMttlJ-ATkwt"
+            <a href="https://youtu.be/EEhY2ppoIVQ"
                target="_blank"
                rel="noopener noreferrer nofollow">
-              Cycling Coach: Aquarium Cycling Guide
+              Aquarium Equipment Simplified: A Compatibility-First Guide to Gear
             </a>
           </p>
 
           <!-- Embedded video -->
           <div class="video-embed">
             <iframe
-              src="https://www.youtube.com/embed/bNotFJdlSAc?rel=0&amp;modestbranding=1"
-              title="Cycling Coach: Aquarium Cycling Guide"
+              src="https://www.youtube.com/embed/EEhY2ppoIVQ?rel=0&amp;modestbranding=1"
+              title="Aquarium Equipment Simplified: A Compatibility-First Guide to Gear"
               frameborder="0"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
               allowfullscreen
@@ -208,24 +208,16 @@
 
           <noscript>
             <p>
-              <a href="https://youtu.be/bNotFJdlSAc?si=BhKFPMttlJ-ATkwt" target="_blank" rel="noopener noreferrer nofollow">
-                <img src="https://img.youtube.com/vi/bNotFJdlSAc/hqdefault.jpg" alt="Watch Cycling Coach: Aquarium Cycling Guide on YouTube" width="480" height="270">
+              <a href="https://youtu.be/EEhY2ppoIVQ" target="_blank" rel="noopener noreferrer nofollow">
+                <img src="https://img.youtube.com/vi/EEhY2ppoIVQ/hqdefault.jpg" alt="Watch Aquarium Equipment Simplified: A Compatibility-First Guide to Gear on YouTube" width="480" height="270">
               </a>
             </p>
           </noscript>
         </div>
         <p class="muted" style="margin:.35rem 0 0;">
-          Creating a healthy home for your aquatic life starts with a stable biological cycle. Whether you’re setting up a new aquarium or managing a system reset, understanding how beneficial bacteria process waste is essential for long-term fish health.
+          Stop overthinking aquarium equipment. Learn how to choose compatible gear for your freshwater tank based on size, stability, and fish welfare—not hype or “best-of” lists. This video shows how to focus on what actually works together for your setup.
         </p>
-        <p class="muted" style="margin:.35rem 0 0;">
-          This guide shows you how to use the free <a href="https://thetankguide.com/cycling">Cycling Coach</a> tool here on The Tank Guide to navigate fish-in and fishless cycling, helping you determine when your aquarium is biologically balanced and ready for fish.
-        </p>
-        <p class="muted" style="margin:.35rem 0 0;">
-          Because pH and temperature directly affect ammonia toxicity, water safety is more complex than a simple test strip. We explain how the Cycling Coach accounts for these variables and walk through the 24-Hour Challenge to confirm your biofilter can safely handle a full biological load.
-        </p>
-        <p class="muted" style="margin:.35rem 0 0;">
-          🐠 Use the free <a href="https://thetankguide.com/cycling">Cycling Coach</a> here on TheTankGuide to see exactly what your tank needs next.
-        </p>
+        <p class="muted" style="margin:.35rem 0 0;"><a href="https://thetankguide.com/gear/">Explore compatible gear on The Tank Guide</a></p>
         <p class="muted" style="margin:.35rem 0 0;">Added: 2025-12-22</p>
           <hr class="media-divider" />
           <div class="video-meta">


### PR DESCRIPTION
### Motivation
- Update the Community Video Picks featured card to a new approved YouTube video and short description to keep the media hub current. 
- Add a direct CTA to the Gear page so readers can follow up on the video guidance without changing the card layout. 
- Preserve existing section headers, archive CTA, and card layout while swapping only the featured content.

### Description
- Updated the featured video anchor `href`, iframe `src` and `title`, and noscript thumbnail `src`/`alt` to the new video ID `EEhY2ppoIVQ` in `media.html`. 
- Replaced the prior multi-paragraph description with the exact approved short description text and added a new inline CTA link `Explore compatible gear on The Tank Guide` pointing to `https://thetankguide.com/gear/` directly under that description. 
- Kept the Community Video Picks header/intro, archive CTA, creator line, and existing YouTube channel button unchanged. 
- Changed file: `media.html` (path: `/workspace/website-fish-keeper/media.html`).

### Testing
- Ran a targeted content verification using `rg` to confirm the new video ID, exact title text, and CTA link are present in `media.html`, and this check succeeded. 
- Verified the repository guard script ran as part of commit hooks (`node scripts/guard-live-files.js`) and the commit completed successfully. 
- Attempted to capture desktop and mobile screenshots via Playwright, but browser binaries could not be installed in this environment; `npx playwright install chromium` failed with HTTP 403 and screenshots could not be produced. 
- Did not run the full Playwright test suite due to unavailable browser binaries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e366900efc83328319519ca6760274)