### PR TITLE
Add goldfish article to Core Principles on blog index

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -169,6 +169,9 @@
             "@id": "https://thetankguide.com/aquarium-fertilizers-guide-liquid-root-tabs/"
           },
           {
+            "@id": "https://thetankguide.com/why-goldfish-are-misunderstood/"
+          },
+          {
             "@id": "https://thetankguide.com/blog/holiday-gift-guide-aquarium-lovers.html"
           }
         ]
@@ -239,6 +242,23 @@
         },
         "mainEntityOfPage": "https://thetankguide.com/aquarium-livestock-sourcing-comparison/",
         "datePublished": "2026-02-10"
+      },
+      {
+        "@type": "BlogPosting",
+        "@id": "https://thetankguide.com/why-goldfish-are-misunderstood/",
+        "url": "https://thetankguide.com/why-goldfish-are-misunderstood/",
+        "headline": "Why Goldfish Are the Most Misunderstood Fish in the Aquarium Hobby",
+        "description": "Why goldfish care is often misunderstood: bowl myths, the one-inch-per-gallon mistake, nitrogen cycle basics, and why real space and filtration matter.",
+        "image": "https://thetankguide.com/assets/images/why-goldfish-are-misunderstood.jpeg",
+        "inLanguage": "en-US",
+        "publisher": {
+          "@id": "https://thetankguide.com/#organization"
+        },
+        "author": {
+          "@id": "https://thetankguide.com/#organization"
+        },
+        "mainEntityOfPage": "https://thetankguide.com/why-goldfish-are-misunderstood/",
+        "datePublished": "2026-05-23"
       },
       {
         "@type": "BlogPosting",
@@ -597,6 +617,29 @@
             </h3>
             <p class="card-excerpt">Low maintenance aquariums aren’t about tougher fish. Learn how bioload, tank size, and planning create stability—and why “hardy” is the wrong term for beginners.</p>
             <a class="card-read" href="/low-maintenance-fish-aquariums/">Read the blog →</a>
+          </div>
+        </article>
+        <article class="blog-card">
+          <a class="card-thumb-link" href="/why-goldfish-are-misunderstood/" aria-label="Read: Why Goldfish Are the Most Misunderstood Fish in the Aquarium Hobby">
+            <span class="card-media">
+              <img
+                class="blog-card-image"
+                src="/assets/images/why-goldfish-are-misunderstood.jpeg"
+                alt="Goldfish in a properly sized filtered aquarium"
+                loading="lazy"
+                decoding="async"
+              >
+            </span>
+          </a>
+          <div class="card-content">
+            <p class="card-kicker">
+              <span class="card-author">The Tank Guide</span>
+            </p>
+            <h3 class="card-title">
+              <a href="/why-goldfish-are-misunderstood/">Why Goldfish Are the Most Misunderstood Fish in the Aquarium Hobby</a>
+            </h3>
+            <p class="card-excerpt">A concise guide to common goldfish myths: why bowls fail, why the one-inch-per-gallon rule breaks down, how the nitrogen cycle affects resilience, and why goldfish need real space and filtration to thrive.</p>
+            <a class="card-read" href="/why-goldfish-are-misunderstood/">Read the blog →</a>
           </div>
         </article>
         <article class="blog-card">


### PR DESCRIPTION
### Motivation
- Add the live article page to the main blog index so the goldfish piece is discoverable from `https://thetankguide.com/blogs/` under the correct topic grouping.
- Keep the blog index markup and JSON-LD consistent so the new post appears visually and in structured data without altering unrelated cards.

### Description
- Modified `blogs/index.html` to add a new blog card under the `Core Principles` section using the exact existing card markup and styling pattern (thumb link, image, title, excerpt, and read link). 
- Added the card link `/why-goldfish-are-misunderstood/` with title `Why Goldfish Are the Most Misunderstood Fish in the Aquarium Hobby` and image reference `/assets/images/why-goldfish-are-misunderstood.jpeg` and a concise excerpt aligned to the article topic. 
- Updated the page's JSON-LD by inserting a `hasPart` entry for the new URL and a matching `BlogPosting` object (with `url`, `headline`, `description`, `image`, `mainEntityOfPage`, and `datePublished`) to keep structured data discoverability in sync with the on-page listing. 
- Kept all neighboring cards, sections, and existing markup unmodified and matched attribute patterns like `class=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a149256822883329b4106d681114f28)