### PR TITLE
Add bottom ad slot to carpeting plants article

### DIFF
--- a/beginner-carpeting-plants-low-tech/index.html
+++ b/beginner-carpeting-plants-low-tech/index.html
@@ -398,6 +398,24 @@
         <h3>What carpeting plants should beginners avoid?</h3>
         <p>Monte Carlo, HC Cuba, Glossostigma, and often Dwarf Hairgrass tend to perform best in higher-tech aquariums with stronger lighting and injected CO₂.</p>
       </div>
+
+      <div class="ttg-ad-slot ttg-house-ad-slot"
+           id="ad-beginner-carpeting-plants-rotator"
+           data-ttg-ad-rotator="true"
+           data-ttg-ad-manifest="/assets/ads/manifest.json"
+           data-ttg-ad-interval="10000"
+           aria-label="Advertisement">
+        <a class="ttg-ad-banner-link" href="/store.html">
+          <img class="ttg-ad-img"
+               src="/assets/img/ads/Daily-tank-journal-ad.PNG"
+               alt="Daily Tank Journal promotion"
+               loading="lazy">
+        </a>
+        <div>
+          <strong>Build stable planted systems with confidence.</strong>
+          <p style="margin: 6px 0 0;">Track plant growth, maintenance, and tank changes with our journals and guides.</p>
+        </div>
+      </div>
     </article>
   </main>
   <div class="blog-footer-fade" aria-hidden="true"></div>


### PR DESCRIPTION
### Motivation
- Add the Tank Guide custom bottom house ad slot to the carpeting-plants article so this page matches the site’s approved blog ad-slot pattern and displays the same bottom house/rotator unit used on other Tank Guide posts.

### Description
- Inserted the custom bottom ad slot into `beginner-carpeting-plants-low-tech/index.html` immediately after the article body (after the FAQ) and before the footer, matching the implementation and wrapper/classes/attributes from `planted-aquarium-substrate-guide-aquasoil-dirt/index.html` (`.ttg-ad-slot ttg-house-ad-slot`, `data-ttg-ad-rotator`, `data-ttg-ad-manifest`, image/link markup and spacing).

### Testing
- Ran `git diff --check` (passed), compared the extracted `.blog-body` text from HEAD to the edited file to confirm article copy is unchanged (passed), and programmatically verified exactly one new slot exists and that it sits after the FAQ and before `#site-footer` (passed); attempted desktop/mobile Playwright rendering checks but the Chromium browser download failed from the Playwright CDN (403) so visual browser tests were blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b5575012c83328ba337421ee8733e)