### PR TITLE
Fix journal heading styling and remove special entry card tilt

### DIFF
--- a/css/journal.css
+++ b/css/journal.css
@@ -1117,3 +1117,50 @@ button:focus {
         border: 1px solid #ccc;
     }
 }
+
+/* ========================================
+   BALANCE EXPERIMENT JOURNAL ENTRY FIXES
+   ========================================
+   Keep long-form journal entries on the legal-pad theme even when the
+   shared app bundle applies dark-theme heading/link overrides globally.
+*/
+
+.journal-card,
+.journal-card:hover,
+.journal-card:focus-within {
+    transform: none;
+}
+
+.card-header h3,
+.card-header h3 a,
+.card-body h4,
+.card-body h5,
+.card-body h6 {
+    color: #2c7a7b !important;
+    -webkit-text-fill-color: #2c7a7b !important;
+    text-decoration: none;
+    text-shadow: none;
+}
+
+.card-header h3 a:hover,
+.card-header h3 a:focus {
+    color: #285e61 !important;
+    -webkit-text-fill-color: #285e61 !important;
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 0.18em;
+}
+
+.card-body h4,
+.card-body h5,
+.card-body h6 {
+    margin: 1.25rem 0 0.75rem;
+    font-weight: 700;
+    line-height: 1.3;
+}
+
+.card-body h4:first-child,
+.card-body h5:first-child,
+.card-body h6:first-child {
+    margin-top: 0;
+}


### PR DESCRIPTION
### Motivation
- Long-form Balance Experiment entries were inheriting global light/white text and link styles and a slight hover rotation, causing headings to appear silver/underlined and the card to look tilted.
- The intent is to restore the legal-pad journal design (dark/teal headings, no unintended underlines, no tilt) without changing any journal content or overall layout.

### Description
- Modified `css/journal.css` to add scoped overrides under a "BALANCE EXPERIMENT JOURNAL ENTRY FIXES" block so the changes apply only to journal cards.
- Neutralized card transforms by overriding `.journal-card`, `.journal-card:hover`, and `.journal-card:focus-within` with `transform: none;` to remove the 0.5deg hover rotation.
- Forced readable heading color on card headers and in-card section headings by setting `.card-header h3`, `.card-header h3 a`, and `.card-body h4,h5,h6` to `color: #2c7a7b !important` and clearing `text-decoration` so headings no longer look like links.
- Kept underlines only for actual links on hover/focus by restoring an underline on `.card-header h3 a:hover`/`:focus` while preserving the notebook background, red margin line, spacing, shadows, typography, and layout.

### Testing
- Ran `git diff --check` which returned clean output for the changed file.
- Ran `npx stylelint css/journal.css` which reported pre-existing `selector-class-pattern` errors across `css/journal.css` (173 errors) unrelated to the small override block; the stylelint run failed on those historical violations.
- Attempted to capture screenshots and validate computed styles via Playwright but `npx playwright install` failed due to Playwright CDN download `403` errors in this environment, so automated screenshot capture could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6ebf58d883329c4aa865b58ba67e)