### PR TITLE
Fix cool-down fish tank audit metadata

### DIFF
--- a/cool-down-fish-tank/index.html
+++ b/cool-down-fish-tank/index.html
@@ -12,7 +12,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>How to Cool Down a Fish Tank During a Heat Wave</title>
-  <meta name="description" content="Is your fish tank too hot? Learn how to safely cool down an aquarium during a summer heat wave, protect oxygen levels, and survive sudden power outages.">
+  <meta name="description" content="Fish tank too hot? Safely cool an aquarium during a heat wave, protect oxygen levels, and prepare for sudden power outages.">
   <meta name="author" content="The Tank Guide" />
   <meta name="robots" content="index, follow" />
   <meta name="article:summary" content="Summer heat waves can rapidly deplete dissolved oxygen in your aquarium while stressing your fish. This practical guide covers safe methods to cool down an overheating fish tank, recognize signs of heat stress, and prepare your aquarium for summer power outages and blackouts.">
@@ -29,6 +29,10 @@
   <meta property="og:title" content="How to Save Your Aquarium From Extreme Summer Heat" />
   <meta property="og:description" content="Don't let a summer heat wave crash your tank. Here is how to safely cool down a hot aquarium, protect oxygen levels, and survive power outages." />
   <meta property="og:url" content="https://thetankguide.com/cool-down-fish-tank/" />
+  <meta property="og:image" content="https://thetankguide.com/assets/img/logos/logo-1200x630.png" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="The Tank Guide aquarium care guides." />
   <meta property="article:section" content="Aquarium Care" />
   <meta property="article:tag" content="aquarium temperature" />
   <meta property="article:tag" content="fish tank cooling" />
@@ -41,6 +45,8 @@
   <meta name="twitter:url" content="https://thetankguide.com/cool-down-fish-tank/" />
   <meta name="twitter:title" content="How to Save Your Aquarium From Extreme Summer Heat" />
   <meta name="twitter:description" content="Don't let a summer heat wave crash your tank. Here is how to safely cool down a hot aquarium, protect oxygen levels, and survive power outages." />
+  <meta name="twitter:image" content="https://thetankguide.com/assets/img/logos/logo-1200x630.png" />
+  <meta name="twitter:image:alt" content="The Tank Guide aquarium care guides." />
 
   <!--#include virtual="/includes/schema-organization.html" -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
@@ -54,9 +60,17 @@
     "@type": "BlogPosting",
     "@id": "https://thetankguide.com/cool-down-fish-tank/#blogposting",
     "headline": "How to Cool Down a Fish Tank During a Heat Wave",
-    "description": "Is your fish tank too hot? Learn how to safely cool down an aquarium during a summer heat wave, protect oxygen levels, and survive sudden power outages.",
+    "description": "Fish tank too hot? Safely cool an aquarium during a heat wave, protect oxygen levels, and prepare for sudden power outages.",
     "articleSection": "Aquarium Care",
     "keywords": ["how to cool down a fish tank", "aquarium temperature", "fish tank cooling", "heat wave safety", "power outage prep", "dissolved oxygen", "emergency aquarium care", "water quality"],
+    "image": {
+      "@type": "ImageObject",
+      "@id": "https://thetankguide.com/assets/img/logos/logo-1200x630.png#image",
+      "url": "https://thetankguide.com/assets/img/logos/logo-1200x630.png",
+      "width": 1200,
+      "height": 630
+    },
+    "hasPart": { "@id": "https://thetankguide.com/cool-down-fish-tank/#howto" },
     "author": {
       "@type": "Organization",
       "@id": "https://thetankguide.com/#brand",
@@ -159,6 +173,35 @@
     ]
   }
   </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "HowTo",
