### PR TITLE
Add heat-wave aquarium cooling guide page

### DIFF
--- a/cool-down-fish-tank/index.html
+++ b/cool-down-fish-tank/index.html
@@ -1,0 +1,436 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <!-- Google Tag Manager -->
+  <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+  new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+  j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+  'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-KTRVCMQN');</script>
+  <!-- End Google Tag Manager -->
+  <link rel="preload" href="/footer.html?v=1.5.2" as="fetch" crossorigin="anonymous">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>How to Cool Down a Fish Tank During a Heat Wave</title>
+  <meta name="description" content="Is your fish tank too hot? Learn how to safely cool down an aquarium during a summer heat wave, protect oxygen levels, and survive sudden power outages.">
+  <meta name="author" content="The Tank Guide" />
+  <meta name="robots" content="index, follow" />
+  <meta name="article:summary" content="Summer heat waves can rapidly deplete dissolved oxygen in your aquarium while stressing your fish. This practical guide covers safe methods to cool down an overheating fish tank, recognize signs of heat stress, and prepare your aquarium for summer power outages and blackouts.">
+  <meta name="keywords" content="how to cool down a fish tank, aquarium temperature, fish tank cooling, heat wave safety, power outage prep, dissolved oxygen, emergency aquarium care, water quality">
+  <link rel="canonical" href="https://thetankguide.com/cool-down-fish-tank/" />
+  <link rel="icon" type="image/png" sizes="16x16" href="/assets/img/logos/favicon-16.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/assets/img/logos/favicon-32.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/assets/img/Logo-Master-180x180.PNG">
+  <link rel="apple-touch-icon" sizes="512x512" href="/assets/img/Logo-Master-512x512.PNG">
+
+  <meta property="og:site_name" content="The Tank Guide" />
+  <meta property="og:type" content="article" />
+  <meta property="og:locale" content="en_US" />
+  <meta property="og:title" content="How to Save Your Aquarium From Extreme Summer Heat" />
+  <meta property="og:description" content="Don't let a summer heat wave crash your tank. Here is how to safely cool down a hot aquarium, protect oxygen levels, and survive power outages." />
+  <meta property="og:url" content="https://thetankguide.com/cool-down-fish-tank/" />
+  <meta property="article:section" content="Aquarium Care" />
+  <meta property="article:tag" content="aquarium temperature" />
+  <meta property="article:tag" content="fish tank cooling" />
+  <meta property="article:tag" content="heat wave safety" />
+  <meta property="article:tag" content="power outage prep" />
+  <meta property="article:tag" content="dissolved oxygen" />
+  <meta property="article:tag" content="emergency aquarium care" />
+  <meta property="article:tag" content="water quality" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:url" content="https://thetankguide.com/cool-down-fish-tank/" />
+  <meta name="twitter:title" content="How to Save Your Aquarium From Extreme Summer Heat" />
+  <meta name="twitter:description" content="Don't let a summer heat wave crash your tank. Here is how to safely cool down a hot aquarium, protect oxygen levels, and survive power outages." />
+
+  <!--#include virtual="/includes/schema-organization.html" -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/blogs-bundle.min.css?v=1.0.0">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    "@id": "https://thetankguide.com/cool-down-fish-tank/#blogposting",
+    "headline": "How to Cool Down a Fish Tank During a Heat Wave",
+    "description": "Is your fish tank too hot? Learn how to safely cool down an aquarium during a summer heat wave, protect oxygen levels, and survive sudden power outages.",
+    "articleSection": "Aquarium Care",
+    "keywords": ["how to cool down a fish tank", "aquarium temperature", "fish tank cooling", "heat wave safety", "power outage prep", "dissolved oxygen", "emergency aquarium care", "water quality"],
+    "author": {
+      "@type": "Organization",
+      "@id": "https://thetankguide.com/#brand",
+      "name": "The Tank Guide"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "@id": "https://thetankguide.com/#fishkeepinglifeco",
+      "name": "FishKeepingLifeCo"
+    },
+    "datePublished": "2026-07-13",
+    "dateModified": "2026-07-13",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://thetankguide.com/cool-down-fish-tank/"
+    },
+    "url": "https://thetankguide.com/cool-down-fish-tank/",
+    "isPartOf": { "@id": "https://thetankguide.com/#website" }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "How do you cool down a fish tank during a heat wave?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Monitor the aquarium temperature, increase surface agitation and oxygenation, reduce unnecessary heat sources, and cool the aquarium gradually. Avoid rapid temperature changes."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can a fan cool an aquarium?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Yes. A fan can help cool an aquarium through evaporative cooling by moving air across the water surface when it is safe to open or remove the lid."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Can you use frozen water bottles to cool a fish tank?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "A sealed frozen water bottle can work as a temporary emergency cooling method, but watch the temperature closely and bring it down gradually rather than rapidly."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Should you do a water change if an aquarium is too hot?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "A small partial water change with slightly cooler, properly conditioned water can help gradually lower temperature, but very cold water and drastic temperature swings should be avoided."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How do you oxygenate a fish tank during a power outage?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Use a battery-operated aquarium air pump connected to an air stone. If you do not have one, manually scoop aquarium water and pour it back into the tank to disturb the surface periodically."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What are signs that fish are struggling from heat?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Signs include rapid breathing, heavy gill movement, fish gathering near the surface, unusual lethargy, sudden feeding changes, unusual swimming, and spending more time near filter outputs or air stones."
+        }
+      }
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "https://thetankguide.com/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Blog",
+        "item": "https://thetankguide.com/blogs/"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": "How to Keep Your Aquarium Safe During a Summer Heat Wave",
+        "item": "https://thetankguide.com/cool-down-fish-tank/"
+      }
+    ]
+  }
+  </script>
+  <script defer src="/js/nav.js?v=1.1.0"></script>
+</head>
+<body class="blog-article blog-open-page topic-care">
+  <a href="#main-content" class="skip-link">Skip to content</a>
+  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KTRVCMQN" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+  <div id="site-nav"></div>
+
+  <nav aria-label="Breadcrumb" class="breadcrumb blog-breadcrumb">
+    <ol>
+      <li><a href="/">Home</a></li>
+      <li style="color: #666;" aria-hidden="true">/</li>
+      <li><a href="/blogs/">Blog</a></li>
+      <li style="color: #666;" aria-hidden="true">/</li>
+      <li aria-current="page">How to Keep Your Aquarium Safe During a Summer Heat Wave</li>
+    </ol>
+  </nav>
+
+  <main class="article-layout" id="main-content">
+    <article>
+      <a class="back-link" href="/blogs/" aria-label="Back to all blog posts"><span aria-hidden="true">← </span>Back to all posts</a>
+
+      <header class="article-header">
+        <h1>How to Keep Your Aquarium Safe During a Summer Heat Wave</h1>
+        <p class="deck">By The Tank Guide</p>
+      </header>
+
+      <div class="callout" role="note" aria-label="Direct answer">
+        <p><strong>Quick answer:</strong> The safest way to cool down a fish tank during a heat wave is to monitor temperature, increase surface agitation and oxygenation, reduce unnecessary heat sources, and cool the aquarium gradually. Avoid sudden temperature swings and prepare backup aeration for power outages.</p>
+      </div>
+
+      <div class="section-split" aria-hidden="true"></div>
+
+      <div class="blog-body">
+        <p>Summer heat does not only affect us. Your aquarium can feel it too.</p>
+
+        <p>When temperatures outside climb and your home starts getting warmer, aquarium temperatures can slowly rise with the room. During a heat wave, that can create problems even in an otherwise healthy, established aquarium.</p>
+
+        <p>The biggest concern is not always the temperature itself.</p>
+
+        <p>It is oxygen.</p>
+
+        <p>Warmer water holds less dissolved oxygen than cooler water, and higher temperatures raise a fish's metabolism and oxygen demand at the same time. That combination puts extra stress on an aquarium, especially in heavily stocked tanks or aquariums with limited surface movement.</p>
+
+        <h2>Why Does Warm Aquarium Water Have Less Oxygen?</h2>
+
+        <p>Warm aquarium water holds less dissolved oxygen because the solubility of oxygen decreases as water temperature rises. Warmer water simply has a lower capacity to hold it.</p>
+
+        <p>For a little perspective, freshwater at around 75°F (24°C) can hold roughly 8.3 milligrams of dissolved oxygen per liter at saturation under typical atmospheric conditions. At around 86°F (30°C), that maximum drops closer to 7.5 milligrams per liter.</p>
+
+        <p>Those numbers are approximate and can shift with factors like altitude and water chemistry, but the lesson holds: as aquarium temperature rises, the water's oxygen capacity drops — right as your fish's metabolism, and their oxygen demand, is climbing too.</p>
+
+        <p>The good news: there are several simple things you can do to help your aquarium through the hottest days of summer.</p>
+
+        <h2>How Do You Monitor an Aquarium During a Heat Wave?</h2>
+
+        <p>The first step is knowing what is actually happening in your tank.</p>
+
+        <p>Do not assume your aquarium is fine just because the room feels comfortable to you. Keep a reliable thermometer in the aquarium and check it during the hottest part of the day.</p>
+
+        <p>We also recommend an INKBIRD temperature controller or another device that offers similar monitoring and alerts. Depending on the model, that can mean audible alarms, heating or cooling control, Wi-Fi connectivity, or smartphone alerts when the tank moves outside your set range — features vary, so check what your specific device offers.</p>
+
+        <p>An alert gives you a chance to investigate before the temperature becomes a bigger problem. That is especially helpful when temperatures keep climbing while you are at work, asleep, or simply not standing in front of the tank.</p>
+
+        <p>More importantly, know the preferred temperature range of the fish and other livestock you keep. What is acceptable for one species could be stressful for another.</p>
+
+        <p>You should also pay attention to how quickly the temperature is changing.</p>
+
+        <p>Stability matters. Rapidly cooling an aquarium creates its own stress, so manage rising temperatures gradually rather than panicking and suddenly making the tank cold.</p>
+
+        <h2>How Can You Increase Oxygen in a Warm Aquarium?</h2>
+
+        <p>One of the most important things you can do during a heat wave is increase gas exchange and surface agitation.</p>
+
+        <p>An air stone and air pump are simple options for adding water movement and aeration. You can also use the filtration equipment already running on your tank. If you have a hang-on-back filter, slightly lowering the water level can increase the surface disturbance created by the filter return. For filters with adjustable outflows or spray bars, try pointing the flow upward toward the surface.</p>
+
+        <p>You are not trying to create a strong current throughout the whole aquarium — you want more movement at the surface. Most of the gas exchange in your aquarium happens where the water meets the air, so more disturbance there means faster gas exchange.</p>
+
+        <h2>What Are the Signs That Fish Are Struggling From Heat?</h2>
+
+        <p>Your fish are one of the best indicators that something is wrong. Watch for:</p>
+
+        <ul>
+          <li>Rapid breathing or heavy gill movement.</li>
+          <li>Fish gathering near the surface.</li>
+          <li>Unusual lethargy.</li>
+          <li>A sudden change in feeding behavior.</li>
+          <li>Unusual swimming.</li>
+          <li>Fish spending more time near filter outputs, air stones, or areas of stronger water movement.</li>
+        </ul>
+
+        <p>Do not wait until every fish in the tank is struggling.</p>
+
+        <p>Check the temperature. Test the water. Increase oxygenation. Then make gradual changes based on what you find.</p>
+
+        <h2>Can a Fan Cool an Aquarium?</h2>
+
+        <p>Yes, a fan can help cool an aquarium through evaporative cooling. Removing or opening the lid, when safe for your livestock, and directing a fan across the water's surface increases evaporation and helps lower the temperature. How much it drops depends on your aquarium, room temperature, humidity, airflow, and exposed water surface.</p>
+
+        <p>Aquarium cooling fans exist, but even a small household or clip-on fan may help depending on your setup.</p>
+
+        <p>There is one major thing to remember: more evaporation means more frequent top-offs. Topping off is not the same as a water change — water evaporates, but dissolved minerals and waste products stay behind. Keep up your normal maintenance and water change routine.</p>
+
+        <p>Also think about your livestock before leaving a tank uncovered. Some fish are excellent jumpers, so a breathable mesh or screen top may be worth considering for jump-prone species. Pets and young children can also make an open-top aquarium unsafe.</p>
+
+        <h2>Reduce Unnecessary Heat Sources</h2>
+
+        <p>Look around your aquarium and consider what may be adding heat.</p>
+
+        <p>Aquarium lighting can contribute heat, especially when lights run for long periods. During extreme heat, reducing the photoperiod or turning the light off during the hottest part of the day may help — a few days of reduced lighting is easier to deal with than a tank running too hot. Keep curtains or blinds closed if direct sunlight reaches the aquarium or the room it's in.</p>
+
+        <p>Check your heater, too. A properly functioning heater should stop once it reaches the set temperature, but equipment fails. If the tank is unusually warm compared with the room, make sure the heater is not stuck on — another good reason a temperature controller with alerts is worth having, since catching the change early gives you time to fix the problem before it grows.</p>
+
+        <h2>Can You Use Ice or Frozen Water Bottles to Cool a Fish Tank?</h2>
+
+        <p>A sealed frozen water bottle can work as a temporary emergency cooling method, but you need to watch the aquarium temperature closely — the point is to bring it down gradually, not rapidly. Use a clean, sealed container and keep an eye on your thermometer, since a small aquarium can change temperature much faster than a large one.</p>
+
+        <p>Do not dump untreated ice cubes into your tank. If you need active cooling, gradual and controlled changes are safer than repeatedly shocking the tank with extreme swings. For aquariums that regularly struggle with excessive heat, a proper cooling fan or chiller may be a better long-term solution.</p>
+
+        <h2>Should You Do a Water Change If Your Aquarium Is Too Hot?</h2>
+
+        <p>A small partial water change using slightly cooler, properly conditioned water can help gradually lower the temperature of an overheating aquarium — but this is not the time to dump in very cold water. Sudden swings stress fish, so always use a water conditioner and avoid drastic temperature changes.</p>
+
+        <p>Water changes are also worth doing because summer heat is a good time to pay extra attention to water quality. Here's another piece of aquarium chemistry worth knowing: ammonia in your aquarium can exist in different forms, and as pH and temperature rise, more of it shifts toward un-ionized ammonia, or NH3 — the more toxic form for fish. So don't assume heat is the only problem when fish start acting differently.</p>
+
+        <p>Test the water. Ammonia and nitrite should stay at zero.</p>
+
+        <h2>Consider Feeding Less During Extreme Heat</h2>
+
+        <p>Feeding less during extreme heat means less waste entering the aquarium and less organic material for it to process. We already think many aquarium fish are overfed, and a heat wave is not the time to add extra food because you're worried about them. Feed lightly, remove uneaten food, and keep an eye on water quality.</p>
+
+        <h2>Check Your Water Parameters</h2>
+
+        <p>If your fish are acting differently, don't jump straight to blaming the heat — test the water. Check ammonia, nitrite, and nitrate, ideally with a liquid test kit so you get a full picture of what's happening in the tank.</p>
+
+        <p>At The Tank Guide, we generally treat nitrate from 0–20 ppm as the low-range, "safe" zone for most freshwater aquariums we discuss. When nitrate climbs higher, it's time to look at a water change and your overall maintenance routine. Your specific aquarium and livestock still matter — know what's normal for your tank so you can recognize when something changes.</p>
+
+        <h2>How Do You Oxygenate a Fish Tank During a Power Outage?</h2>
+
+        <p>A battery-operated aquarium air pump is one of the simplest ways to provide emergency aeration during a power outage — and one of those supplies that's easy to overlook until you suddenly need it.</p>
+
+        <p>Summer heat often comes with thunderstorms, hurricanes, and other severe weather that can knock out power. If that happens, your normal filter and air pump stop working at the exact moment your water is warmest and holding the least oxygen. A battery-operated pump connected to an air stone keeps water moving until power returns.</p>
+
+        <p>Keep one with your aquarium supplies, and make sure the batteries are fresh — or, if rechargeable, actually charged. It sounds simple, but emergency equipment only helps if it's ready when you need it. For larger fish rooms or multiple aquariums, a battery backup or portable power station may also be worth considering.</p>
+
+        <h2>No Battery Air Pump? Manually Agitate the Water</h2>
+
+        <p>If the power is out and you do not have a battery-operated air pump, you can manually create surface agitation. Take a clean, soap-free cup or small container, scoop water from the tank, and pour it back in from a short distance so it disturbs the surface. Then do it again. And again.</p>
+
+        <p>Is standing there with a cup as convenient or consistent as a battery-powered air pump? Absolutely not. But in an emergency, doing something beats watching your fish struggle while you wait for the power to return.</p>
+
+        <p>Repeat the process periodically, especially if fish are breathing rapidly or gathering near the surface. Use aquarium water for this, not fresh tap water each time — and be sensible about how high you pour from. You're trying to disturb the surface, not launch water across the room or hit your fish with a waterfall from the ceiling.</p>
+
+        <p>This is a temporary emergency option, not a replacement for continuous aeration — all the more reason to have a battery-operated air pump ready before you need one.</p>
+
+        <h2>How Should You Prepare an Aquarium for a Major Storm or Blackout?</h2>
+
+        <p>If a hurricane, major thunderstorm, or another event with the potential for an extended outage is approaching, prepare aquarium water ahead of time. We keep dedicated aquarium buckets for a reason.</p>
+
+        <p>Fill clean, aquarium-only buckets with the water you'd normally use for a water change, prepare it appropriately for your setup, and keep the buckets covered somewhere they won't be contaminated by cleaners, sprays, pets, or anything else you don't want in your tank.</p>
+
+        <p>This does not mean every outage requires a water change — it's about having options. If the power stays out long enough that you need an emergency water change, having water ready makes it much easier. You'll likely have enough going on during a major storm without also hunting for clean buckets in the dark.</p>
+
+        <p>Just remember to check the temperature of the prepared water before adding it — we're still trying to avoid sudden swings.</p>
+
+        <h2>Quick Aquarium Heat Emergency and Preparation Checklist</h2>
+
+        <p>The easiest time to prepare for extreme heat is before your aquarium is already overheating.</p>
+
+        <p>But if your fish tank is too hot or your fish appear stressed, start here.</p>
+
+        <h3>Immediate Emergency Action Steps</h3>
+
+        <ul>
+          <li>Check the aquarium temperature.</li>
+          <li>Watch for rapid breathing, unusual lethargy, or fish gathering near the surface.</li>
+          <li>Test ammonia, nitrite, and nitrate.</li>
+          <li>Increase surface agitation and oxygenation.</li>
+          <li>Add an air stone or increase aeration if power is available.</li>
+          <li>Point adjustable filter outflows toward the surface or slightly lower the water level for a running hang-on-back filter.</li>
+          <li>Reduce or temporarily turn off aquarium lighting.</li>
+          <li>Use a fan across the water surface when it is safe to open the lid.</li>
+          <li>Feed lightly or temporarily reduce feeding.</li>
+          <li>If needed, perform a small water change with slightly cooler, properly conditioned water.</li>
+          <li>Avoid rapid temperature changes.</li>
+          <li>If the power is out, start a battery-operated air pump.</li>
+          <li>No battery air pump? Manually scoop aquarium water and pour it back into the tank to disturb the surface and encourage gas exchange.</li>
+        </ul>
+
+        <h3>Before the Next Heat Wave or Major Storm</h3>
+
+        <ul>
+          <li>Keep a reliable thermometer in the aquarium.</li>
+          <li>Consider an INKBIRD temperature controller or another temperature monitoring device with alerts.</li>
+          <li>Have an air pump and air stone available.</li>
+          <li>Keep a battery-operated air pump for power outages.</li>
+          <li>Make sure you have fresh batteries or charged rechargeable batteries ready.</li>
+          <li>Keep water conditioner and a liquid test kit on hand.</li>
+          <li>If severe weather is approaching, prepare aquarium water in clean, dedicated buckets ahead of time.</li>
+          <li>Know the temperature requirements of the fish and other livestock you keep.</li>
+          <li>Know what you can do manually if the power goes out and your normal equipment stops running.</li>
+        </ul>
+
+        <p>The goal is not to panic and do everything at once.</p>
+
+        <p>Check the tank, identify the problem, prioritize oxygenation, and make gradual changes.</p>
+
+        <p>Aquarium keeping is often about stability and balance.</p>
+
+        <p>Summer heat waves can temporarily push that balance in the wrong direction, but a little preparation can make a big difference.</p>
+
+        <p>Your aquarium does not need perfect conditions every second of every day.</p>
+
+        <p>It needs a fish keeper who cares and is paying attention.</p>
+
+        <section class="faq-section" aria-label="Frequently Asked Questions">
+          <h2>Frequently Asked Questions</h2>
+          <details>
+            <summary>How do you cool down a fish tank during a heat wave?</summary>
+            <p>Monitor the aquarium temperature, increase surface agitation and oxygenation, reduce unnecessary heat sources, and cool the aquarium gradually. Avoid rapid temperature changes.</p>
+          </details>
+          <details>
+            <summary>Can a fan cool an aquarium?</summary>
+            <p>Yes. A fan can help cool an aquarium through evaporative cooling by moving air across the water surface when it is safe to open or remove the lid.</p>
+          </details>
+          <details>
+            <summary>Can you use frozen water bottles to cool a fish tank?</summary>
+            <p>A sealed frozen water bottle can work as a temporary emergency cooling method, but watch the temperature closely and bring it down gradually rather than rapidly.</p>
+          </details>
+          <details>
+            <summary>Should you do a water change if an aquarium is too hot?</summary>
+            <p>A small partial water change with slightly cooler, properly conditioned water can help gradually lower temperature, but very cold water and drastic temperature swings should be avoided.</p>
+          </details>
+          <details>
+            <summary>How do you oxygenate a fish tank during a power outage?</summary>
+            <p>Use a battery-operated aquarium air pump connected to an air stone. If you do not have one, manually scoop aquarium water and pour it back into the tank to disturb the surface periodically.</p>
+          </details>
+          <details>
+            <summary>What are signs that fish are struggling from heat?</summary>
+            <p>Signs include rapid breathing, heavy gill movement, fish gathering near the surface, unusual lethargy, sudden feeding changes, unusual swimming, and spending more time near filter outputs or air stones.</p>
+          </details>
+        </section>
+
+        <div class="ttg-ad-slot ttg-house-ad-slot"
+             id="ad-cool-down-fish-tank-rotator"
+             data-ttg-ad-rotator="true"
+             data-ttg-ad-manifest="/assets/ads/manifest.json"
+             data-ttg-ad-interval="10000"
+             aria-label="Advertisement">
+          <a class="ttg-ad-banner-link" href="/store.html">
+            <img class="ttg-ad-img"
+                 src="/assets/img/ads/Daily-tank-journal-ad.PNG"
+                 alt="Daily Tank Journal promotion"
+                 loading="lazy">
+          </a>
+          <div>
+            <strong>Tools that keep aquarium care consistent.</strong>
+            <p style="margin: 6px 0 0;">Log temperature, water tests, feeding, and maintenance with our journals and guides.</p>
+          </div>
+        </div>
+      </div>
+    </article>
+  </main>
+
+  <div id="footer-placeholder"></div>
+
+  <script>
+    fetch('/footer.html?v=1.5.2')
+      .then(response => response.text())
+      .then(html => {
+        document.getElementById('footer-placeholder').innerHTML = html;
+      })
+      .catch(error => console.error('Error loading footer:', error));
+  </script>
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -428,4 +428,11 @@
     <priority>0.8</priority>
   </url>
 
