### PR TITLE
Set hero image and add inline section images for goldfish article

### DIFF
--- a/why-goldfish-are-misunderstood/index.html
+++ b/why-goldfish-are-misunderstood/index.html
@@ -15,10 +15,12 @@
   <meta property="og:type" content="article" />
   <meta property="og:site_name" content="The Tank Guide" />
   <meta property="og:url" content="https://thetankguide.com/why-goldfish-are-misunderstood/" />
+  <meta property="og:image" content="https://thetankguide.com/assets/images/why-goldfish-are-misunderstood.jpeg" />
 
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Why Goldfish Are the Most Misunderstood Aquarium Fish" />
   <meta name="twitter:description" content="The goldfish bowl is a cultural myth. Learn about the nitrogen cycle, biological resilience, and why these intelligent fish deserve a quality life." />
+  <meta name="twitter:image" content="https://thetankguide.com/assets/images/why-goldfish-are-misunderstood.jpeg" />
 
   <link rel="stylesheet" href="/css/blogs-bundle.min.css?v=1.0.0">
   <script defer src="/js/nav.js?v=1.1.0"></script>
@@ -55,6 +57,7 @@
         "datePublished": "2026-05-23",
         "dateModified": "2026-05-23",
         "mainEntityOfPage": { "@type": "WebPage", "@id": "https://thetankguide.com/why-goldfish-are-misunderstood/" },
+        "image": "https://thetankguide.com/assets/images/why-goldfish-are-misunderstood.jpeg",
         "isPartOf": { "@id": "https://thetankguide.com/#website" },
         "publisher": { "@id": "https://thetankguide.com/#organization" },
         "author": { "@id": "https://thetankguide.com/#organization" },
@@ -90,6 +93,14 @@
         <p class="deck">The Tank Guide<br>Owned and published by FishKeepingLifeCo</p>
       </header>
       <div class="blog-body">
+        <figure class="tg-figure tg-figure--hero">
+          <img
+            src="/assets/images/why-goldfish-are-misunderstood.jpeg"
+            alt="Goldfish in a clear aquarium representing proper goldfish care and habitat."
+            loading="eager"
+            fetchpriority="high"
+            decoding="async">
+        </figure>
         <p>From Sesame Street to American Dad, goldfish bowls are everywhere.</p>
         <p>Cartoons, movies, commercials, classrooms, waiting rooms — for generations, the image of a goldfish swimming around in a tiny glass bowl has been treated as completely normal.</p>
         <p>It’s one of the most recognizable images associated with fishkeeping.</p><p>And honestly, if you grow up seeing it constantly, why would you ever question it?</p><p>Most people don’t.</p>
@@ -98,6 +109,13 @@
         <p>But the strange thing is that most people never actually get to see what goldfish really are.</p>
         <p>They never see the massive comet goldfish gliding through outdoor ponds. Most people don’t realize how long they live, how much space they actually need, or how different a well-kept goldfish looks from the ones sold for cents at the bottom of a feeder tank.</p>
         <p>And honestly, I used to misunderstand them too.</p>
+        <figure class="tg-figure">
+          <img
+            src="/assets/images/One _inch _per _gallon.jpeg"
+            alt="Small aquarium illustrating the limitations behind the one inch per gallon stocking myth."
+            loading="lazy"
+            decoding="async">
+        </figure>
         <h2>The 10-Gallon Aquarium and the “One Inch Per Gallon” Myth</h2>
         <p>I remember being around 11 or 12 years old and wanting fish for the first time. I already had an empty tank sitting in the garage, and I had family members who kept guppies for years.</p>
         <p>Eventually, my younger sister and I went into a pet store to pick out fish.</p>
