### PR TITLE
Sitemap cleanup, URL normalization, and indexing guardrails

### DIFF
--- a/diy-sump-lessons-learned.html
+++ b/diy-sump-lessons-learned.html
@@ -13,7 +13,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>DIY Sump Setup: Lessons Learned from a Hardware Failure</title>
   <meta name="description" content="A real-world DIY sump failure and fix. Learn how check valves, siphon breaks, and system design impact aquarium safety and reliability.">
-  <link rel="canonical" href="https://thetankguide.com/diy-sump-lessons-learned/">
+  <link rel="canonical" href="https://thetankguide.com/diy-sump-lessons-learned.html">
   <meta name="robots" content="index, follow">
   <link rel="icon" type="image/png" sizes="16x16" href="/assets/img/logos/favicon-16.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/img/logos/favicon-32.png">
@@ -23,7 +23,7 @@
   <meta property="og:type" content="article">
   <meta property="og:title" content="DIY Sump Setup: Lessons Learned from a Hardware Failure">
   <meta property="og:description" content="A real-world DIY sump failure and fix. Learn how system design, check valves, and siphon breaks affect aquarium stability.">
-  <meta property="og:url" content="https://thetankguide.com/diy-sump-lessons-learned/">
+  <meta property="og:url" content="https://thetankguide.com/diy-sump-lessons-learned.html">
   <meta property="og:image" content="https://thetankguide.com/assets/images/diy-aquarium-sump-check-valve-care-guide-sump-lesson-hero.png">
   <meta property="og:image:alt" content="DIY aquarium sump setup with check valve and return line used in lessons learned guide">
   <meta property="og:site_name" content="The Tank Guide">
@@ -54,7 +54,7 @@
         },
         "mainEntityOfPage": {
           "@type": "WebPage",
-          "@id": "https://thetankguide.com/diy-sump-lessons-learned/"
+          "@id": "https://thetankguide.com/diy-sump-lessons-learned.html"
         },
         "datePublished": "2026-01-20",
         "dateModified": "2026-01-20",

--- a/freshwater-aquarium-clean-up-crew-snail-welfare.html
+++ b/freshwater-aquarium-clean-up-crew-snail-welfare.html
@@ -13,7 +13,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Freshwater Aquarium Clean-Up Crew: A Guide to Snail Welfare &amp; Balance</title>
   <meta name="description" content="Stop treating snails as algae tools. Learn how to integrate snails into your aquarium ecosystem ethically, prevent shell erosion, and maintain long-term balance." />
-  <link rel="canonical" href="https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare" />
+  <link rel="canonical" href="https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare.html" />
   <link rel="icon" type="image/png" sizes="16x16" href="/assets/img/logos/favicon-16.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/img/logos/favicon-32.png">
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/Logo-Master-180x180.PNG">
@@ -27,7 +27,7 @@
   <meta property="og:locale" content="en_US" />
   <meta property="og:title" content="Freshwater Aquarium Clean-Up Crew: A Guide to Snail Welfare &amp; Balance" />
   <meta property="og:description" content="Stop treating snails as algae tools. Learn how to integrate snails into your aquarium ecosystem ethically, prevent shell erosion, and maintain long-term balance." />
-  <meta property="og:url" content="https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare" />
+  <meta property="og:url" content="https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare.html" />
   <meta property="og:image" content="https://thetankguide.com/assets/images/mts-on-strainer-2025-11-03.jpg" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -35,7 +35,7 @@
   <meta property="article:published_time" content="2026-01-15" />
   <meta property="article:modified_time" content="2026-01-15" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:url" content="https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare" />
+  <meta name="twitter:url" content="https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare.html" />
   <meta name="twitter:title" content="Freshwater Aquarium Clean-Up Crew: A Guide to Snail Welfare &amp; Balance" />
   <meta name="twitter:description" content="Stop treating snails as algae tools. Learn how to integrate snails into your aquarium ecosystem ethically, prevent shell erosion, and maintain long-term balance." />
   <meta name="twitter:image" content="https://thetankguide.com/assets/images/mts-on-strainer-2025-11-03.jpg" />
@@ -82,7 +82,7 @@
     "dateModified": "2026-01-15",
     "mainEntityOfPage": {
       "@type": "WebPage",
-      "@id": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare"
+      "@id": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare.html"
     },
     "isPartOf": { "@id": "https://thetankguide.com/#website" }
   }
