### PR TITLE
Add Plant Fest 2026 to Spotlight Blogs index

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -170,8 +170,28 @@
           },
           {
             "@id": "https://thetankguide.com/blog/holiday-gift-guide-aquarium-lovers.html"
+          },
+          {
+            "@id": "https://thetankguide.com/fritz-plant-fest-2026/"
           }
         ]
+      },
+      {
+        "@type": "BlogPosting",
+        "@id": "https://thetankguide.com/fritz-plant-fest-2026/",
+        "url": "https://thetankguide.com/fritz-plant-fest-2026/",
+        "headline": "Plant Fest 2026 — A Different Side of the Aquarium Hobby",
+        "description": "Reflections from Fitz’s Fish Ponds Plant Fest 2026 on pond keeping, aquatic plants, koi culture, filtration, shrimp bowls, and the ecosystem principles connecting ponds and aquariums.",
+        "image": "https://thetankguide.com/assets/images/fritz-plant-fest-2026-hero.jpeg",
+        "inLanguage": "en-US",
+        "publisher": {
+          "@id": "https://thetankguide.com/#organization"
+        },
+        "author": {
+          "@id": "https://thetankguide.com/#organization"
+        },
+        "mainEntityOfPage": "https://thetankguide.com/fritz-plant-fest-2026/",
+        "datePublished": "2026-05-04"
       },
       {
         "@type": "BlogPosting",
@@ -1026,6 +1046,29 @@
         <p class="topic-sub">Holiday checklists, gift guides, and seasonal care.</p>
       </header>
       <div class="blogs-grid">
+        <article class="blog-card">
+          <a class="card-thumb-link" href="/fritz-plant-fest-2026/" aria-label="Read: Plant Fest 2026 — A Different Side of the Aquarium Hobby">
+            <span class="card-media">
+              <img
+                class="card-thumb blog-card-image pos-center"
+                src="/assets/images/fritz-plant-fest-2026-hero.jpeg"
+                alt="Fitz's Fish Ponds Plant Fest 2026"
+                loading="lazy"
+                decoding="async"
+              />
+            </span>
+          </a>
+          <div class="card-content">
+            <p class="card-kicker">
+              <span class="card-author">The Tank Guide</span>
+            </p>
+            <h3 class="card-title">
+              <a href="/fritz-plant-fest-2026/">Plant Fest 2026 — A Different Side of the Aquarium Hobby</a>
+            </h3>
+            <p class="card-excerpt">Reflections from Fitz’s Fish Ponds Plant Fest 2026 on pond keeping, aquatic plants, koi culture, filtration, shrimp bowls, and the shared ecosystem principles connecting ponds and aquariums.</p>
+            <a class="card-read" href="/fritz-plant-fest-2026/">Read the blog →</a>
+          </div>
+        </article>
         <article class="blog-card">
           <a class="card-thumb-link" href="/blog/holiday-gift-guide-aquarium-lovers.html" aria-label="Read: A Thoughtful Holiday Gift Guide for Aquarium Lovers: What to Buy (and What to Avoid)">
             <span class="card-media">


### PR DESCRIPTION
### Motivation

- Surface the newly audited live article in the site's Spotlight Blogs so readers can discover `Plant Fest 2026 — A Different Side of the Aquarium Hobby` from the main blog index.

### Description

- Updated the Spotlight Blogs source `blogs/index.html` by adding the article to the `CollectionPage` `hasPart` list and inserting a corresponding `BlogPosting` JSON-LD node with `datePublished`, `image`, and canonical `url`.
- Inserted a new blog card at the top of the `#topic-seasonal` (`Special Events & Seasonal Guides`) grid using the clean directory URL `/fritz-plant-fest-2026/` and the hero image path `/assets/images/fritz-plant-fest-2026-hero.jpeg`.
- The card follows the existing blog-card structure (kicker/author, title, link, excerpt, image) and uses the exact article title and an excerpt aligned to the live page; no unrelated cards were modified.

### Testing

- Searched and verified the new identifiers and placements with `rg -n "fritz-plant-fest-2026|blogs-grid|card-kicker|datePublished"` which returned the inserted occurrences and locations in `blogs/index.html`.
- Reviewed the change with `git diff -- blogs/index.html` and confirmed the inserted JSON-LD and card markup match the site's patterns.
- Ran the repository checks via the commit step which invoked the `guard:live` script and completed successfully, and the file was added and committed with `git` without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8147afe34833287140c4492bc3824)