@@ -114,9 +132,30 @@
         <p>The fish lasted a few weeks before they eventually died.</p><p>At the time, it was just disappointing.</p><p>It took years to understand why those fish died. And longer still to understand what their dying actually meant.</p>
         <p>Years later, after I actually got deeper into fishkeeping and started understanding things like water chemistry, aquarium filtration, oxygen exchange, and the nitrogen cycle, I realized how unfair that setup really was for the fish.</p>
         <h2>Biological Resilience vs. Proper Care</h2><p>Goldfish are descended from wild carp, and that lineage shows. They can handle temperature swings, low oxygen, and water conditions that would kill most tropical fish outright.</p><p>And unfortunately, people often confuse survival with proper care.</p><p>There’s a huge difference between an animal surviving and an animal thriving.</p><p>Goldfish became known as “easy fish” because they could tolerate poor setups longer than many species. Bowls became normalized. Tiny tanks became normalized. Using goldfish to cycle aquariums became normalized.</p><p>But resilience shouldn’t be an excuse for poor care.</p>
+        <figure class="tg-figure">
+          <img
+            src="/assets/images/Klaus_American_dad.jpeg"
+            alt="Pop-culture style goldfish bowl depiction highlighting the myth of keeping goldfish in bowls."
+            loading="lazy"
+            decoding="async">
+        </figure>
         <h2>The Goldfish Bowl Myth</h2><p>What’s interesting is that this problem goes far beyond pet stores.</p><p>It became cultural.</p><p>Even now, I’ll be watching Sesame Street with my kid and see Elmo with a goldfish living in a bowl, and I cringe.</p><p>For decades, pop culture has reinforced the idea that fish bowls are normal.</p><p>Goldfish are active fish. They produce heavy waste. They need oxygen-rich water, stable water quality, and room to move. Comets especially are incredibly athletic fish that can grow surprisingly large in the right environments.</p><p>Most people simply never get to see that side of them.</p>
         <h2>Shifting Perspectives: From Comets to Fancy Goldfish</h2><p>For a long time, I honestly wrote goldfish off.</p><p>Then years later, after I had already started getting more serious about fishkeeping, my sister ended up buying a few goldfish while she was away at college. When it was time for her to leave again, I basically inherited the fish because I knew they weren’t in a good setup.</p><p>At the time, I didn’t even know exactly what type of goldfish they were.</p><p>I remember posting online asking for advice and immediately getting the usual internet reactions:<br>“Poor fish.”<br>“This is terrible.”</p><p>But eventually somebody actually helped identify them and pointed me in the right direction. They turned out to be fancy goldfish, specifically orandas — a variety known for their rounded bodies and distinctive head growth called a wen.</p><p>Once I understood what they needed, I started trying to improve their situation the best I could with the space and resources I had available at the time.</p><p>I ended up setting them up in a 20-gallon long aquarium. Looking back now, I know that still wasn’t ideal long term for a high-bioload species, but at the time I was genuinely trying to do better with the information and resources I had available.</p><p>Ironically, one of the same people criticizing me later messaged me privately.</p><p>He told me he noticed that instead of getting defensive, I actually tried to learn and improve the care for the fish. Then he explained that his girlfriend had impulsively bought a goldfish and added it to his tropical aquarium, and he didn’t know what to do with it.</p><p>So he gave the fish to me.</p><p>That interaction stuck with me because it reminded me that education works a lot better than humiliation in this hobby.</p><p>A lot of people genuinely care. They just start with bad information.</p>
+        <figure class="tg-figure">
+          <img
+            src="/assets/images/goldfish-swim-bladder-disease-oranda-upside-down-aquarium-care-guide.jpeg"
+            alt="Oranda goldfish showing buoyancy trouble associated with swim bladder issues."
+            loading="lazy"
+            decoding="async">
+        </figure>
         <h2>Confronting Swim Bladder Issues</h2><p>One of those goldfish eventually developed what I believe was swim bladder disease.</p><p>It started struggling to stay upright and eventually spent a lot of time floating awkwardly upside down. At the time, this was one of my first real experiences dealing with fish illness.</p><p>I researched everything I could.</p><p>I read about feeding deshelled boiled peas to help digestion and relieve pressure. I went to the grocery store, bought frozen peas, boiled them daily, and tried everything I could think of to help the fish recover.</p><p>The fish eventually passed.</p><p>I remember standing over the tank trying to figure out what else I could have done.</p>
