### PR TITLE
Left-align carpeting plants article layout

### DIFF
--- a/beginner-carpeting-plants-low-tech/index.html
+++ b/beginner-carpeting-plants-low-tech/index.html
@@ -25,6 +25,29 @@
   <meta name="twitter:description" content="Want a lush aquarium carpet without expensive CO₂ or high lighting? Discover the 5 best beginner-friendly carpeting plants for low-tech tanks.">
 
   <link rel="stylesheet" href="/css/blogs-bundle.min.css?v=1.0.0">
+  <style>
+    @media (min-width: 900px) {
+      body.carpeting-left-layout .blog-breadcrumb,
+      body.carpeting-left-layout main.article-layout {
+        width: min(calc(100% - clamp(4rem, 18vw, 18rem)), var(--article-shell-max));
+        margin-left: clamp(2rem, 8vw, 8rem);
+        margin-right: auto;
+      }
+
+      body.carpeting-left-layout .article-layout article,
+      body.carpeting-left-layout .article-header,
+      body.carpeting-left-layout .tg-figure--hero,
+      body.carpeting-left-layout .section-split,
+      body.carpeting-left-layout .blog-body {
+        margin-left: 0;
+        margin-right: 0;
+      }
+
+      body.carpeting-left-layout .article-header {
+        text-align: left;
+      }
+    }
+  </style>
   <script defer src="/js/nav.js?v=1.1.0"></script>
   <script src="/assets/js/consent-mode.js?v=1.5.2" defer></script>
 
@@ -112,7 +135,7 @@
   }
   </script>
 </head>
-<body class="blog-article blog-open-page topic-core">
+<body class="blog-article blog-open-page topic-core carpeting-left-layout">
   <a href="#main-content" class="skip-link">Skip to content</a>
   <div id="site-nav"></div>
 


### PR DESCRIPTION
### Motivation
- The article at `beginner-carpeting-plants-low-tech/` should use a left-weighted editorial column on desktop rather than the site-wide centered blog shell. 
- The change must be page-specific and preserve all article text, metadata, FAQ/schema, hero image, and responsive behavior.

### Description
- Added a page-specific body class and lightweight CSS override inside `beginner-carpeting-plants-low-tech/index.html` to introduce `carpeting-left-layout` and desktop-only layout rules. 
- The override shifts the breadcrumb and `main.article-layout` left by setting a controlled `width` and `margin-left`, while keeping `margin-right: auto` to preserve right whitespace and the existing `--article-shell-max`. 
- Overrode centering for the article sub-containers (`.article-layout article`, `.article-header`, `.tg-figure--hero`, `.section-split`, `.blog-body`) so hero, intro/deck, featured lists, body, and FAQ align consistently in the new left column. 
- No article copy, headings, schema, breadcrumb logic, blog index status, hero asset files, or shared CSS files were modified; the change is page-specific.

### Testing
- Ran a visible-text comparison (`python3` HTML parse assertion) against the pre-change version to confirm that page/article text is unchanged and the edit only added layout markers; this check passed. 
- Asserted the presence of the injected desktop CSS markers and body class in the modified file; this check passed. 
- Ran `git diff --check`/whitespace checks as part of the workflow and observed no whitespace errors. 
- Attempted browser-based screenshot validation via Playwright but the environment blocked browser downloads (Playwright Chromium install returned HTTP 403), so full headless screenshot verification was environment-blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a308e9c5e7c8332b87119976c32a49e)