### PR TITLE
Fix mobile article centering for carpeting plants page

### DIFF
--- a/beginner-carpeting-plants-low-tech/index.html
+++ b/beginner-carpeting-plants-low-tech/index.html
@@ -26,6 +26,39 @@
 
   <link rel="stylesheet" href="/css/blogs-bundle.min.css?v=1.0.0">
   <style>
+    @media (max-width: 640px) {
+      body.carpeting-left-layout .blog-breadcrumb,
+      body.carpeting-left-layout main.article-layout {
+        box-sizing: border-box;
+        width: 100%;
+        max-width: var(--article-shell-max);
+        margin-left: auto;
+        margin-right: auto;
+      }
+
+      body.carpeting-left-layout main.article-layout {
+        padding-left: clamp(1rem, 5vw, 1.5rem);
+        padding-right: clamp(1rem, 5vw, 1.5rem);
+      }
+
+      body.carpeting-left-layout .blog-breadcrumb {
+        padding-left: clamp(1rem, 5vw, 1.5rem);
+        padding-right: clamp(1rem, 5vw, 1.5rem);
+      }
+
+      body.carpeting-left-layout .article-layout article,
+      body.carpeting-left-layout .article-header,
+      body.carpeting-left-layout .tg-figure--hero,
+      body.carpeting-left-layout .section-split,
+      body.carpeting-left-layout .blog-body {
+        box-sizing: border-box;
+        width: 100%;
+        max-width: var(--article-body-max);
+        margin-left: auto;
+        margin-right: auto;
+      }
+    }
+
     @media (min-width: 900px) {
       body.carpeting-left-layout .blog-breadcrumb,
       body.carpeting-left-layout main.article-layout {


### PR DESCRIPTION
### Motivation
- Mobile layout on the beginner carpeting plants article had the article column hugging the left edge and leaving a large blank right margin at small viewports, so the content needed to be centred or allowed to occupy full width with balanced padding on small screens.

### Description
- Added a mobile-only CSS override (`@media (max-width: 640px)`) in `beginner-carpeting-plants-low-tech/index.html` to make `.blog-breadcrumb` and `main.article-layout` use `width: 100%`, `max-width: var(--article-shell-max)`, and `margin-left/right: auto` with responsive `padding-left/right` so the column is centred on small screens.
- Applied matching `box-sizing`, `width`, `max-width`, and `margin-left/right: auto` rules to the article-level elements (`.article-layout article`, `.article-header`, `.tg-figure--hero`, `.section-split`, `.blog-body`) so hero, headings, callout/AI overview blocks, and FAQs align consistently inside the centred container.
- Preserved the existing desktop `@media (min-width: 900px)` left-layout behavior and left all header/footer/schema/script/ad-slot references unchanged.

### Testing
- Ran `git diff --check` and a local static verification script which confirmed the new mobile media query, the retained desktop query, presence of the schema script, the header mount, and the footer mount, and that no ad slot was introduced (passed).
- Executed `npm run guard:blog-ads` which surfaced an unrelated existing ad-slot guard mismatch for another page (guard failed for that unrelated check).
- Attempted browser-based verification via Playwright but `npx playwright install` was blocked by a Playwright CDN `403 Forbidden`, so visual Playwright screenshots/layout checks could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3092116d088332a5f0d39e3c9b37e7)