### PR TITLE
Remove top callout cards from beginner carpeting plants article

### DIFF
--- a/beginner-carpeting-plants-low-tech/index.html
+++ b/beginner-carpeting-plants-low-tech/index.html
@@ -202,24 +202,6 @@
         <p>In fact, some of the most successful planted tanks are built using simple, low-tech methods focused on patience, consistency, and choosing the right plants. While certain carpeting plants may take longer to establish, many can still spread and create attractive foreground coverage without requiring expensive equipment.</p>
         <p>That’s why this list focuses on beginner carpeting plants that are low-tech compatible, reasonably forgiving, and capable of producing rewarding results in the average freshwater aquarium.</p>
 
-        <section class="callout" aria-labelledby="direct-answer-heading">
-          <h2 id="direct-answer-heading">Can You Grow a Carpet Without CO₂?</h2>
-          <p><strong>Yes, you can grow a lush aquarium carpet without injected CO₂ using hardy, low-tech plants.</strong> The best beginner carpeting plants for low-tech aquariums are Dwarf Sagittaria, Pygmy Chain Sword, Marsilea hirsuta, Pearl Weed, and Cryptocoryne parva. These plants succeed through consistent care, root nutrition, patience, and stable aquarium conditions.</p>
-        </section>
-
-        <section class="callout" aria-labelledby="featured-list-heading">
-          <h2 id="featured-list-heading">Best Beginner Carpeting Plants at a Glance</h2>
-          <p>The 5 best beginner carpeting plants for low-tech aquariums are:</p>
-          <ol>
-            <li>Dwarf Sagittaria (<em>Sagittaria subulata</em>)</li>
-            <li>Pygmy Chain Sword (<em>Helanthium tenellum</em>)</li>
-            <li><em>Marsilea hirsuta</em></li>
-            <li>Pearl Weed (<em>Hemianthus micranthemoides</em>)</li>
-            <li><em>Cryptocoryne parva</em></li>
-          </ol>
-          <p>These plants can grow successfully without injected CO₂ and are among the most forgiving carpeting options for beginner planted tank hobbyists.</p>
-        </section>
-
         <h2>What Makes a Good Beginner Carpeting Plant?</h2>
         <p>Not every carpeting plant is a good choice for beginners. Many popular species require stronger lighting, injected CO₂, and more intensive maintenance than most new hobbyists are prepared for.</p>
         <p>When putting together this list, we focused on easy aquarium carpeting plants that give hobbyists a realistic chance of success.</p>


### PR DESCRIPTION
### Motivation
- The two prominent card-style callouts at the top of the article were oversized on mobile and disrupted the flow into the main article content.

### Description
- Removed the two visible callout sections from `beginner-carpeting-plants-low-tech/index.html` so the intro now flows directly into the "What Makes a Good Beginner Carpeting Plant?" section.
- Kept all metadata, JSON-LD (Article/FAQ/Breadcrumb) schema, footer loading, and the rest of the article content unchanged.
- Cleaned up surrounding spacing so no empty wrappers, extra gaps, or broken borders remain after removal.

### Testing
- Verified the headings were removed with `rg -n "Can You Grow a Carpet Without CO₂|Best Beginner Carpeting Plants at a Glance|direct-answer-heading|featured-list-heading"` and ran `git diff --check` with no issues.
- Parsed the HTML with `python3` and parsed the `application/ld+json` block with `node` to confirm schema and footer markers remain intact.
- Attempted Playwright mobile/desktop screenshot checks but browser install failed due to a Playwright CDN `403 Forbidden`, so live screenshots were not generated; source-level checks confirm the visible cards are gone and the article transitions cleanly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a8c8795748332b68d55cd083dcc02)