### PR TITLE
Update Plant Fest 2026 hero image and aligned metadata

### DIFF
--- a/fritz-plant-fest-2026/index.html
+++ b/fritz-plant-fest-2026/index.html
@@ -27,12 +27,12 @@
   <meta property="og:title" content="Plant Fest 2026 — A Different Side of the Aquarium Hobby" />
   <meta property="og:description" content="A reflection on Fitz’s Fish Ponds Plant Fest 2026 and what it reveals about koi ponds, aquatic plants, shrimp bowls, filtration, and the shared ecosystem principles connecting ponds and aquariums." />
   <meta property="og:url" content="https://thetankguide.com/fritz-plant-fest-2026/" />
-  <meta property="og:image" content="https://thetankguide.com/assets/img/logos/logo-1200x630.png" />
+  <meta property="og:image" content="https://thetankguide.com/assets/images/fritz-plant-fest-2026-hero.jpeg" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:url" content="https://thetankguide.com/fritz-plant-fest-2026/" />
   <meta name="twitter:title" content="Plant Fest 2026 — A Different Side of the Aquarium Hobby" />
   <meta name="twitter:description" content="A reflection on Fitz’s Fish Ponds Plant Fest 2026 and what it reveals about koi ponds, aquatic plants, shrimp bowls, filtration, and the shared ecosystem principles connecting ponds and aquariums." />
-  <meta name="twitter:image" content="https://thetankguide.com/assets/img/logos/logo-1200x630.png" />
+  <meta name="twitter:image" content="https://thetankguide.com/assets/images/fritz-plant-fest-2026-hero.jpeg" />
 
   <!--#include virtual="/includes/schema-organization.html" -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -60,7 +60,7 @@
           "@type": "WebPage",
           "@id": "https://thetankguide.com/fritz-plant-fest-2026/"
         },
-        "image": "https://thetankguide.com/assets/img/logos/logo-1200x630.png",
+        "image": "https://thetankguide.com/assets/images/fritz-plant-fest-2026-hero.jpeg",
         "datePublished": "2026-05-04",
         "dateModified": "2026-05-04",
         "isPartOf": { "@id": "https://thetankguide.com/#website" }
@@ -115,6 +115,10 @@
         <h1 class="article-title">Plant Fest 2026 — A Different Side of the Aquarium Hobby</h1>
         <p class="deck">Reflections from Fitz’s Fish Ponds Plant Fest 2026 and the Growing Connection Between Ponds, Plants, and Aquatic Ecosystems</p>
         <p class="deck">The Tank Guide · Owned and published by FishKeepingLifeCo</p>
+
+        <figure class="article-hero">
+          <img src="/assets/images/fritz-plant-fest-2026-hero.jpeg" alt="Fitz's Fish Ponds Plant Fest 2026" loading="eager" decoding="async">
+        </figure>
       </header>
 
       <div class="section-split" aria-hidden="true"></div>


### PR DESCRIPTION
### Motivation
- Ensure the article uses the correct hero/featured image and that all social and schema references reflect the visible hero image to avoid mismatched previews and metadata.

### Description
- Updated `fritz-plant-fest-2026/index.html` to insert the visible article hero `<figure>` using the repo-relative path `/assets/images/fritz-plant-fest-2026-hero.jpeg` (file-local change only).
- Replaced the previous logo image URL in Open Graph and Twitter meta tags with the absolute hero URL `https://thetankguide.com/assets/images/fritz-plant-fest-2026-hero.jpeg`.
- Updated the `BlogPosting` schema `image` field to the same absolute hero URL `https://thetankguide.com/assets/images/fritz-plant-fest-2026-hero.jpeg`.
- Preserved the article body copy and structure exactly; no body text was edited.

### Testing
- Verified file existence with `test -f assets/images/fritz-plant-fest-2026-hero.jpeg` which succeeded.
- Confirmed references were updated using `rg` searches for the hero and meta fields which returned the new hero URL in `fritz-plant-fest-2026/index.html` (succeeded).
- Reviewed the working tree and diff with `git diff -- fritz-plant-fest-2026/index.html` and committed the change with `git commit`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f803c634e8833298e26a1c72442553)