@@ -116,31 +116,31 @@
         "@type": "HowToStep",
         "name": "Heat the base",
         "text": "Heat the calcium-rich baby food in a saucepan or bowl. Do not allow it to reach a boil.",
-        "url": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare#step1"
+        "url": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare.html#step1"
       },
       {
         "@type": "HowToStep",
         "name": "Add gelatin",
         "text": "Stir in one packet of unflavored gelatin thoroughly until completely dissolved.",
-        "url": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare#step2"
+        "url": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare.html#step2"
       },
       {
         "@type": "HowToStep",
         "name": "Mix nutrients",
         "text": "Mix in the calcium carbonate and your protein source (fish flakes or spirulina).",
-        "url": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare#step3"
+        "url": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare.html#step3"
       },
       {
         "@type": "HowToStep",
         "name": "Set and chill",
         "text": "Pour the mixture into a flat container and refrigerate for approximately 2 hours until firm.",
-        "url": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare#step4"
+        "url": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare.html#step4"
       },
       {
         "@type": "HowToStep",
         "name": "Portion and store",
         "text": "Cut the snello into 1 cm cubes and move to the freezer for long-term storage.",
-        "url": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare#step5"
+        "url": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare.html#step5"
       }
     ]
   }
@@ -571,7 +571,7 @@
         "@type": "ListItem",
         "position": 3,
         "name": "Freshwater Aquarium Clean-Up Crew: A Guide to Snail Welfare & Balance",
-        "item": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare"
+        "item": "https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare.html"
       }
     ]
   }

--- a/robots.txt
+++ b/robots.txt
@@ -15,3 +15,12 @@ Allow: /
 
 User-agent: Bingbot
 Allow: /
+
+Disallow: /node_modules/
+Disallow: /workers/node_modules/
+Disallow: /footer.html
+Disallow: /nav.html
+Disallow: /params.html
+Disallow: /store-prototype.html
+Disallow: /feature-your-tank-confirmation.html
+Disallow: /404.html

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -45,7 +45,7 @@
   </url>
 
   <url>
-    <loc>https://thetankguide.com/feature-your-tank-confirmation.html</loc>
+    <loc>https://thetankguide.com/pages/university.html</loc>
     <lastmod>2025-12-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
@@ -215,7 +215,7 @@
   </url>
 
   <url>
-    <loc>https://thetankguide.com/diy-sump-lessons-learned/</loc>
+    <loc>https://thetankguide.com/diy-sump-lessons-learned.html</loc>
     <changefreq>monthly</changefreq>
     <priority>0.80</priority>
   </url>
@@ -306,7 +306,7 @@
   </url>
 
   <url>
-    <loc>https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare</loc>
+    <loc>https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare.html</loc>
     <lastmod>2026-01-06</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
@@ -357,7 +357,7 @@
   <!-- University & Educational -->
 
   <url>
-    <loc>https://thetankguide.com/university/</loc>
+    <loc>https://thetankguide.com/books/daily-tank-journal-planted/</loc>
     <lastmod>2025-12-16</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -398,6 +398,13 @@
     <lastmod>2025-12-16</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://thetankguide.com/cookie-settings.html</loc>
+    <lastmod>2026-04-29</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.2</priority>
   </url>
 
 </urlset>

--- a/university/index.html
+++ b/university/index.html
@@ -14,7 +14,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <title>Aquarium University — Hybrid Academic &amp; Aquatic Learning | The Tank Guide</title>
   <meta name="description" content="Dive into Aquarium University by The Tank Guide. Our courses bridge aquatic science with hands-on fishkeeping practice for confident beginner aquarists." />
   <meta name="robots" content="index,follow" />
-  <link rel="canonical" href="https://thetankguide.com/university/" />
+  <link rel="canonical" href="https://thetankguide.com/pages/university.html" />
   <link rel="icon" type="image/png" sizes="16x16" href="/assets/img/logos/favicon-16.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/assets/img/logos/favicon-32.png">
   <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/Logo-Master-180x180.PNG">
@@ -26,7 +26,7 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
   <meta property="og:type" content="website" />
   <meta property="og:title" content="Aquarium University — Hybrid Academic &amp; Aquatic Learning" />
   <meta property="og:description" content="Follow guided study tracks, watch technique labs, and earn certificates that blend academic fundamentals with practical aquarium keeping." />
-  <meta property="og:url" content="https://thetankguide.com/university/" />
+  <meta property="og:url" content="https://thetankguide.com/pages/university.html" />
   <meta property="og:image" content="https://thetankguide.com/assets/img/logos/logo-1200x630.png" />
   <meta property="og:image:width" content="1200" />
   <meta property="og:image:height" content="630" />