+    "@id": "https://thetankguide.com/cool-down-fish-tank/#howto",
+    "name": "Immediate Emergency Action Steps",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://thetankguide.com/cool-down-fish-tank/"
+    },
+    "isPartOf": { "@id": "https://thetankguide.com/cool-down-fish-tank/#blogposting" },
+    "step": [
+      { "@type": "HowToStep", "position": 1, "text": "Check the aquarium temperature." },
+      { "@type": "HowToStep", "position": 2, "text": "Watch for rapid breathing, unusual lethargy, or fish gathering near the surface." },
+      { "@type": "HowToStep", "position": 3, "text": "Test ammonia, nitrite, and nitrate." },
+      { "@type": "HowToStep", "position": 4, "text": "Increase surface agitation and oxygenation." },
+      { "@type": "HowToStep", "position": 5, "text": "Add an air stone or increase aeration if power is available." },
+      { "@type": "HowToStep", "position": 6, "text": "Point adjustable filter outflows toward the surface or slightly lower the water level for a running hang-on-back filter." },
+      { "@type": "HowToStep", "position": 7, "text": "Reduce or temporarily turn off aquarium lighting." },
+      { "@type": "HowToStep", "position": 8, "text": "Use a fan across the water surface when it is safe to open the lid." },
+      { "@type": "HowToStep", "position": 9, "text": "Feed lightly or temporarily reduce feeding." },
+      { "@type": "HowToStep", "position": 10, "text": "If needed, perform a small water change with slightly cooler, properly conditioned water." },
+      { "@type": "HowToStep", "position": 11, "text": "Avoid rapid temperature changes." },
+      { "@type": "HowToStep", "position": 12, "text": "If the power is out, start a battery-operated air pump." },
+      { "@type": "HowToStep", "position": 13, "text": "No battery air pump? Manually scoop aquarium water and pour it back into the tank to disturb the surface and encourage gas exchange." }
+    ]
+  }
+  </script>
   <script defer src="/js/nav.js?v=1.1.0"></script>
 </head>
 <body class="blog-article blog-open-page topic-care">
@@ -185,7 +228,7 @@
         <p class="deck">By The Tank Guide</p>
       </header>
 
-      <div class="callout" role="note" aria-label="Direct answer">
+      <div class="callout" role="note">
         <p><strong>Quick answer:</strong> The safest way to cool down a fish tank during a heat wave is to monitor temperature, increase surface agitation and oxygenation, reduce unnecessary heat sources, and cool the aquarium gradually. Avoid sudden temperature swings and prepare backup aeration for power outages.</p>
       </div>
 
@@ -411,6 +454,8 @@
             <img class="ttg-ad-img"
                  src="/assets/img/ads/Daily-tank-journal-ad.PNG"
                  alt="Daily Tank Journal promotion"
+                 width="3840"
+                 height="1088"
                  loading="lazy">
           </a>
           <div>


### PR DESCRIPTION
### Motivation
- Resolve non-AdSense audit findings for the article by improving SEO/social metadata, adding actionable AEO schema, reducing CLS risk for the house ad, and fixing a redundant ARIA attribute while preserving the existing ownership and page content constraints. 
- Keep the page's SEO title and H1 unchanged and preserve the `The Tank Guide` / `FishKeepingLifeCo` entity model and `sameAs` links.

### Description
- Updated `cool-down-fish-tank/index.html` to shorten the `<meta name="description">` while leaving the SEO title and H1 exactly as-is. 
- Added Open Graph image metadata (`og:image`, `og:image:width`, `og:image:height`, `og:image:alt`) and matching Twitter/X image tags using `https://thetankguide.com/assets/img/logos/logo-1200x630.png` (1200×630). 
- Aligned the page `BlogPosting` JSON-LD to include the same `ImageObject` and added a `hasPart` reference to the new HowTo node. 
- Injected a `HowTo` JSON-LD node with stable `@id` `https://thetankguide.com/cool-down-fish-tank/#howto` built only from the visible “Immediate Emergency Action Steps” checklist steps. 
- Removed the redundant `aria-label="Direct answer"` from the direct-answer callout while preserving `role="note"` and the visible “Quick answer:” wording. 
- Added intrinsic `width="3840"` and `height="1088"` attributes to the existing house ad `<img class="ttg-ad-img" src="/assets/img/ads/Daily-tank-journal-ad.PNG">` to reduce CLS without changing `src`, `alt`, `loading`, classes, or layout. 
- Left the shared include `includes/schema-organization.html` intact so `FishKeepingLifeCo` remains the publisher/parent (`@id` = `https://thetankguide.com/#fishkeepinglifeco`) and `The Tank Guide` website node (`@id` = `https://thetankguide.com/#website`) continues to be referenced.

### Testing
- Ran `git diff --check` and automated JSON-LD parsing via `python3` to validate all injected JSON-LD blocks parsed as valid JSON-LD, which succeeded. 
- Automated assertions verified the SEO title and H1 remained unchanged, the shortened meta description was present, the `HowTo` node exists with the specified `@id`, and the `BlogPosting` still references `isPartOf` -> `https://thetankguide.com/#website` and `publisher` -> `https://thetankguide.com/#fishkeepinglifeco`. 
- Verified PNG intrinsic dimensions by reading image headers (logo: `1200×630`; house ad: `3840×1088`), confirmed `og:image`/`twitter:image` and schema image dimensions match, and confirmed the redundant `aria-label="Direct answer"` was removed; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5508310d80833292f4c354609771f9)