### PR TITLE
Add Plant Fest 2026 card to Special Events & Seasonal Guides index

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -1027,6 +1027,29 @@
       </header>
       <div class="blogs-grid">
         <article class="blog-card">
+          <a class="card-thumb-link" href="https://thetankguide.com/fritz-plant-fest-2026/" aria-label="Read: Plant Fest 2026 — A Different Side of the Aquarium Hobby">
+            <span class="card-media">
+              <img
+                class="card-thumb blog-card-image"
+                src="/assets/images/fritz-plant-fest-2026-hero.jpeg"
+                alt="Fitz's Fish Ponds Plant Fest 2026"
+                loading="lazy"
+                decoding="async"
+              />
+            </span>
+          </a>
+          <div class="card-content">
+            <p class="card-kicker">
+              <span class="card-author">The Tank Guide</span>
+            </p>
+            <h3 class="card-title">
+              <a href="https://thetankguide.com/fritz-plant-fest-2026/">Plant Fest 2026 — A Different Side of the Aquarium Hobby</a>
+            </h3>
+            <p class="card-excerpt">Reflections on Fitz’s Fish Ponds Plant Fest 2026, from koi ponds and aquatic plants to greenhouse systems, shrimp bowls, filtration, and the ecosystem principles shared with aquariums.</p>
+            <a class="card-read" href="https://thetankguide.com/fritz-plant-fest-2026/">Read the blog →</a>
+          </div>
+        </article>
+        <article class="blog-card">
           <a class="card-thumb-link" href="/blog/holiday-gift-guide-aquarium-lovers.html" aria-label="Read: A Thoughtful Holiday Gift Guide for Aquarium Lovers: What to Buy (and What to Avoid)">
             <span class="card-media">
               <img


### PR DESCRIPTION
### Motivation
- Make the existing live article `https://thetankguide.com/fritz-plant-fest-2026/` discoverable from the main blog index under the appropriate category. 
- Keep the blog index structure and ordering intact while surfacing a timely seasonal post.

### Description
- Updated the blog index source file `blogs/index.html` to insert a new blog-card in the `Special Events & Seasonal Guides` section (`#topic-seasonal`).
- The new card matches the existing card pattern and uses the requested metadata: title `Plant Fest 2026 — A Different Side of the Aquarium Hobby`, link `https://thetankguide.com/fritz-plant-fest-2026/`, image `/assets/images/fritz-plant-fest-2026-hero.jpeg`, and the provided excerpt text. 
- The card was inserted at the top of the section's card list and no unrelated cards or sections were modified.

### Testing
- Searched the index with `rg -n "Special Events & Seasonal Guides|fritz-plant-fest-2026" blogs/index.html` to confirm the new entry is present, which succeeded. 
- Inspected the insertion region with `nl -ba blogs/index.html | sed -n '1018,1065p'` to verify markup, placement, and that the image path, title, and link are correct, which succeeded. 
- Reviewed the file diff to ensure only the intended card insertion was added and other content was preserved, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f815ad87988332ba87dbd1456d1e8a)