### PR TITLE
Add April 2026 Balance Experiment special journal entry

### DIFF
--- a/data/journal.csv
+++ b/data/journal.csv
@@ -1,4 +1,5 @@
 Date,Time,Category,Action/Observation,Notes/Results,Nitrate(ppm),Dosing,ThrivePlus(pumps),WaterChange,tags,Image
+2026-04,,Journal Update,The Balance Experiment — 29G Planted System,"Long-form nitrate-control and ecosystem stability experiment documenting Phase 1 completion and Phase 2 activation across a 17-day observation window.",,,,"journal,29g-tank,experiment,nitrate-control,ecosystem-balance,flow-optimization,plants,filtration,bba",/journal/2026-04-balance-experiment-phase-1-phase-2.html
 2026-04-11,,Journal Update,Maintenance Reset & Start of Nitrate-Control Experiment (Day 0),"Major maintenance reset performed with filtration and plant updates, initiating a nitrate-driven water change experiment and entering a controlled observation phase.",,,,,"journal,29g-tank,maintenance-reset,water-change,filtration,plants,nitrate-experiment,system-monitoring",
 2025-09-09,,Feeding,Fed: veggie-only (zucchini/spinach or wafers),Scheduled feeding (backfilled per user approval),,,,,,
 2025-09-10,,Feeding,Fed: flakes + bloodworms,Scheduled feeding (backfilled per user approval),,,,,,

--- a/data/journal/2026-04.json
+++ b/data/journal/2026-04.json
@@ -1,10 +1,18 @@
 [
   {
+    "date": "2026-04",
+    "title": "The Balance Experiment \u2014 29G Planted System",
+    "body": "Long-form nitrate-control and ecosystem stability experiment documenting Phase 1 completion and Phase 2 activation across a 17-day observation window.",
+    "category": "Journal Update",
+    "quick_facts": "Phase 1 completed; Phase 2 activated; 17-day observation window; nitrate-control + ecosystem stability focus",
+    "nitrate_ppm": "Tracked across Phase 1 and Phase 2"
+  },
+  {
     "date": "2026-04-11",
     "title": "Maintenance Reset & Start of Nitrate-Control Experiment (Day 0)",
-    "body": "Performed a standard maintenance water change with additional filter and plant adjustments. Pre–water change nitrate levels measured between 40–80 ppm, indicating elevated nutrient buildup. Completed the usual large-volume change: ~90%+ sump drain; ~70–75% display drain. 🔧 Filtration Updates: Replaced polyfill layer; Replaced 5-in-1 filter sponge (Temu media) positioned before the polyfill; Dosed Stability to support bacterial re-establishment following media replacement; Dosed Prime during refill as usual. 🌱 Plant Maintenance: Trimmed Java moss in both sump and display; Removed and discarded browned/decaying sections; Transferred healthy moss from display into sump to maintain refugium density. Plant mass remains strong and actively growing. 🧪 Experiment Begins — Day 0: Transitioning from schedule-based water changes → nitrate-driven water changes. Goal: Reduce unnecessary large water changes; Allow system to find natural nutrient balance; Track nitrate accumulation under current lower bioload + high plant mass. 📊 Follow-Up Reading: April 14, 2026 (Day 3): Nitrates measured at ~5–10 ppm. This indicates strong nutrient uptake from plants, effective reset from the April 11 water change, and readiness for controlled observation phase. 📌 System Status: Filtration refreshed; Plant mass redistributed and cleaned; Nitrates reset to low range; System stable. Tank is now officially in a controlled nitrate-monitoring phase.",
+    "body": "Performed a standard maintenance water change with additional filter and plant adjustments. Pre\u2013water change nitrate levels measured between 40\u201380 ppm, indicating elevated nutrient buildup. Completed the usual large-volume change: ~90%+ sump drain; ~70\u201375% display drain. \ud83d\udd27 Filtration Updates: Replaced polyfill layer; Replaced 5-in-1 filter sponge (Temu media) positioned before the polyfill; Dosed Stability to support bacterial re-establishment following media replacement; Dosed Prime during refill as usual. \ud83c\udf31 Plant Maintenance: Trimmed Java moss in both sump and display; Removed and discarded browned/decaying sections; Transferred healthy moss from display into sump to maintain refugium density. Plant mass remains strong and actively growing. \ud83e\uddea Experiment Begins \u2014 Day 0: Transitioning from schedule-based water changes \u2192 nitrate-driven water changes. Goal: Reduce unnecessary large water changes; Allow system to find natural nutrient balance; Track nitrate accumulation under current lower bioload + high plant mass. \ud83d\udcca Follow-Up Reading: April 14, 2026 (Day 3): Nitrates measured at ~5\u201310 ppm. This indicates strong nutrient uptake from plants, effective reset from the April 11 water change, and readiness for controlled observation phase. \ud83d\udccc System Status: Filtration refreshed; Plant mass redistributed and cleaned; Nitrates reset to low range; System stable. Tank is now officially in a controlled nitrate-monitoring phase.",
     "category": "Journal Update",
-    "quick_facts": "Maintenance reset completed; pre-WC nitrate 40–80 ppm; ~90%+ sump / ~70–75% display water change; polyfill and 5-in-1 sponge replaced; Stability and Prime dosed; moss trimmed and redistributed; nitrate-driven experiment started; day-3 nitrate ~5–10 ppm",
-    "nitrate_ppm": "5–10 (Day 3 follow-up)"
+    "quick_facts": "Maintenance reset completed; pre-WC nitrate 40\u201380 ppm; ~90%+ sump / ~70\u201375% display water change; polyfill and 5-in-1 sponge replaced; Stability and Prime dosed; moss trimmed and redistributed; nitrate-driven experiment started; day-3 nitrate ~5\u201310 ppm",
+    "nitrate_ppm": "5\u201310 (Day 3 follow-up)"
   }
 ]

