### PR TITLE
Fix BlogPosting author to Organization on goldfish article

### DIFF
--- a/why-goldfish-are-misunderstood/index.html
+++ b/why-goldfish-are-misunderstood/index.html
@@ -73,7 +73,7 @@
         "image": "https://thetankguide.com/assets/images/why-goldfish-are-misunderstood.jpeg",
         "isPartOf": { "@id": "https://thetankguide.com/#website" },
         "publisher": { "@id": "https://thetankguide.com/#organization" },
-        "author": { "@id": "https://thetankguide.com/#website" },
+        "author": { "@id": "https://thetankguide.com/#organization" },
         "keywords": ["most misunderstood fish", "goldfish aquarium hobby", "goldfish bowl myth", "aquarium filtration", "nitrogen cycle for beginners"]
       },
       {


### PR DESCRIPTION
### Motivation
- Correct the `BlogPosting.author` reference which was incorrectly pointing to the `WebSite` node so the article author is the publishing `Organization` (FishKeepingLifeCo) while keeping the rest of the graph intact.

### Description
- Updated `why-goldfish-are-misunderstood/index.html` JSON-LD by changing the `BlogPosting` line from `"author": { "@id": "https://thetankguide.com/#website" },` to `"author": { "@id": "https://thetankguide.com/#organization" },` and preserved all other schema nodes and the article content unchanged.

### Testing
- Parsed and validated the page JSON-LD and confirmed `BlogPosting.author` is `https://thetankguide.com/#organization`, `BlogPosting.publisher` is `https://thetankguide.com/#organization`, `BlogPosting.isPartOf` is `https://thetankguide.com/#website`, `Organization` and `WebSite` nodes exist, and `FAQPage` and `BreadcrumbList` remain present; inspected the file diff to confirm a single-line schema edit and verified the article body text was unchanged, and all automated checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14869226088332bf3c2770d0f3c566)