+  <url>
+    <loc>https://thetankguide.com/cool-down-fish-tank/</loc>
+    <lastmod>2026-07-13</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
 </urlset>


### PR DESCRIPTION
### Motivation
- Publish a dedicated Tank Guide article that explains how to safely cool down an aquarium during extreme heat, preserve dissolved oxygen, and prepare for power outages.  
- Provide a properly structured live blog page with accessible layout, metadata, and matching schema so the content integrates with the site tooling and sitemap.

### Description
- Created the new article page at `cool-down-fish-tank/index.html` using the supplied article body verbatim, preserving a single H1 and the required H2/H3 heading hierarchy, and added the concise direct-answer callout near the top.  
- Added `BlogPosting`, `FAQPage`, and `BreadcrumbList` JSON-LD nodes, site metadata (SEO title, canonical, meta description, OG/Twitter tags, category, and tags), accessible skip link and back-link pattern, shared nav/footer loader, and the standard bottom ad slot.  
- Updated `sitemap.xml` to include `https://thetankguide.com/cool-down-fish-tank/` and applied the site’s normal fallback for hero image because the requested asset `aquarium-heat-wave-cooling-guide.jpg` was not found.  
- Intentionally omitted `HowTo` schema following the audit guidance because the content is emergency/safety guidance with checklists rather than a single procedural how-to.

### Testing
- Ran `npm run guard:live`, which passed as part of the pre-commit/validation step.  
- Ran `npm run guard:blog-ads`, which failed during a separate pre-existing ad-slot mismatch unrelated to this page (no failures attributable to the new page).  
- Executed a custom Python validation that confirmed: one H1, preserved heading hierarchy including required H3 checklist headings, JSON-LD parseability for the added schemas, visible FAQ and matching `FAQPage` schema, `BreadcrumbList` presence, `BlogPosting` presence, direct-answer callout, footer/ad loader, and that the page was not added to the blog index; this validation passed.  
- Attempted a Playwright mobile screenshot / horizontal-overflow check, but it could not run in this environment because Playwright's Chromium browser binaries were not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54f4fbd1248332949336088d180fb6)