--- a/journal.html
+++ b/journal.html
@@ -242,6 +242,141 @@
           <!-- Card Grid Container -->
           <div class="journal-grid">
 
+              <!-- The Balance Experiment — 29G Planted System -->
+              <article id="entry-2026-04-balance-experiment-phase-1-phase-2" class="journal-card standout-moment"
+                       data-date="2026-04"
+                       data-type="update"
+                       data-category="journal-update"
+                       data-focus="system-monitoring">
+                  <div class="card-header">
+                      <span class="card-icon">🧭</span>
+                      <h3><a href="/journal/2026-04-balance-experiment-phase-1-phase-2.html">The Balance Experiment — 29G Planted System</a></h3>
+                      <time datetime="2026-04">April 2026</time>
+                  </div>
+                  <div class="card-body">
+                      <h4>🧪 Experiment Scope</h4>
+                      <ul>
+                          <li><strong>Window:</strong> 17-day system observation (Phase 1 completion → Phase 2 activation)</li>
+                          <li><strong>Primary objective:</strong> Nitrate-control without forced schedule-based intervention</li>
+                          <li><strong>Secondary objective:</strong> Validate ecosystem self-regulation across flow, plants, and filtration layers</li>
+                      </ul>
+
+                      <hr>
+
+                      <h4>━━━━━━━━━━ PHASE 1 — Completion Log ━━━━━━━━━━</h4>
+                      <ul>
+                          <li><strong>Goal:</strong> Complete reset stabilization after deep-maintenance and Day 0 nitrate experiment start.</li>
+                          <li><strong>Method:</strong>
+                              <ul>
+                                  <li>Hold normal feeding rhythm with no emergency water-change override.</li>
+                                  <li>Track nitrate response against plant uptake and filtration consistency.</li>
+                                  <li>Use targeted BBA observation points instead of broad chemical escalation.</li>
+                              </ul>
+                          </li>
+                      </ul>
+
+                      <h4>📅 Day-by-Day Checkpoints (Phase 1)</h4>
+                      <ul>
+                          <li><strong>Day 1–3:</strong>
+                              <ul>
+                                  <li>Post-reset nitrate collapse into low range confirmed.</li>
+                                  <li>No instability signals in fish behavior or circulation pattern.</li>
+                              </ul>
+                          </li>
+                          <li><strong>Day 4–7:</strong>
+                              <ul>
+                                  <li>Plant mass maintained active uptake with no major melt cycle.</li>
+                                  <li>Flow distribution remained even across display and sump return zones.</li>
+                              </ul>
+                          </li>
+                          <li><strong>Day 8–12:</strong>
+                              <ul>
+                                  <li>Nutrient curve remained controlled with no abrupt spike event.</li>
+                                  <li>BBA pressure stayed localized to prior hardware-prone zones.</li>
+                              </ul>
+                          </li>
+                          <li><strong>Day 13–17:</strong>
+                              <ul>
+                                  <li>System held stability without forced reset maintenance.</li>
+                                  <li>Phase 1 exit criteria met: controlled nitrate trend + stable biological response.</li>
+                              </ul>
+                          </li>
+                      </ul>
+
+                      <hr>
+
+                      <h4>🧰 Phase 1 Technical Notes</h4>
+                      <ul>
+                          <li><strong>Filtration behavior:</strong>
+                              <ul>
+                                  <li>Mechanical pathway remained consistent after prior media refresh.</li>
+                                  <li>No major evidence of flow choke or restart instability during observation window.</li>
+                              </ul>
+                          </li>
+                          <li><strong>Plant subsystem:</strong>
+                              <ul>
+                                  <li>Refugium + display mass continued acting as primary nutrient sink.</li>
+                                  <li>Trim discipline prioritized dead-zone removal over aggressive reshaping.</li>
+                              </ul>
+                          </li>
+                          <li><strong>Algae control posture:</strong>
+                              <ul>
+                                  <li>BBA monitored as indicator species for imbalance pockets.</li>
+                                  <li>Escalation threshold deferred pending Phase 2 flow optimization results.</li>
+                              </ul>
+                          </li>
+                      </ul>
+
+                      <hr>
+
+                      <h4>━━━━━━━━━━ PHASE 2 — Activation Protocol ━━━━━━━━━━</h4>
+                      <ul>
+                          <li><strong>Activation trigger:</strong> Phase 1 stability confirmed across nitrate, behavior, and mechanical flow.</li>
+                          <li><strong>Phase 2 objective:</strong> Convert stability into repeatable balance by tightening flow-path efficiency and nutrient capture continuity.</li>
+                      </ul>
+
+                      <h4>🚀 Phase 2 Action Stack</h4>
+                      <ul>
+                          <li><strong>Flow Optimization Layer</strong>
+                              <ul>
+                                  <li>Prioritize return-path uniformity to reduce detritus settlement pockets.</li>
+                                  <li>Use hardware-zone inspection points as recurring turbulence checks.</li>
+                              </ul>
+                          </li>
+                          <li><strong>Nitrate-Control Layer</strong>
+                              <ul>
+                                  <li>Continue nitrate-driven water change logic (no calendar-first resets).</li>
+                                  <li>Track trend direction over point readings to avoid over-correction.</li>
+                              </ul>
+                          </li>
+                          <li><strong>Ecosystem-Balance Layer</strong>
+                              <ul>
+                                  <li>Keep plant mass density stable in both display and sump zones.</li>
+                                  <li>Preserve biological filtration continuity during any minor media adjustments.</li>
+                              </ul>
+                          </li>
+                      </ul>
+
+                      <hr>
+
+                      <h4>📌 Phase Conclusions & Forward Controls</h4>
+                      <ul>
+                          <li><strong>Phase 1 result:</strong> Completed successfully with stable nitrate behavior and no corrective emergency maintenance events.</li>
+                          <li><strong>Phase 2 status:</strong> Active.</li>
+                          <li><strong>Next validation target:</strong>
+                              <ul>
+                                  <li>Confirm flow optimization lowers recurring BBA pressure zones.</li>
+                                  <li>Confirm nitrate-control remains stable under normal feeding variance.</li>
+                                  <li>Confirm system can sustain balance with minimal intervention cadence.</li>
+                              </ul>
+                          </li>
+                      </ul>
+                  </div>
+                  <div class="card-footer">
+                      <span class="tag">journal</span><span class="tag">29g-tank</span><span class="tag">experiment</span><span class="tag">nitrate-control</span><span class="tag">ecosystem-balance</span><span class="tag">flow-optimization</span><span class="tag">plants</span><span class="tag">filtration</span><span class="tag">bba</span>
+                  </div>
+              </article>
+
               <!-- Maintenance Reset & Start of Nitrate-Control Experiment (Day 0) -->
               <article id="entry-2026-04-11-maintenance-reset-nitrate-experiment-day-0" class="journal-card standout-moment"
                        data-date="2026-04-11"


