### PR TITLE
Constrain Plant Fest hero image height and container on article page

### DIFF
--- a/fritz-plant-fest-2026/index.html
+++ b/fritz-plant-fest-2026/index.html
@@ -40,6 +40,42 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/blogs-bundle.min.css?v=1.0.0">
 
+  <style>
+    body.blog-article .article-header {
+      gap: clamp(0.8rem, 2.5vw, 1.15rem);
+    }
+
+    body.blog-article .article-hero {
+      width: min(100%, 780px);
+      margin: clamp(0.65rem, 2vw, 0.95rem) auto 0;
+      border-radius: 14px;
+      overflow: hidden;
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.12);
+      box-shadow: 0 12px 28px rgba(0, 0, 0, 0.24);
+      padding: 0;
+    }
+
+    body.blog-article .article-hero img {
+      width: 100%;
+      height: clamp(220px, 36vw, 420px);
+      object-fit: cover;
+      object-position: center;
+      display: block;
+    }
+
+    @media (max-width: 640px) {
+      body.blog-article .article-hero {
+        width: min(100%, 620px);
+        margin-top: 0.5rem;
+      }
+
+      body.blog-article .article-hero img {
+        height: clamp(180px, 48vw, 250px);
+      }
+    }
+  </style>
+
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",


### PR DESCRIPTION
### Motivation
- The hero image for the Plant Fest article was visually overpowering on narrow viewports and pushed article content too far below the fold, so a page-scoped styling fix was needed to make the hero read like a blog header while preserving copy and the image asset.

### Description
- Added page-scoped CSS in `fritz-plant-fest-2026/index.html` to constrain the hero container to `width: min(100%, 780px)` and center it so the image no longer renders edge-to-edge.
- Applied responsive height clamps to the hero image (`height: clamp(...)`) with `object-fit: cover` to cap vertical dominance while keeping the image undistorted and preserving rounded corners and spacing.
- Tightened the `.article-header` spacing to improve the title/deck/publication-to-hero rhythm so the article content becomes readable sooner on mobile.
- The change is page-specific, and no blog body text or image assets were modified or replaced.

### Testing
- Located the target page and related styles using `rg` to confirm the fix scope and found the change is page-specific; this succeeded.
- Started a local static server with `python -m http.server 4173` to preview the page; the server started successfully.
- Attempted automated mobile/desktop screenshots with Playwright, but the run failed because Playwright browser binaries were not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f806de8a1c83329b4005478ebccde9)