### PR TITLE
Move hero above Quick answer and add heat-wave article to Seasonal Guides

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -1116,6 +1116,29 @@
           </div>
         </article>
         <article class="blog-card">
+          <a class="card-thumb-link" href="https://thetankguide.com/cool-down-fish-tank/" aria-label="Read: How to Keep Your Aquarium Safe During a Summer Heat Wave">
+            <span class="card-media">
+              <img
+                class="card-thumb blog-card-image"
+                src="/assets/images/keep-fish-tank-cool-during-heatwave.jpeg"
+                alt="Aquarium being kept cool and monitored during a summer heat wave"
+                loading="lazy"
+                decoding="async"
+              />
+            </span>
+          </a>
+          <div class="card-content">
+            <p class="card-kicker">
+              <span class="card-author">The Tank Guide</span>
+            </p>
+            <h3 class="card-title">
+              <a href="https://thetankguide.com/cool-down-fish-tank/">How to Keep Your Aquarium Safe During a Summer Heat Wave</a>
+            </h3>
+            <p class="card-excerpt">A practical summer heat-wave aquarium guide covering safe cooling, dissolved oxygen, heat stress, surface agitation, fans, water changes, and emergency aeration during power outages.</p>
+            <a class="card-read" href="https://thetankguide.com/cool-down-fish-tank/">Read the blog →</a>
+          </div>
+        </article>
+        <article class="blog-card">
           <a class="card-thumb-link" href="/blog/holiday-gift-guide-aquarium-lovers.html" aria-label="Read: A Thoughtful Holiday Gift Guide for Aquarium Lovers: What to Buy (and What to Avoid)">
             <span class="card-media">
               <img

--- a/cool-down-fish-tank/index.html
+++ b/cool-down-fish-tank/index.html
@@ -228,10 +228,6 @@
         <p class="deck">By The Tank Guide</p>
       </header>
 
-      <div class="callout" role="note">
-        <p><strong>Quick answer:</strong> The safest way to cool down a fish tank during a heat wave is to monitor temperature, increase surface agitation and oxygenation, reduce unnecessary heat sources, and cool the aquarium gradually. Avoid sudden temperature swings and prepare backup aeration for power outages.</p>
-      </div>
-
       <figure class="tg-figure tg-figure--hero">
         <img
           src="/assets/images/keep-fish-tank-cool-during-heatwave.jpeg"
@@ -243,6 +239,10 @@
           decoding="async"
         />
       </figure>
+
+      <div class="callout" role="note">
+        <p><strong>Quick answer:</strong> The safest way to cool down a fish tank during a heat wave is to monitor temperature, increase surface agitation and oxygenation, reduce unnecessary heat sources, and cool the aquarium gradually. Avoid sudden temperature swings and prepare backup aeration for power outages.</p>
+      </div>
 
       <div class="section-split" aria-hidden="true"></div>
 


### PR DESCRIPTION
### Motivation
- Improve the visual hierarchy of the heat-wave article so the hero image appears directly under the article identity/byline for clearer context. 
- Surface the article in the appropriate category on the blog index by adding it to `Special Events & Seasonal Guides` because the content is seasonal and focused on summer heat-wave emergency preparation. 

### Description
- In `cool-down-fish-tank/index.html` moved the existing hero `<figure class="tg-figure tg-figure--hero">` block to appear immediately after the article header and before the Quick answer callout, preserving the same image asset path `/assets/images/keep-fish-tank-cool-during-heatwave.jpeg` and all responsive classes and loading attributes. 
- Ensured the Quick answer callout (`<div class="callout" role="note">`) was not modified in wording and now appears directly after the hero with clean spacing. 
- Confirmed the hero image was not duplicated and the article body, H1, SEO meta, FAQ phrasing, HowTo checklist, footer, house ad, and JSON-LD schema were left unchanged. 
- In `blogs/index.html` added a new blog card in the `#topic-seasonal` section using the existing card markup and classes with Title `How to Keep Your Aquarium Safe During a Summer Heat Wave`, Link `https://thetankguide.com/cool-down-fish-tank/`, Image `assets/images/keep-fish-tank-cool-during-heatwave.jpeg`, and the provided excerpt. 

### Testing
- Parsed and validated embedded JSON-LD blocks in `cool-down-fish-tank/index.html` and they loaded without JSON errors (passed). 
- Verified the hero appears once in the article (`body hero img src count 1`) and that the Quick answer callout now follows the hero (checked by file inspection and server render). 
- Ran `git diff --check` and local guard script `npm run guard:live` which completed successfully. 
- `npm run guard:blog-ads` failed on an unrelated existing holiday gift guide ad-slot mismatch and is not caused by these changes. 
- Playwright visual/layout checks were attempted but could not complete because headless browsers were not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a552f5184188332b90f652f03cfdfec)