### PR DESCRIPTION
### Motivation
- Introduce a flagship long-form “special experiment” journal entry for April 2026 documenting Phase 1 completion and Phase 2 activation of a 17-day nitrate-control ecosystem experiment. 
- Ensure the entry is treated as a featured/month-level system entry and preserves the exact long-form structure (dividers, emoji headers, phase labels, nested bullets, and checkpoint formatting).

### Description
- Added a month-level row to `data/journal.csv` for `2026-04` with the requested slug, title, summary, tags, and URL and placed it above the existing Apr 11 entry to preserve featured ordering. 
- Inserted a new structured entry object at the top of `data/journal/2026-04.json` with the month-level date `2026-04` and experiment-specific metadata following the repository’s JSON formatting conventions. 
- Injected a full long-form featured article block into `journal.html` directly under the April 2026 month header and above the Apr 11 card, using the slug-based article id and display date `April 2026`, while preserving all headings, divider bars, emoji headers, nested lists, phase sections, and exact content hierarchy. 

### Testing
- Validated `data/journal/2026-04.json` formatting using `python -m json.tool` which completed successfully. 
- Parsed `data/journal.csv` using Python’s `csv` module to confirm CSV integrity which completed successfully. 
- Verified the HTML insertion by inspecting `journal.html` to confirm the new article appears directly below the April 2026 header and above the Apr 11 entry, and that nested lists and dividers are present. 
- Attempted automated screenshot capture with a Playwright script, but the environment lacks the `playwright` module and the screenshot step could not run (`Cannot find module 'playwright'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1efe10c0c8332a0076b407d8169ad)