### PR TITLE
Remove duplicate Etsy text from Amazon footer CTA

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -59,7 +59,7 @@
       rel="noopener noreferrer"
       aria-label="Shop our books on Amazon (opens in a new tab)"
     >
-      Shop our books on Amazon • Etsy »
+      Shop our books on Amazon »
     </a>
   </p>
   <p class="amazon-cta under-social" role="presentation">


### PR DESCRIPTION
### Motivation
- Remove a hardcoded duplicate “Etsy” reference that was appended to the Amazon CTA in the shared footer so the Amazon line reads independently while preserving the dedicated Etsy CTA.

### Description
- Edited `footer.html` to replace the Amazon anchor text `Shop our books on Amazon • Etsy »` with `Shop our books on Amazon »`, leaving the standalone `Shop on Etsy »` anchor and all footer structure, classes, and styling unchanged.

### Testing
- Ran `npm run footer:lint` successfully; attempted Playwright-based screenshot capture failed because `npx playwright install chromium` could not download Chromium (403), so visual browser screenshots could not be produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08d18bb5088332a1047f35566f9423)