### PR TITLE
Fix carpeting plants page SEO and accessibility

### DIFF
--- a/beginner-carpeting-plants-low-tech/index.html
+++ b/beginner-carpeting-plants-low-tech/index.html
@@ -114,6 +114,14 @@
         "publisher": { "@id": "https://thetankguide.com/#organization" }
       },
       {
+        "@type": "Organization",
+        "@id": "https://thetankguide.com/#editorial-team",
+        "name": "The Tank Guide Editorial Team",
+        "url": "https://thetankguide.com/about.html",
+        "parentOrganization": { "@id": "https://thetankguide.com/#organization" },
+        "isPartOf": { "@id": "https://thetankguide.com/#website" }
+      },
+      {
         "@type": "WebPage",
         "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#webpage",
         "url": "https://thetankguide.com/beginner-carpeting-plants-low-tech/",
@@ -124,6 +132,7 @@
         "breadcrumb": { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#breadcrumb" },
         "mainEntity": [
           { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#article" },
+          { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#howto" },
           { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#faq" }
         ]
       },
@@ -138,8 +147,25 @@
         "mainEntityOfPage": { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#webpage" },
         "isPartOf": { "@id": "https://thetankguide.com/#website" },
         "publisher": { "@id": "https://thetankguide.com/#organization" },
-        "author": { "@id": "https://thetankguide.com/#organization" },
+        "author": { "@id": "https://thetankguide.com/#editorial-team" },
         "keywords": ["beginner carpeting plants", "low-tech carpeting plants", "carpeting plants without CO₂", "easy aquarium carpeting plants", "low-tech aquarium plants", "beginner aquarium plants", "freshwater carpeting plants", "aquarium foreground plants", "carpeting plants for shrimp tanks"]
+      },
+      {
+        "@type": "HowTo",
+        "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#howto",
+        "url": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#how-to-help-carpeting-plants-spread-in-a-low-tech-tank",
+        "name": "How to Help Carpeting Plants Spread in a Low-Tech Tank",
+        "description": "A visible step-by-step section for encouraging low-tech aquarium carpeting plants to spread through root nutrition, lighting, dense planting, trimming, stability, and patience.",
+        "isPartOf": { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#webpage" },
+        "mainEntityOfPage": { "@id": "https://thetankguide.com/beginner-carpeting-plants-low-tech/#webpage" },
+        "step": [
+          { "@type": "HowToStep", "position": 1, "name": "Use root nutrition", "text": "Root tabs or nutrient-rich substrate help runner plants establish and spread, especially in inert sand or gravel." },
+          { "@type": "HowToStep", "position": 2, "name": "Provide enough light", "text": "Lighting affects spread versus vertical growth. Too little light often causes plants to stretch upward instead of carpeting." },
+          { "@type": "HowToStep", "position": 3, "name": "Plant densely when possible", "text": "Starting with more small plant portions shortens the time it takes for the foreground to fill in." },
+          { "@type": "HowToStep", "position": 4, "name": "Trim and replant stem plants", "text": "Pearl Weed needs regular trimming and replanting to stay low and carpet-like." },
+          { "@type": "HowToStep", "position": 5, "name": "Keep conditions stable", "text": "Low-tech tanks grow more slowly, so stability matters more than chasing high-tech results." },
+          { "@type": "HowToStep", "position": 6, "name": "Be patient", "text": "Most low-tech carpets take months, not days, to look established." }
+        ]
       },
       {
         "@type": "FAQPage",
@@ -175,21 +201,87 @@
 </head>
 <body class="blog-article blog-open-page topic-core carpeting-left-layout">
   <a href="#main-content" class="skip-link">Skip to content</a>
-  <div id="site-nav"></div>
+  <div id="site-nav">
+    <header id="global-nav">
+      <div class="inner">
+        <button
+          id="ttg-nav-open"
+          class="hamburger"
+          type="button"
+          aria-controls="ttg-drawer"
+          aria-expanded="false"
+          aria-label="Open menu"
+          data-nav="hamburger"
+        >
+          <span class="hamburger__bars" aria-hidden="true"></span>
+        </button>
+        <a class="site-brand brand" href="/" aria-label="The Tank Guide — Home">
+          <span class="site-brand__title">The Tank Guide</span>
+          <span class="site-brand__subtitle">a product of <span class="site-brand__em">FishKeepingLifeCo</span></span>
+        </a>
+        <nav class="site-links links" aria-label="Primary">
+          <ul class="nav__list">
+            <li class="nav__item"><a href="/" class="nav__link" data-nav="home">Home</a></li>
+            <li class="nav__item"><a href="/stocking-advisor.html" class="nav__link" data-nav="stocking">Stocking Advisor</a></li>
+            <li class="nav__item"><a href="/gear/" class="nav__link" data-nav="gear">Gear</a></li>
+            <li class="nav__item"><a href="/cycling-coach/" class="nav__link" data-nav="params">Cycling Coach</a></li>
+            <li class="nav__item"><a href="/community-tanks.html" class="nav__link" data-nav="community-tanks">Community Tanks</a></li>
+            <li class="nav__item"><a href="/podcast/" class="nav__link" data-nav="podcast">Podcast</a></li>
+            <li class="nav__item"><a href="/media.html" class="nav__link" data-nav="media">Media</a></li>
+            <li class="nav__item"><a href="/store.html" class="nav__link" data-nav="store">Store</a></li>
+            <li class="nav__item"><a href="/about.html" class="nav__link" data-nav="about">About</a></li>
+            <li class="nav__item"><a href="/assistant.html" class="nav__link" data-nav="assistant">AI Assistant</a></li>
+          </ul>
+        </nav>
+      </div>
+      <aside
+        id="ttg-drawer"
+        aria-label="Site"
+        data-nav="drawer"
+        aria-hidden="true"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="drawer-title"
+      >
+        <h2 id="drawer-title" class="ttg-visually-hidden">Site navigation</h2>
+        <div class="drawer-head">
+          <span class="drawer-title">The Tank Guide</span>
+          <button id="drawer-close" class="drawer-close" type="button" aria-label="Close menu" data-nav="drawer-close">
+            <span aria-hidden="true">×</span>
+          </button>
+        </div>
+        <nav class="drawer-links" aria-label="Mobile">
+          <ul class="nav__list nav__list--drawer">
+            <li class="nav__item"><a id="drawer-first" href="/" class="nav__link" data-nav="home">Home</a></li>
+            <li class="nav__item"><a href="/stocking-advisor.html" class="nav__link" data-nav="stocking">Stocking Advisor</a></li>
+            <li class="nav__item"><a href="/gear/" class="nav__link" data-nav="gear">Gear</a></li>
+            <li class="nav__item"><a href="/cycling-coach/" class="nav__link" data-nav="params">Cycling Coach</a></li>
+            <li class="nav__item"><a href="/community-tanks.html" class="nav__link" data-nav="community-tanks">Community Tanks</a></li>
+            <li class="nav__item"><a href="/podcast/" class="nav__link" data-nav="podcast">Podcast</a></li>
+            <li class="nav__item"><a href="/media.html" class="nav__link" data-nav="media">Media</a></li>
+            <li class="nav__item"><a href="/store.html" class="nav__link" data-nav="store">Store</a></li>
+            <li class="nav__item"><a href="/about.html" class="nav__link" data-nav="about">About</a></li>
+            <li class="nav__item"><a href="/assistant.html" class="nav__link" data-nav="assistant">AI Assistant</a></li>
+          </ul>
+        </nav>
+      </aside>
+      <div id="ttg-overlay" data-nav="overlay" aria-hidden="true"></div>
+    </header>
+  </div>
 
   <nav aria-label="Breadcrumb" class="breadcrumb blog-breadcrumb">
     <ol>
       <li><a href="/">Home</a></li>
-      <li style="color: #666;">/</li>
+      <li style="color: #666;" aria-hidden="true">/</li>
       <li><a href="/blogs/">Blog</a></li>
-      <li style="color: #666;">/</li>
+      <li style="color: #666;" aria-hidden="true">/</li>
       <li aria-current="page">5 Best Beginner Carpeting Plants for Low-Tech Aquariums</li>
     </ol>
   </nav>
 
   <main class="article-layout" id="main-content">
     <article>
-      <a class="back-link" href="/blogs/" aria-label="Back to all blog posts">← Back to all posts</a>
+      <a class="back-link" href="/blogs/" aria-label="Back to all blog posts"><span aria-hidden="true">← </span>Back to all posts</a>
 
       <header class="article-header">
         <h1>5 Best Beginner Carpeting Plants for Low-Tech Aquariums</h1>
@@ -362,7 +454,7 @@
           >
         </figure>
 
-        <h2>How to Help Carpeting Plants Spread in a Low-Tech Tank</h2>
+        <h2 id="how-to-help-carpeting-plants-spread-in-a-low-tech-tank">How to Help Carpeting Plants Spread in a Low-Tech Tank</h2>
         <p>A successful planted aquarium isn’t built by choosing the most demanding plants. It’s built through patience, consistency, and creating a stable environment where plants can thrive.</p>
         <ul>
           <li><strong>Use root nutrition.</strong> Root tabs or nutrient-rich substrate help runner plants establish and spread, especially in inert sand or gravel.</li>
@@ -425,6 +517,18 @@
     <a href="/terms.html">Terms</a>
     <a href="/contact-feedback.html">Contact</a>
   </section>
-  <div id="site-footer" data-footer-src="/footer.html?v=1.5.2"></div>
+  <div id="site-footer" data-footer-src="/footer.html?v=1.5.2">
+    <nav class="footer-links" aria-label="Footer fallback links">
+      <a href="/trust-security.html">Trust &amp; Security</a>
+      <span class="dot" aria-hidden="true">·</span>
+      <a href="/cookie-settings.html">Cookie Settings</a>
+      <span class="dot" aria-hidden="true">·</span>
+      <a href="/cookie-settings.html">Do Not Sell or Share My Personal Information</a>
+      <span class="dot" aria-hidden="true">·</span>
+      <a href="/store.html">Store</a>
+      <span class="dot" aria-hidden="true">·</span>
+      <a href="/copyright-dmca.html">Copyright &amp; DMCA</a>
+    </nav>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Repair multiple SEO/JSON-LD and accessibility issues on the article so search engines and assistive tech see a complete, connected page graph and usable navigation/footer without relying solely on client-side JS. 
- Add machine-readable HowTo data for the visible instructional section and map the article author to a truthful editorial entity while preserving FishKeepingLifeCo as the publisher. 
- Make breadcrumb separators and the back-link arrow decorative to avoid screen readers announcing them, and ensure critical nav/footer pathways have server-rendered fallbacks.

### Description
- Files changed: `beginner-carpeting-plants-low-tech/index.html` only. 
- Added a connected `HowTo` JSON-LD node at `https://thetankguide.com/beginner-carpeting-plants-low-tech/#howto` with `6` `HowToStep` entries that exactly reflect the visible on-page steps, and included that node in the page `mainEntity` list. 
- Introduced an `Organization` node for the editorial group at `https://thetankguide.com/#editorial-team` and updated the Article `author` to reference that editorial entity while leaving `publisher` referencing `https://thetankguide.com/#organization` (FishKeepingLifeCo), preserving the WebSite→Organization relationship. 
- Added progressive server-rendered fallbacks so `#site-nav` contains the site header/nav markup and `#site-footer` contains a minimal footer links fallback (the existing `/js/footer-loader.js` loader and canonical `footer.html` remain in place and unchanged). 
- Accessibility fixes: breadcrumb visual separators now include `aria-hidden="true"`, the back-link arrow was wrapped as `<span aria-hidden="true">← </span>` to hide the glyph from assistive tech, and the HowTo section heading was given an id to match the HowTo `url`. 
- Preserved article content, hero image, inline images, ad slot, headings, and layout; no wording was changed.

### Testing
- Static JSON-LD/accessibility checks (`node` validation script) confirmed the presence of `#organization`, `#website`, `#editorial-team`, `#webpage`, `#article`, `#howto`, `#faq`, and `#breadcrumb` nodes and that the `HowTo` node contains exactly 6 steps (passed). 
- Article body comparison script validated that the article body text (visible content between `.blog-body` and the ad slot) is unchanged (passed). 
- Project guard script `npm run guard:live` ran and passed local repository checks (passed). 
- Attempted automated browser render checks with Playwright were blocked by the environment when trying to download Chromium (download CDN returned 403), so headless browser rendering could not be executed here (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b594da3dc8332a014a3989cc174a6)