### PR TITLE
Clarify Tank Guide / FishKeepingLifeCo schema relationships for BlogPosting JSON-LD

### DIFF
--- a/includes/schema-organization.html
+++ b/includes/schema-organization.html
@@ -34,17 +34,10 @@
       "@id": "https://thetankguide.com/#organization",
       "name": "FishKeepingLifeCo",
       "url": "https://thetankguide.com/",
-      "description": "FishKeepingLifeCo is the parent company and publisher of The Tank Guide.",
-      "owns": {
-        "@id": "https://thetankguide.com/#website"
-      },
-      "sameAs": [
-        "https://www.instagram.com/FishKeepingLifeCo",
-        "https://www.tiktok.com/@FishKeepingLifeCo",
-        "https://x.com/fishkeepinglife",
-        "https://www.youtube.com/@fishkeepinglifeco",
-        "https://www.facebook.com/fishkeepinglifeco"
-      ]
+      "description": "Legacy organization ID retained for backward-compatible schema references.",
+      "sameAs": {
+        "@id": "https://thetankguide.com/#fishkeepinglifeco"
+      }
     },
     {
       "@type": "Brand",
@@ -56,8 +49,7 @@
         "url": "https://thetankguide.com/assets/img/Logo-Master-512x512.PNG"
       },
       "parentOrganization": {
-        "@type": "Organization",
-        "@id": "https://thetankguide.com/#organization"
+        "@id": "https://thetankguide.com/#fishkeepinglifeco"
       }
     },
     {
@@ -67,10 +59,10 @@
       "name": "The Tank Guide",
       "description": "The Tank Guide is an educational aquarium website offering tools, guides, and beginner-friendly resources.",
       "publisher": {
-        "@id": "https://thetankguide.com/#organization"
+        "@id": "https://thetankguide.com/#fishkeepinglifeco"
       },
       "creator": {
-        "@id": "https://thetankguide.com/#organization"
+        "@id": "https://thetankguide.com/#fishkeepinglifeco"
       },
       "author": {
         "@id": "https://thetankguide.com/#brand"
@@ -79,7 +71,7 @@
         "@id": "https://thetankguide.com/#brand"
       },
       "owner": {
-        "@id": "https://thetankguide.com/#organization"
+        "@id": "https://thetankguide.com/#fishkeepinglifeco"
       },
       "inLanguage": "en-US",
       "potentialAction": {


### PR DESCRIPTION
### Motivation
- Fix the audit warning where `BlogPosting` referenced `author: #brand` and `publisher: #fishkeepinglifeco` without both nodes and their relationship being clearly defined in the shared include. 
- Ensure the site publication (The Tank Guide) is explicitly tied to the parent company (FishKeepingLifeCo) so page-level JSON-LD references are unambiguous.

### Description
- Updated `includes/schema-organization.html` to explicitly define and relate the three shared nodes: `#fishkeepinglifeco` (primary Organization), `#brand` (The Tank Guide Brand), and `#website` (WebSite). 
- Kept `#fishkeepinglifeco` as `Organization` with preserved `sameAs` social links and `@id` `https://thetankguide.com/#fishkeepinglifeco`. 
- Kept `#brand` as `Brand` with `@id` `https://thetankguide.com/#brand` and set `parentOrganization` to `https://thetankguide.com/#fishkeepinglifeco`. 
- Updated the `WebSite` node with `@id` `https://thetankguide.com/#website` to point `publisher`, `creator`, and `owner` to `#fishkeepinglifeco`, and retained `brand -> #brand`; left a legacy `#organization` node as a backward-compatible alias that `sameAs` -> `#fishkeepinglifeco`. 
- Did not modify any article copy or per-page BlogPosting JSON-LD other than relying on the shared include; `dateModified` behavior was not changed by this patch.

### Testing
- Searched and inspected schema and page JSON-LD with `rg` to confirm the include defines `#brand`, `#fishkeepinglifeco`, and `#website` and that pages reference those IDs; checks succeeded. 
- Spot-checked representative pages for resolved references and `dateModified` presence: `/aquarium-fertilizers-guide-liquid-root-tabs/`, `/diy-sump-lessons-learned/`, `/fritz-plant-fest-2026/`, and `/aquarium-plants-remove-nitrates/`; all pages reference `author -> #brand`, `publisher -> #fishkeepinglifeco`, `isPartOf -> #website`, and include `dateModified`. 
- Verified the shared file changed: `includes/schema-organization.html` and confirmed the intended relationship encoding between brand, website, and parent organization; validation checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f81192330c8332979d09e5ed3d0f37)