+        <figure class="tg-figure">
+          <img
+            src="/assets/images/comet-goldfish-overcrowded-tank-vs-healthy-pond-comparison.jpeg"
+            alt="Comparison of comet goldfish in cramped tank conditions versus healthy pond conditions."
+            loading="lazy"
+            decoding="async">
+        </figure>
         <h2>Reimagining Comets as Pond Fish</h2><p>Recently, we attended Fitz’s Fish Ponds PlantFest 2026, and it completely brought all of those memories back.</p><p>Seeing large, mature comet goldfish in outdoor ponds was honestly kind of surreal.</p><p>These were the same fish people buy for cents as feeder fish. But in a proper pond environment, they looked completely different: graceful, active, colorful, powerful, and elegant.</p><p>Some of them moved slowly through the water like koi, with long flowing tails trailing behind them in massive schools.</p><p>In that kind of water, comets and commons make sense in a way they never do behind glass.</p><p>Most people only ever see the first stage of a comet goldfish’s life.</p><p>They never get to see what the fish can actually become when given a proper environment instead of a confined space.</p>
         <h2>Goldfish Care and the Things I Wish Someone Told Me Earlier</h2><p>If I could go back and tell that eleven-year-old kid one thing, it wouldn’t be complicated.</p><p>Goldfish are not bowl fish. They’re not disposable pets. And they’re definitely not temporary decorations.</p><p>They need real filtration, real water volume, and stable water conditions. Before adding fish to any aquarium, people should understand the nitrogen cycle, water conditioning, and proper acclimation.</p><p>Single-tail goldfish like comets and commons are generally much better suited for ponds or very large aquariums long term, while many fancy goldfish varieties require slower flow and more specialized care.</p><p>Most importantly:<br>don’t judge a fish by the conditions it’s commonly sold in.</p>
         <h2>Frequently Asked Questions About Goldfish</h2>


### PR DESCRIPTION
### Motivation
- Ensure the article uses the requested hero image and that all inline images are placed above their target headings for clearer visual storytelling.
- Align Open Graph, Twitter card, and BlogPosting schema image references with the new hero so share previews and structured data are consistent.
- Preserve the article text, metadata, footer, and site layout while using the site’s existing responsive figure pattern.

### Description
- Added `og:image` and `twitter:image` meta tags pointing to `https://thetankguide.com/assets/images/why-goldfish-are-misunderstood.jpeg` and added the same absolute URL to the BlogPosting `image` property in the page schema.
- Inserted a top-of-article hero `figure.tg-figure--hero` using `/assets/images/why-goldfish-are-misunderstood.jpeg` with descriptive alt text and eager loading attributes.
- Inserted four inline `figure.tg-figure` images with descriptive alt text immediately above the requested headings using the exact asset paths: `/assets/images/One _inch _per _gallon.jpeg`, `/assets/images/Klaus_American_dad.jpeg`, `/assets/images/goldfish-swim-bladder-disease-oranda-upside-down-aquarium-care-guide.jpeg`, and `/assets/images/comet-goldfish-overcrowded-tank-vs-healthy-pond-comparison.jpeg`.
- Kept all article body copy, headings, ad slot, footer, and other metadata intact and used the site’s existing article image classes to preserve responsive presentation.

### Testing
- Ran `rg -n "why-goldfish-are-misunderstood|Goldfish Bowl Myth|One Inch Per Gallon" .` to locate the source file and confirm targets; command succeeded and returned `why-goldfish-are-misunderstood/index.html`.
- Used `sed -n '1,240p' why-goldfish-are-misunderstood/index.html` and `nl -ba why-goldfish-are-misunderstood/index.html | sed -n '1,230p'` to inspect the file and confirm the meta and image insertions; both commands succeeded and show the new tags and figure elements in place.
- Ran `git diff -- why-goldfish-are-misunderstood/index.html` to verify the exact file changes; this produced the expected diff showing only image/meta insertions.
- A repository integrity check (footer hash) reported a mismatch (footer lock) during the standard commit check and flagged the footer as locked, but the file edits themselves are limited to the article page and metadata only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145bb231e08332adcc6fe886c44332)