### PR TITLE
Fix Plant Fest 2026 BlogPosting entity relationship warning

### DIFF
--- a/fritz-plant-fest-2026/index.html
+++ b/fritz-plant-fest-2026/index.html
@@ -85,11 +85,9 @@
         "headline": "Plant Fest 2026 — A Different Side of the Aquarium Hobby",
         "description": "A reflection on Fitz’s Fish Ponds Plant Fest 2026 and what it reveals about koi ponds, aquatic plants, shrimp bowls, filtration, and the shared ecosystem principles connecting ponds and aquariums.",
         "author": {
-          "@type": "Organization",
           "@id": "https://thetankguide.com/#brand"
         },
         "publisher": {
-          "@type": "Organization",
           "@id": "https://thetankguide.com/#fishkeepinglifeco"
         },
         "mainEntityOfPage": {

--- a/includes/schema-organization.html
+++ b/includes/schema-organization.html
@@ -56,8 +56,7 @@
         "url": "https://thetankguide.com/assets/img/Logo-Master-512x512.PNG"
       },
       "parentOrganization": {
-        "@type": "Organization",
-        "@id": "https://thetankguide.com/#organization"
+        "@id": "https://thetankguide.com/#fishkeepinglifeco"
       }
     },
     {
@@ -67,10 +66,10 @@
       "name": "The Tank Guide",
       "description": "The Tank Guide is an educational aquarium website offering tools, guides, and beginner-friendly resources.",
       "publisher": {
-        "@id": "https://thetankguide.com/#organization"
+        "@id": "https://thetankguide.com/#fishkeepinglifeco"
       },
       "creator": {
-        "@id": "https://thetankguide.com/#organization"
+        "@id": "https://thetankguide.com/#fishkeepinglifeco"
       },
       "author": {
         "@id": "https://thetankguide.com/#brand"
@@ -79,7 +78,7 @@
         "@id": "https://thetankguide.com/#brand"
       },
       "owner": {
-        "@id": "https://thetankguide.com/#organization"
+        "@id": "https://thetankguide.com/#fishkeepinglifeco"
       },
       "inLanguage": "en-US",
       "potentialAction": {


### PR DESCRIPTION
### Motivation
- Resolve a JSON-LD relationship warning on the Plant Fest article by ensuring the BlogPosting references only real, defined entity nodes and the site/company hierarchy is explicit.  
- Preserve FishKeepingLifeCo as the parent company/publisher and keep all its `sameAs` social links intact.  
- Make the change page-specific and update the shared include so other pages referencing the same IDs remain consistent, while leaving the article body and visible content unchanged.

### Description
- Updated `includes/schema-organization.html` to explicitly relate the site brand and website to the company by setting `parentOrganization` and `publisher`/`creator`/`owner` to `https://thetankguide.com/#fishkeepinglifeco`.  
- Edited `fritz-plant-fest-2026/index.html` BlogPosting JSON-LD to reference entity IDs by `@id` only (removed conflicting inline `"@type": "Organization"` hints) so `author` -> `https://thetankguide.com/#brand`, `publisher` -> `https://thetankguide.com/#fishkeepinglifeco`, and `isPartOf` -> `https://thetankguide.com/#website`.  
- Files changed: `includes/schema-organization.html` (shared include) and `fritz-plant-fest-2026/index.html` (page-specific).  
- Exact @id values used: FishKeepingLifeCo = `https://thetankguide.com/#fishkeepinglifeco`, The Tank Guide website = `https://thetankguide.com/#website`, The Tank Guide brand = `https://thetankguide.com/#brand`, and FishKeepingLifeCo `sameAs` links were preserved; article body text was not modified.

### Testing
- Parsed JSON-LD blocks from both edited files with `python` `json.loads(...)` and confirmed the JSON-LD is valid.  
- Verified references via repository search (`rg`) to confirm `#brand`, `#fishkeepinglifeco`, and `#website` are defined and referenced as intended.  
- Committed changes successfully with the message `Fix Plant Fest BlogPosting entity relationships`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f812b5c40483329da3b46c0358829d)