@@ -99,17 +99,17 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
     "@graph": [
       {
         "@type": ["WebPage", "CollectionPage"],
-        "@id": "https://thetankguide.com/university/#webpage",
-        "url": "https://thetankguide.com/university/",
+        "@id": "https://thetankguide.com/pages/university.html#webpage",
+        "url": "https://thetankguide.com/pages/university.html",
         "name": "Aquarium University — Hybrid Academic & Aquatic Learning",
         "description": "Dive into Aquarium University by The Tank Guide. Our courses bridge aquatic science with hands-on fishkeeping practice for confident beginner aquarists.",
         "isPartOf": { "@id": "https://thetankguide.com/#website" },
         "publisher": { "@id": "https://thetankguide.com/#organization" },
         "mainEntity": {
           "@type": "Organization",
-          "@id": "https://thetankguide.com/university/#program",
+          "@id": "https://thetankguide.com/pages/university.html#program",
           "name": "Aquarium University",
-          "url": "https://thetankguide.com/university/",
+          "url": "https://thetankguide.com/pages/university.html",
           "description": "Hybrid academic-meets-hobby curriculum highlighting labs, study tracks, and certification paths for aquarists.",
           "parentOrganization": {
             "@id": "https://thetankguide.com/#organization"
@@ -118,10 +118,10 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       },
       {
         "@type": "BreadcrumbList",
-        "@id": "https://thetankguide.com/university/#breadcrumb",
+        "@id": "https://thetankguide.com/pages/university.html#breadcrumb",
         "itemListElement": [
           { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://thetankguide.com/" },
-          { "@type": "ListItem", "position": 2, "name": "Aquarium University", "item": "https://thetankguide.com/university/" }
+          { "@type": "ListItem", "position": 2, "name": "Aquarium University", "item": "https://thetankguide.com/pages/university.html" }
         ]
       }
     ]


### PR DESCRIPTION
### Motivation
- Ensure the sitemap contains only public, canonical pages and includes the requested live pages for SEO/AEO/GEO and AdSense readiness. 
- Remove internal, prototype, and test artifacts from indexing signals and prevent accidental crawling of dependency/test directories. 
- Normalize duplicate URL variants and align canonical tags so search engines index the single intended URL per resource.

### Description
- Updated `sitemap.xml` to remove the internal confirmation URL and to include/normalize the requested pages (added `https://thetankguide.com/pages/university.html`, `https://thetankguide.com/books/daily-tank-journal-planted/`, `https://thetankguide.com/cookie-settings.html`, `https://thetankguide.com/diy-sump-lessons-learned.html`, and `https://thetankguide.com/freshwater-aquarium-clean-up-crew-snail-welfare.html`).
- Normalized canonical URLs and metadata: updated `university/index.html` to canonical `https://thetankguide.com/pages/university.html`, and updated `diy-sump-lessons-learned.html` and `freshwater-aquarium-clean-up-crew-snail-welfare.html` to use their `.html` canonical variants (including OG/twitter/mainEntityOfPage URLs and internal anchors where present). 
- Hardened `robots.txt` by adding explicit `Disallow` rules for `node_modules/`, `workers/node_modules/`, and internal/test pages (`/footer.html`, `/nav.html`, `/params.html`, `/store-prototype.html`, `/feature-your-tank-confirmation.html`, `/404.html`) to reduce accidental indexing. 
- Files changed: `sitemap.xml`, `robots.txt`, `university/index.html`, `diy-sump-lessons-learned.html`, `freshwater-aquarium-clean-up-crew-snail-welfare.html`.

### Testing
- XML parse/structure check: parsed `sitemap.xml` with Python `xml.etree.ElementTree` and verified the sitemap is well-formed and contains the expected entries; final sitemap URL count is `57` (passed). 
- Static presence/exclusion checks: used `rg`/pattern scans to confirm the targeted pages are present in the sitemap and that the internal/test pages are not present, and verified robots rules include the new disallows (passed). 
- Live HTTP validation: attempted HTTP requests to verify 200/redirect behavior but requests were blocked by the environment outbound tunnel/proxy (returned `403 Forbidden`), so full public-response validation must be re-run from CI or a network with direct egress (blocked). 
- Project guard verification: site guard script executed during the change workflow and did not report errors (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f83e50a88332b3c4e3cc31a8e00d)