### PR TITLE
Restore universal blog footer and add missing goldfish bottom ad slot

### DIFF
--- a/high-tech-vs-low-tech-planted-aquarium/index.html
+++ b/high-tech-vs-low-tech-planted-aquarium/index.html
@@ -333,6 +333,6 @@
       <a href="/contact-feedback.html">Contact</a>
     </section>
   </noscript>
-  <div id="footer-container"></div>
+  <div id="site-footer" data-footer-src="/footer.html?v=1.5.2"></div>
 </body>
 </html>

--- a/why-goldfish-are-misunderstood/index.html
+++ b/why-goldfish-are-misunderstood/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <link rel="preload" href="/footer.html?v=1.5.2" as="fetch" crossorigin="anonymous">
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Beyond the Bowl: Why Goldfish Are So Misunderstood</title>
@@ -20,6 +21,7 @@
   <meta name="twitter:description" content="The goldfish bowl is a cultural myth. Learn about the nitrogen cycle, biological resilience, and why these intelligent fish deserve a quality life." />
 
   <link rel="stylesheet" href="/css/blogs-bundle.min.css?v=1.0.0">
+  <script defer src="/js/nav.js?v=1.1.0"></script>
 
   <script type="application/ld+json">
   {
@@ -123,8 +125,40 @@
         <h3>What’s the difference between comet goldfish and fancy goldfish?</h3><p>Comet goldfish have streamlined single-tail bodies built for fast swimming and are often best suited for ponds. Fancy goldfish have selectively bred rounded body shapes, double tails, and other specialized traits that make them slower swimmers and more prone to buoyancy issues like swim bladder problems.</p>
         <h3>Can goldfish cycle a new aquarium?</h3><p>Historically, many people used hardy fish like goldfish to start the nitrogen cycle in a new aquarium. Today, most experienced hobbyists recommend fishless cycling methods to avoid exposing fish to toxic ammonia and nitrite spikes.</p>
         <h2>A Small Reminder That Education Matters</h2><p>Recently, I visited one of my old teachers, and she reminded me of something I had completely forgotten.</p><p>Apparently years ago she posted online that she bought goldfish for her kids, and I messaged her explaining some basic care advice so the fish would have a better chance at living long-term.</p><p>She told me one of those fish is still alive today years later.</p><p>Hearing that honestly meant a lot to me.</p><p>Goldfish survived decades of poor care because they’re incredibly resilient animals.</p><p>But resilience should never be mistaken for quality of life.</p>
+        <div class="ttg-ad-slot ttg-house-ad-slot"
+             id="ad-why-goldfish-are-misunderstood-rotator"
+             data-ttg-ad-rotator="true"
+             data-ttg-ad-manifest="/assets/ads/manifest.json"
+             data-ttg-ad-interval="10000"
+             aria-label="Advertisement">
+          <a class="ttg-ad-banner-link" href="/store.html">
+            <img class="ttg-ad-img"
+                 src="/assets/img/ads/Daily-tank-journal-ad.PNG"
+                 alt="Daily Tank Journal promotion"
+                 loading="lazy">
+          </a>
+          <div>
+            <strong>Tools that keep snail tanks stable.</strong>
+            <p style="margin: 6px 0 0;">Log parameters, feeding, and maintenance with our journals and guides.</p>
+          </div>
+        </div>
       </div>
     </article>
   </main>
+  <div class="blog-footer-fade" aria-hidden="true"></div>
+  <script src="/js/footer-loader.js?v=1.5.2" defer></script>
+  <section class="legal-links" aria-label="Site legal links">
+    <a href="/privacy-legal.html">Privacy Policy</a>
+    <a href="/terms.html">Terms</a>
+    <a href="/contact-feedback.html">Contact</a>
+  </section>
+  <noscript>
+    <section class="legal-links" aria-label="Site legal links (noscript)">
+      <a href="/privacy-legal.html">Privacy Policy</a>
+      <a href="/terms.html">Terms</a>
+      <a href="/contact-feedback.html">Contact</a>
+    </section>
+  </noscript>
+  <div id="site-footer" data-footer-src="/footer.html?v=1.5.2"></div>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Ensure blog article pages use the same shared footer include and ad-slot pattern as the reference blog to prevent one-off footers and missing ad placements.
- Restore the missing bottom ad slot on the goldfish article so it matches other blog pages.
- Standardize future blog scaffold usage so all posts inherit the universal footer/ad behavior automatically.

### Description
- Updated `high-tech-vs-low-tech-planted-aquarium/index.html` to replace the one-off `<div id="footer-container">` with the shared mount `<div id="site-footer" data-footer-src="/footer.html?v=1.5.2"></div>` so it uses the `footer-loader.js` pattern.
- Updated `why-goldfish-are-misunderstood/index.html` to add a footer preload (`<link rel="preload" href="/footer.html?v=1.5.2" as="fetch" crossorigin="anonymous">`), reintroduce the shared nav script (`/js/nav.js`), insert the bottom house ad slot markup matching the reference page, and add the `blog-footer-fade`, `footer-loader.js` include, legal links block, and the `#site-footer` mount.
- All added ad/footer markup reuses the existing shared include/template pattern (`footer-loader.js` + `#site-footer[data-footer-src]`) and the same house-ad rotator markup used by the reference blog page, avoiding page-specific footer duplication.
- Files changed: `high-tech-vs-low-tech-planted-aquarium/index.html` and `why-goldfish-are-misunderstood/index.html`.

### Testing
- Verified changed files and content with `git status --short` and file inspections using `nl` to confirm the new `#site-footer` mount and ad-slot insertion, which succeeded.
- Executed the repository guard during commit which reported the footer checksum check and allowed the change with approval, and the commit completed successfully.
- Created the PR metadata using the project's `make_pr` helper to record the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a123ec832588332a597e1f667c35e1a)