### PR TITLE
Update blog sitemap coverage

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -216,10 +216,10 @@
 
   <url>
     <loc>https://thetankguide.com/diy-sump-lessons-learned.html</loc>
+    <lastmod>2026-01-20</lastmod>
     <changefreq>monthly</changefreq>
-    <priority>0.80</priority>
+    <priority>0.8</priority>
   </url>
-
 
   <url>
     <loc>https://thetankguide.com/neocaridina-shrimp-diet-biofilm-guide/</loc>
@@ -271,7 +271,7 @@
   </url>
 
   <url>
-    <loc>https://thetankguide.com/reduce-aquarium-nitrates-pothos-guide.html</loc>
+    <loc>https://thetankguide.com/reduce-aquarium-nitrates-pothos-guide</loc>
     <lastmod>2026-01-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
@@ -417,6 +417,13 @@
   <url>
     <loc>https://thetankguide.com/why-goldfish-are-misunderstood/</loc>
     <lastmod>2026-05-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://thetankguide.com/beginner-carpeting-plants-low-tech/</loc>
+    <lastmod>2026-06-15</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
### Motivation
- Ensure the live `sitemap.xml` includes every current blog/article canonical URL so search engines can index newly created and recently updated posts. 
- Normalize URL forms and metadata in the sitemap to match the canonical paths used across the site.

### Description
- Edited the live sitemap source `sitemap.xml` to add and normalize blog entries. 
- Added `https://thetankguide.com/beginner-carpeting-plants-low-tech/` with a `lastmod`, `changefreq`, and `priority` entry matching the sitemap style. 
- Normalized the `reduce-aquarium-nitrates-pothos-guide` entry to the canonical path `https://thetankguide.com/reduce-aquarium-nitrates-pothos-guide` (removed the `.html` variant). 
- Added a missing `lastmod` and normalized `priority` formatting for `https://thetankguide.com/diy-sump-lessons-learned.html` and kept all other sitemap fields consistent with site conventions.

### Testing
- Ran `git diff --check` to ensure no whitespace/format errors were introduced, which returned clean. 
- Ran a Python XML validation script that parsed `sitemap.xml`, confirmed well-formed XML, verified all `<loc>` values are absolute `https://thetankguide.com` URLs, and confirmed there are no duplicate `<loc>` entries. 
- Verified the required blog canonical URLs (the six specified plus older pages) are present in the sitemap using a canonical audit script against the repo HTML files. 
- Confirmed `robots.txt` references `https://thetankguide.com/sitemap.xml` so crawlers will discover the updated sitemap.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b5dacd6a8833289856eb36ccccafb)