### PR TITLE
Insert inline section images for Plant Fest 2026 blog post

### DIFF
--- a/fritz-plant-fest-2026/index.html
+++ b/fritz-plant-fest-2026/index.html
@@ -172,6 +172,16 @@
         <p>Walking through the property, you could see exposed plumbing, centralized water systems, rotating drum filters, chillers, and large-scale pond infrastructure all operating in real time. Unlike many display systems where equipment is hidden, much of the filtration and plumbing here was visible — which made the event feel genuinely educational rather than purely decorative.</p>
         <p>For freshwater aquarium hobbyists, it was fascinating to see those same principles scaled into massive outdoor environments.</p>
 
+        <figure class="tg-figure">
+          <img
+            src="/assets/images/koi-side-of-the-hobby-fritz-plant-fest-2026.jpeg"
+            alt="Large koi swimming in display ponds during Fritz Plant Fest 2026"
+            class="tg-img"
+            loading="lazy"
+            decoding="async"
+          >
+        </figure>
+
         <h2>The Koi Side of the Hobby</h2>
         <p>The koi presence was hard to ignore.</p>
         <p>Large ponds filled with healthy koi surrounded the property, with some fish reaching prices in the thousands of dollars — a clear sign of just how serious and established this side of the hobby is.</p>
@@ -199,9 +209,31 @@
           <li>How do ecosystems balance themselves?</li>
         </ul>
 
+        <figure class="tg-figure">
+          <img
+            src="/assets/images/aquarium-and-pond-equipment-oase-filter-fritz-plant-fest-2026.jpeg"
+            alt="Cutaway pond filtration system display with layered media at Plant Fest 2026"
+            class="tg-img"
+            loading="lazy"
+            decoding="async"
+          >
+          <figcaption>Cutaway display of a pond filtration system at Fritz Plant Fest 2026 showing layered mechanical and biological filtration media.</figcaption>
+        </figure>
+
         <h2>Aquarium and Pond Equipment Observations</h2>
         <p>One brand that appeared heavily throughout the store was Oase, particularly in pond filtration and water management equipment.</p>
         <p>The event also highlighted how much crossover now exists between higher-end aquarium hobbyists and pond keepers. Some attendees immediately recognized premium planted tank equipment like Chihiros lighting systems just by appearance — a small moment that said a lot about how fluidly many hobbyists move between different areas of the aquatic world.</p>
+
+        <figure class="tg-figure">
+          <img
+            src="/assets/images/carnivorous-plants-fritz-plant-fest-2026.jpeg"
+            alt="Carnivorous plants on display at Fritz Plant Fest 2026"
+            class="tg-img"
+            loading="lazy"
+            decoding="async"
+          >
+          <figcaption>Plant Fest 2026 showcased more than aquatics — including a growing interest in carnivorous and exotic plant species.</figcaption>
+        </figure>
 
         <h2>An Unexpected Purchase: Carnivorous Plants</h2>
         <p>One unexpected part of the trip was leaving with two carnivorous plants: a Sarracenia pitcher plant and a Drosera sundew.</p>


### PR DESCRIPTION
### Motivation
- Add the three requested inline images and captions to the Plant Fest 2026 article while preserving the original article copy and metadata. 
- Ensure the inserted media follow the site’s existing article image pattern and render responsively on the same layout used across the blog.

### Description
- Updated `fritz-plant-fest-2026/index.html` to insert `figure` blocks using the site pattern (`tg-figure` / `tg-img`) directly above the headings `The Koi Side of the Hobby`, `Aquarium and Pond Equipment Observations`, and `An Unexpected Purchase: Carnivorous Plants`.
- Added descriptive `alt` text for all three images and added the requested captions under the equipment and carnivorous plant images exactly as provided.
- Inserted image paths: `assets/images/koi-side-of-the-hobby-fritz-plant-fest-2026.jpeg`, `assets/images/aquarium-and-pond-equipment-oase-filter-fritz-plant-fest-2026.jpeg`, and `assets/images/carnivorous-plants-fritz-plant-fest-2026.jpeg`.
- Preserved the hero image, all article body text and headings, and existing metadata/schema/sitemap entries without modification.

### Testing
- Located and validated the target file with `rg -n "fritz-plant-fest-2026|The Koi Side of the Hobby|Aquarium and Pond Equipment Observations|An Unexpected Purchase: Carnivorous Plants" .`, and the search succeeded.
- Inspected the modified context with `sed -n '140,250p' fritz-plant-fest-2026/index.html` and `nl -ba fritz-plant-fest-2026/index.html | sed -n '160,250p'` to confirm exact placement, and both checks succeeded.
- Verified the inserted image block pattern with `rg -n "tg-figure|tg-img" fritz-plant-fest-2026/index.html` and inspected the file diff to confirm only image/caption blocks were added; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f80dcf87608332a3af023c52f21a92)