### PR TITLE
Add article: 5 Best Beginner Carpeting Plants for Low‑Tech Aquariums

### DIFF
--- a/beginner-carpeting-plants-low-tech/index.html
+++ b/beginner-carpeting-plants-low-tech/index.html
@@ -1,0 +1,283 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <link rel="preload" href="/footer.html?v=1.5.2" as="fetch" crossorigin="anonymous">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>5 Best Beginner Carpeting Plants for Low-Tech Aquariums</title>
+  <meta name="description" content="Want a lush aquarium carpet without expensive CO₂ or high lighting? Discover the 5 best beginner-friendly carpeting plants for low-tech tanks.">
+  <meta name="author" content="The Tank Guide" />
+  <meta name="robots" content="index, follow">
+  <link rel="canonical" href="https://thetankguide.com/beginner-carpeting-plants-low-tech/">
+  <link rel="icon" type="image/png" sizes="16x16" href="/assets/img/logos/favicon-16.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/img/logos/favicon-32.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/Logo-Master-180x180.PNG">
+  <link rel="apple-touch-icon" sizes="512x512" href="/assets/img/Logo-Master-512x512.PNG">
+
+  <meta property="og:title" content="5 Best Beginner Carpeting Plants for Low-Tech Aquariums | The Tank Guide">
+  <meta property="og:description" content="Want a lush aquarium carpet without expensive CO₂ or high lighting? Discover the 5 best beginner-friendly carpeting plants for low-tech tanks.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://thetankguide.com/beginner-carpeting-plants-low-tech/">
+  <meta property="og:site_name" content="The Tank Guide">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Grow an Aquarium Carpet Without CO₂: 5 Best Beginner Plants">
+  <meta name="twitter:description" content="Want a lush aquarium carpet without expensive CO₂ or high lighting? Discover the 5 best beginner-friendly carpeting plants for low-tech tanks.">
+
+  <link rel="stylesheet" href="/css/blogs-bundle.min.css?v=1.0.0">
+  <script defer src="/js/nav.js?v=1.1.0"></script>
+  <script src="/assets/js/consent-mode.js?v=1.5.2" defer></script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "@id": "https://thetankguide.com/#organization",
+        "name": "FishKeepingLifeCo",
+        "alternateName": ["Fish Keeping Life Co", "fishkeepinglife"],
+        "url": "https://thetankguide.com/",
+        "sameAs": [
+          "https://www.instagram.com/FishKeepingLifeCo",
+          "https://www.tiktok.com/@FishKeepingLifeCo",
+          "https://x.com/fishkeepinglife",
+          "https://www.youtube.com/@fishkeepinglifeco",
+          "https://www.facebook.com/fishkeepinglifeco"
+        ]
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://thetankguide.com/#website",
+        "url": "https://thetankguide.com/",
+        "name": "The Tank Guide",
+        "publisher": { "@id": "https://thetankguide.com/#organization" }
+      },
+      {
+        "@type": "WebPage",
+        "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#webpage",
+        "url": "https://thetankguide.com/beginner-carpeting-plants-low-tech/",
+        "name": "5 Best Beginner Carpeting Plants for Low-Tech Aquariums",
+        "description": "Want a lush aquarium carpet without expensive CO₂ or high lighting? Discover the 5 best beginner-friendly carpeting plants for low-tech tanks.",
+        "isPartOf": { "@id": "https://thetankguide.com/#website" },
+        "about": { "@id": "https://thetankguide.com/#organization" },
+        "breadcrumb": { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#breadcrumb" },
+        "mainEntity": [
+          { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#article" },
+          { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#faq" }
+        ]
+      },
+      {
+        "@type": "Article",
+        "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#article",
+        "headline": "5 Best Beginner Carpeting Plants for Low-Tech Aquariums",
+        "description": "Want a lush aquarium carpet without expensive CO₂ or high lighting? Discover the 5 best beginner-friendly carpeting plants for low-tech tanks.",
+        "datePublished": "2026-06-15",
+        "dateModified": "2026-06-15",
+        "mainEntityOfPage": { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#webpage" },
+        "isPartOf": { "@id": "https://thetankguide.com/#website" },
+        "publisher": { "@id": "https://thetankguide.com/#organization" },
+        "author": { "@id": "https://thetankguide.com/#organization" },
+        "keywords": ["beginner carpeting plants", "low-tech carpeting plants", "carpeting plants without CO₂", "easy aquarium carpeting plants", "low-tech aquarium plants", "beginner aquarium plants", "freshwater carpeting plants", "aquarium foreground plants", "carpeting plants for shrimp tanks"]
+      },
+      {
+        "@type": "FAQPage",
+        "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#faq",
+        "url": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#faq",
+        "isPartOf": { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#webpage" },
+        "mainEntityOfPage": { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#webpage" },
+        "mainEntity": [
+          {"@type":"Question","name":"Can you grow an aquarium carpet without CO₂?","acceptedAnswer":{"@type":"Answer","text":"Yes. Several carpeting plants can spread and form attractive foreground coverage without injected CO₂, though growth is usually slower than in high-tech setups."}},
+          {"@type":"Question","name":"What is the easiest carpeting plant for beginners?","acceptedAnswer":{"@type":"Answer","text":"Dwarf Sagittaria is often considered one of the easiest carpeting plants because it spreads through runners, adapts well to different conditions, and grows reliably in low-tech aquariums."}},
+          {"@type":"Question","name":"How long does it take for a carpeting plant to spread?","acceptedAnswer":{"@type":"Answer","text":"Most low-tech carpeting plants take anywhere from a few months to six months or more to establish a noticeable carpet, depending on lighting, nutrients, and plant selection."}},
+          {"@type":"Question","name":"Do carpeting plants need aquasoil?","acceptedAnswer":{"@type":"Answer","text":"No. Many carpeting plants can grow in sand or gravel when supplemented with root tabs or other nutrient sources."}},
+          {"@type":"Question","name":"Are carpeting plants good for shrimp tanks?","acceptedAnswer":{"@type":"Answer","text":"Yes. Carpeting plants create additional surface area for biofilm growth and provide natural grazing areas for shrimp."}},
+          {"@type":"Question","name":"Why is my carpeting plant growing upward instead of spreading?","acceptedAnswer":{"@type":"Answer","text":"Insufficient lighting is one of the most common causes. Plants may stretch vertically in search of more light rather than spreading across the substrate."}},
+          {"@type":"Question","name":"What is the fastest-growing carpeting plant on this list?","acceptedAnswer":{"@type":"Answer","text":"Dwarf Sagittaria is typically the fastest true carpeting plant on this list, while Pearl Weed grows fastest overall but requires trimming and replanting."}},
+          {"@type":"Question","name":"Can Pearl Weed really be used as a carpet?","acceptedAnswer":{"@type":"Answer","text":"Yes. While it is a stem plant rather than a true carpeting plant, regular trimming and replanting can create a dense carpet-like appearance."}},
+          {"@type":"Question","name":"Why is Cryptocoryne parva considered beginner friendly if it grows slowly?","acceptedAnswer":{"@type":"Answer","text":"Its slow growth is balanced by its low maintenance requirements and ability to thrive in stable low-tech aquariums."}},
+          {"@type":"Question","name":"What carpeting plants should beginners avoid?","acceptedAnswer":{"@type":"Answer","text":"Monte Carlo, HC Cuba, Glossostigma, and often Dwarf Hairgrass tend to perform best in higher-tech aquariums with stronger lighting and injected CO₂."}}
+        ]
+      },
+      {
+        "@type": "BreadcrumbList",
+        "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#breadcrumb",
+        "itemListElement": [
+          {"@type":"ListItem","position":1,"name":"Home","item":"https://thetankguide.com/"},
+          {"@type":"ListItem","position":2,"name":"Blog","item":"https://thetankguide.com/blogs/"},
+          {"@type":"ListItem","position":3,"name":"5 Best Beginner Carpeting Plants for Low-Tech Aquariums","item":"https://thetankguide.com/beginner-carpeting-plants-low-tech/"}
+        ]
+      }
+    ]
+  }
+  </script>
+</head>
+<body class="blog-article blog-open-page topic-core">
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <div id="site-nav"></div>
+
+  <nav aria-label="Breadcrumb" class="breadcrumb blog-breadcrumb">
+    <ol>
+      <li><a href="/">Home</a></li>
+      <li style="color: #666;">/</li>
+      <li><a href="/blogs/">Blog</a></li>
+      <li style="color: #666;">/</li>
+      <li aria-current="page">5 Best Beginner Carpeting Plants for Low-Tech Aquariums</li>
+    </ol>
+  </nav>
+
+  <main class="article-layout" id="main-content">
+    <article>
+      <a class="back-link" href="/blogs/" aria-label="Back to all blog posts">← Back to all posts</a>
+
+      <header class="article-header">
+        <h1>5 Best Beginner Carpeting Plants for Low-Tech Aquariums</h1>
+        <p class="deck">The Tank Guide · A FishKeepingLifeCo publication — Jun 2026</p>
+      </header>
+
+      <div class="section-split" aria-hidden="true"></div>
+
+      <div class="blog-body">
+        <p>We’ve all been there.</p>
+        <p>You start looking at beautiful planted aquariums online and before long you’re staring at stunning aquascapes covered in lush green carpeting plants. The rocks are perfectly placed, the plants are immaculate, and the entire aquarium looks like a miniature underwater landscape.</p>
+        <p>Naturally, most of us want to recreate that look in our own aquariums.</p>
+        <p>What often gets left out of the conversation is how many of those showcase aquariums are grown under very different conditions than the average hobbyist tank. Many use high lighting, injected CO₂, nutrient-rich fertilization schedules, and sometimes even start with plants grown immersed before the aquarium is flooded. Those methods can produce incredible results, but they aren’t always the most beginner-friendly path.</p>
+        <p>The good news is that you don’t need a high-tech setup to create a beautiful planted aquarium.</p>
+        <p>In fact, some of the most successful planted tanks are built using simple, low-tech methods focused on patience, consistency, and choosing the right plants. While certain carpeting plants may take longer to establish, many can still spread and create attractive foreground coverage without requiring expensive equipment.</p>
+        <p>That’s why this list focuses on beginner carpeting plants that are low-tech compatible, reasonably forgiving, and capable of producing rewarding results in the average freshwater aquarium.</p>
+
+        <section class="callout" aria-labelledby="direct-answer-heading">
+          <h2 id="direct-answer-heading">Can You Grow a Carpet Without CO₂?</h2>
+          <p><strong>Yes, you can grow a lush aquarium carpet without injected CO₂ using hardy, low-tech plants.</strong> The best beginner carpeting plants for low-tech aquariums are Dwarf Sagittaria, Pygmy Chain Sword, Marsilea hirsuta, Pearl Weed, and Cryptocoryne parva. These plants succeed through consistent care, root nutrition, patience, and stable aquarium conditions.</p>
+        </section>
+
+        <section class="callout" aria-labelledby="featured-list-heading">
+          <h2 id="featured-list-heading">Best Beginner Carpeting Plants at a Glance</h2>
+          <p>The 5 best beginner carpeting plants for low-tech aquariums are:</p>
+          <ol>
+            <li>Dwarf Sagittaria (<em>Sagittaria subulata</em>)</li>
+            <li>Pygmy Chain Sword (<em>Helanthium tenellum</em>)</li>
+            <li><em>Marsilea hirsuta</em></li>
+            <li>Pearl Weed (<em>Hemianthus micranthemoides</em>)</li>
+            <li><em>Cryptocoryne parva</em></li>
+          </ol>
+          <p>These plants can grow successfully without injected CO₂ and are among the most forgiving carpeting options for beginner planted tank hobbyists.</p>
+        </section>
+
+        <h2>What Makes a Good Beginner Carpeting Plant?</h2>
+        <p>Not every carpeting plant is a good choice for beginners. Many popular species require stronger lighting, injected CO₂, and more intensive maintenance than most new hobbyists are prepared for.</p>
+        <p>When putting together this list, we focused on easy aquarium carpeting plants that give hobbyists a realistic chance of success.</p>
+        <ul>
+          <li>Can grow in low-tech aquariums</li>
+          <li>Does not require injected CO₂</li>
+          <li>Readily available in the hobby</li>
+          <li>Forgiving of common beginner mistakes</li>
+          <li>Capable of spreading or covering substrate over time</li>
+          <li>Provides rewarding results without demanding constant maintenance</li>
+        </ul>
+        <p>Root nutrition matters because most freshwater carpeting plants on this list feed heavily from the substrate. Lighting also affects whether many aquarium foreground plants spread sideways or stretch upward. Once you’ve built confidence and experience, there will always be time to experiment with more demanding species later.</p>
+
+        <h3>Quick Comparison: Beginner Carpeting Plants at a Glance</h3>
+        <table>
+          <thead><tr><th>Plant</th><th>Growth Style</th><th>Growth Speed</th><th>CO₂ Required</th><th>Beginner Friendly</th></tr></thead>
+          <tbody>
+            <tr><td>Dwarf Sagittaria</td><td>Runners</td><td>Moderate-Fast</td><td>No</td><td>Excellent</td></tr>
+            <tr><td>Pygmy Chain Sword</td><td>Runners</td><td>Moderate</td><td>No</td><td>Excellent</td></tr>
+            <tr><td>Marsilea hirsuta</td><td>Runners</td><td>Slow</td><td>No</td><td>Excellent</td></tr>
+            <tr><td>Pearl Weed</td><td>Stem Plant</td><td>Fast</td><td>No</td><td>Excellent</td></tr>
+            <tr><td>Cryptocoryne parva</td><td>Rosette</td><td>Very Slow</td><td>No</td><td>Good</td></tr>
+          </tbody>
+        </table>
+        <p>Many hobbyists assume they need injected CO₂ and expensive equipment to grow carpeting plants, but that’s not always true. Several low-tech carpeting plants can spread across the substrate using nothing more than consistent care, patience, and time.</p>
+
+        <h2>1. Dwarf Sagittaria</h2>
+        <p>If someone asks us for the easiest carpeting plant in the hobby, Dwarf Sagittaria—often simply called Dwarf Sag by hobbyists—is probably our first recommendation.</p>
+        <p>This plant has earned a reputation as one of the most beginner-friendly foreground plants available. Given enough time, it produces runners that send new plants across the substrate, gradually filling in open areas of the aquarium.</p>
+        <p>Dwarf Sag has that classic grass-like appearance that most people picture when they think of a carpeting plant. Its bright green blades give aquariums a natural look, and as runners spread throughout the substrate, it can gradually create the appearance of an underwater lawn.</p>
+        <p>One of the things we love most about Dwarf Sag is that it rewards beginners relatively quickly. While no carpeting plant works overnight, Dwarf Sag often begins producing new runners sooner than many of the other plants on this list.</p>
+        <p>Another advantage is its flexibility. It generally tolerates a wide range of aquarium setups, and root tabs can help it spread in sand or gravel. In shrimp tanks, the dense blades create grazing surfaces and shelter for young shrimp.</p>
+        <p>One caution: Dwarf Sag doesn’t always stay as short as people expect. Depending on lighting, nutrients, and overall tank conditions, it can grow taller than a traditional carpet and sometimes behave more like a short foreground or midground plant.</p>
+
+        <h2>2. Pygmy Chain Sword</h2>
+        <p>Pygmy Chain Sword is a carpeting plant that spreads through runners beneath the substrate, gradually sending up new plants as it becomes established. Given enough time, those runners can create a dense carpet that adds texture and depth to the front of an aquarium.</p>
+        <p>The plant has a soft, grassy look that can make an aquarium feel more natural and mature. Rather than looking like a perfectly manicured lawn, Pygmy Chain Sword often resembles a natural meadow or field.</p>
+        <p>Pygmy Chain Sword works well in a wide variety of setups. It looks equally at home in a planted community aquarium, a shrimp tank, or a more carefully designed aquascape. Its ability to blend naturally into almost any layout is one of the reasons it has remained popular with hobbyists for years.</p>
+        <p>Like many rooted low-tech aquarium plants, it benefits from nutrients available in the substrate. Root tabs can help encourage stronger growth and faster spreading, especially in inert substrates.</p>
+        <p>Its main caution is similar to Dwarf Sag: in lower light, it may grow taller and looser instead of staying compact. For most beginner aquarium plants, that is a manageable tradeoff for reliable growth.</p>
+
+        <h2>3. Marsilea hirsuta</h2>
+        <p><em>Marsilea hirsuta</em> is one of those plants that teaches an important lesson in the planted aquarium hobby: slow growth does not mean difficult growth.</p>
+        <p>Unlike some carpeting plants that try to spread quickly, Marsilea tends to take its time. It gradually sends runners through the substrate and slowly fills open areas of the aquarium. The key is remembering that this plant is often working beneath the substrate long before you see significant growth above it.</p>
+        <p>One of the things that makes Marsilea appealing is its adaptability. It can grow in a wide range of aquarium conditions, and many hobbyists have successfully grown it in simple low-tech aquariums.</p>
+        <p>Its appearance is unique compared to many traditional carpeting plants. Depending on conditions, the leaves may resemble tiny clovers, creating a texture that stands out from grass-like foreground plants.</p>
+        <p>Marsilea is particularly well suited for hobbyists who prioritize stability and low maintenance. Once established, it generally requires little intervention beyond routine aquarium care, making it a strong option for patient beginners and peaceful shrimp tanks.</p>
+        <p>The biggest challenge with Marsilea isn’t difficulty—it’s patience. Hobbyists looking for rapid results may become discouraged, but those willing to give the plant time are often rewarded with a unique carpet that fits perfectly into a low-tech aquarium.</p>
+
+        <h2>4. Pearl Weed</h2>
+        <p>Pearl Weed is different from the other plants on this list because it isn’t a traditional carpeting plant. Instead of naturally spreading through runners, Pearl Weed grows as a stem plant. However, with regular trimming and replanting, it can create a dense carpet-like effect that makes it one of the most versatile plants available to beginners.</p>
+        <p>One of the biggest advantages of Pearl Weed is how quickly it grows. Under the right conditions, it can put on noticeable growth in a relatively short period of time, which makes it rewarding for beginners who enjoy seeing progress.</p>
+        <p>The plant itself has small, bright green leaves that can create a lush appearance when grown densely. Left alone, Pearl Weed will continue growing upward like a traditional stem plant. When trimmed regularly, however, it begins to branch out and become much thicker.</p>
+        <p>Because it grows quickly and propagates easily, a small amount can eventually fill a significant portion of an aquarium. It can also work well in shrimp tanks because dense growth provides grazing surfaces and cover.</p>
+        <p>The main caution is that Pearl Weed requires a more hands-on approach than runner-producing carpeting plants. If left unchecked, it will grow upward rather than across the substrate. Hobbyists willing to trim and replant it regularly can create impressive carpet-like results while spending very little money.</p>
+
+        <h2>5. Cryptocoryne parva</h2>
+        <p><em>Cryptocoryne parva</em> is a true carpeting plant, but it’s also one of the slowest-growing plants on this list. That can be both a blessing and a challenge for beginner hobbyists.</p>
+        <p>Unlike many other carpeting plants, Cryptocoryne parva stays naturally compact. Its small, grass-like leaves form low-growing clusters that gradually spread throughout the foreground of an aquarium.</p>
+        <p>One of the reasons Cryptocoryne parva has remained popular for so many years is its ability to thrive in stable, low-tech environments. Like many plants in the Cryptocoryne family, it appreciates stability and tends to perform best when left alone rather than constantly moved or disturbed.</p>
+        <p>The tradeoff for Cryptocoryne parva’s low-maintenance nature is its slow growth. Many beginners expect rapid spreading and become discouraged when they don’t immediately see results.</p>
+        <p>For patient aquarists, Cryptocoryne parva can become a beautiful foreground plant that requires very little maintenance once established. It is also a good choice when you want a neat foreground layout that will not require constant trimming.</p>
+
+        <h2>What Beginners Should Avoid</h2>
+        <p>There are several popular carpeting plants that didn’t make this list, including Monte Carlo, Dwarf Hairgrass, HC Cuba, and Glossostigma.</p>
+        <p>That doesn’t mean they’re bad plants. Many can create some of the most impressive carpets found in the aquarium hobby.</p>
+        <p>The reason we left them off is simple: they often perform best in higher-tech aquariums with stronger lighting, injected CO₂, and more intensive maintenance routines. Dwarf Hairgrass can sometimes work in lower-tech tanks, but it is often frustrating when beginners expect a dense carpet without high light and CO₂.</p>
+        <p>For beginners, it is usually better to start with carpeting plants without CO₂ requirements that offer a higher chance of success while still providing beautiful results.</p>
+
+        <h2>How to Help Carpeting Plants Spread in a Low-Tech Tank</h2>
+        <p>A successful planted aquarium isn’t built by choosing the most demanding plants. It’s built through patience, consistency, and creating a stable environment where plants can thrive.</p>
+        <ul>
+          <li><strong>Use root nutrition.</strong> Root tabs or nutrient-rich substrate help runner plants establish and spread, especially in inert sand or gravel.</li>
+          <li><strong>Provide enough light.</strong> Lighting affects spread versus vertical growth. Too little light often causes plants to stretch upward instead of carpeting.</li>
+          <li><strong>Plant densely when possible.</strong> Starting with more small plant portions shortens the time it takes for the foreground to fill in.</li>
+          <li><strong>Trim and replant stem plants.</strong> Pearl Weed needs regular trimming and replanting to stay low and carpet-like.</li>
+          <li><strong>Keep conditions stable.</strong> Low-tech tanks grow more slowly, so stability matters more than chasing high-tech results.</li>
+          <li><strong>Be patient.</strong> Most low-tech carpets take months, not days, to look established.</li>
+        </ul>
+        <p>Whether you choose Dwarf Sagittaria, Pygmy Chain Sword, Marsilea hirsuta, Pearl Weed, or Cryptocoryne parva, each plant offers a realistic path toward creating a lush planted aquarium without the need for injected CO₂ or complicated equipment.</p>
+        <p>These plants also provide additional surface area throughout the aquarium, creating places for beneficial microorganisms to grow and giving shrimp and other inhabitants more opportunities to forage naturally.</p>
+        <p>At FishKeepingLifeCo, we believe beginners are more likely to enjoy the hobby when they experience success early. The goal isn’t to recreate a competition aquascape overnight. The goal is to build a healthy ecosystem that grows and improves over time.</p>
+
+        <h2 id="faq">FAQ</h2>
+        <h3>Can you grow an aquarium carpet without CO₂?</h3>
+        <p>Yes. Several carpeting plants can spread and form attractive foreground coverage without injected CO₂, though growth is usually slower than in high-tech setups.</p>
+        <h3>What is the easiest carpeting plant for beginners?</h3>
+        <p>Dwarf Sagittaria is often considered one of the easiest carpeting plants because it spreads through runners, adapts well to different conditions, and grows reliably in low-tech aquariums.</p>
+        <h3>How long does it take for a carpeting plant to spread?</h3>
+        <p>Most low-tech carpeting plants take anywhere from a few months to six months or more to establish a noticeable carpet, depending on lighting, nutrients, and plant selection.</p>
+        <h3>Do carpeting plants need aquasoil?</h3>
+        <p>No. Many carpeting plants can grow in sand or gravel when supplemented with root tabs or other nutrient sources.</p>
+        <h3>Are carpeting plants good for shrimp tanks?</h3>
+        <p>Yes. Carpeting plants create additional surface area for biofilm growth and provide natural grazing areas for shrimp.</p>
+        <h3>Why is my carpeting plant growing upward instead of spreading?</h3>
+        <p>Insufficient lighting is one of the most common causes. Plants may stretch vertically in search of more light rather than spreading across the substrate.</p>
+        <h3>What is the fastest-growing carpeting plant on this list?</h3>
+        <p>Dwarf Sagittaria is typically the fastest true carpeting plant on this list, while Pearl Weed grows fastest overall but requires trimming and replanting.</p>
+        <h3>Can Pearl Weed really be used as a carpet?</h3>
+        <p>Yes. While it is a stem plant rather than a true carpeting plant, regular trimming and replanting can create a dense carpet-like appearance.</p>
+        <h3>Why is Cryptocoryne parva considered beginner friendly if it grows slowly?</h3>
+        <p>Its slow growth is balanced by its low maintenance requirements and ability to thrive in stable low-tech aquariums.</p>
+        <h3>What carpeting plants should beginners avoid?</h3>
+        <p>Monte Carlo, HC Cuba, Glossostigma, and often Dwarf Hairgrass tend to perform best in higher-tech aquariums with stronger lighting and injected CO₂.</p>
+      </div>
+    </article>
+  </main>
+  <div class="blog-footer-fade" aria-hidden="true"></div>
+  <script src="/js/footer-loader.js?v=1.5.2" defer></script>
+  <section class="legal-links" aria-label="Site legal links">
+    <a href="/privacy-legal.html">Privacy Policy</a>
+    <a href="/terms.html">Terms</a>
+    <a href="/contact-feedback.html">Contact</a>
+  </section>
+  <div id="site-footer" data-footer-src="/footer.html?v=1.5.2"></div>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Add a polished, SEO‑ready article page for The Tank Guide covering beginner carpeting plants that work in low‑tech tanks and align with specified search intent and metadata. 
- Provide clear extraction‑friendly content blocks (AI Overview/direct answer and featured‑snippet list), structured FAQ, and schema to improve visibility to search engines and answer engines. 

### Description
- Created `beginner-carpeting-plants-low-tech/index.html` containing the article content, one `H1`, skip link, visible breadcrumbs, and the requested H2/H3 structure and educational sections. 
- Set SEO metadata exactly as requested, including `title`, meta description, `canonical` (`https://thetankguide.com/beginner-carpeting-plants-low-tech/`), Open Graph and Twitter/X fields; left `og:image` unset to allow normal site fallback for a future hero asset. 
- Added visible AI Overview/direct answer block and the featured‑snippet style ordered list near the top using the exact provided wording. 
- Implemented JSON‑LD for `Article`/`WebPage`/`WebSite`/`Organization`, `FAQPage`, and `BreadcrumbList` with absolute URLs and connected nodes, and included a visible FAQ section that matches the FAQ schema. 
- Did not modify any blog index or listing surfaces and left the page ready for a hero image to be added later. 

### Testing
- Ran a `python3` validation script which confirmed the canonical URL is present, exactly one `H1`, absence of an invented `og:image` path, valid JSON‑LD parsing, and 10 visible FAQ questions (passed). 
- `git diff --check` reported no issues and the file was committed successfully after precommit hooks ran `npm run guard:live` (hook passed). 
- `npm run guard:blog-ads` failed during testing due to an unrelated existing ad‑slot mismatch for a different page, not caused by this change (flagged as unrelated). 
- Confirmed the page file added at `beginner-carpeting-plants-low-tech/index.html` and that the slug is not present in any blog index (page not added to blog listing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308875f9c48332b80e4eadf0c44370)